### PR TITLE
Fix sign-in form listener setup

### DIFF
--- a/lib/features/profile/presentation/screens/sign_in_screen.dart
+++ b/lib/features/profile/presentation/screens/sign_in_screen.dart
@@ -37,6 +37,7 @@ class _SignInScreenState extends ConsumerState<SignInScreen> {
   late final TextEditingController _passwordController;
   late final FocusNode _emailFocusNode;
   late final FocusNode _passwordFocusNode;
+  ProviderSubscription<SignInFormState>? _signInFormSubscription;
 
   @override
   void initState() {
@@ -57,7 +58,7 @@ class _SignInScreenState extends ConsumerState<SignInScreen> {
       controller.updatePassword(_passwordController.text);
     });
 
-    ref.listen<SignInFormState>(
+    _signInFormSubscription = ref.listenManual<SignInFormState>(
       signInFormControllerProvider,
       (SignInFormState? previous, SignInFormState next) {
         if (previous?.isSubmitting == true && !next.isSubmitting) {
@@ -74,6 +75,7 @@ class _SignInScreenState extends ConsumerState<SignInScreen> {
 
   @override
   void dispose() {
+    _signInFormSubscription?.close();
     _emailController.dispose();
     _passwordController.dispose();
     _emailFocusNode.dispose();


### PR DESCRIPTION
## Summary
- switch the sign-in screen listener to use `ref.listenManual` so it can be started during `initState`
- dispose of the manual provider subscription with the widget lifecycle

## Testing
- Not run (Dart/Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68da79327b54832eb2f6c0203ecb649c