### PR TITLE
Implement shared navigation shell

### DIFF
--- a/lib/features/analytics/presentation/analytics_screen.dart
+++ b/lib/features/analytics/presentation/analytics_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:kopim/features/app_shell/presentation/models/navigation_tab_content.dart';
 import 'package:kopim/l10n/app_localizations.dart';
 
 class AnalyticsScreen extends ConsumerWidget {
@@ -9,18 +10,32 @@ class AnalyticsScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final AppLocalizations strings = AppLocalizations.of(context)!;
+    final NavigationTabContent content = buildAnalyticsTabContent(context, ref);
     return Scaffold(
-      appBar: AppBar(title: Text(strings.analyticsTitle)),
-      body: Center(
-        child: Padding(
-          padding: const EdgeInsets.all(24),
-          child: Text(
-            strings.analyticsComingSoon,
-            textAlign: TextAlign.center,
-          ),
-        ),
-      ),
+      appBar: content.appBarBuilder?.call(context, ref),
+      body: content.bodyBuilder(context, ref),
+      floatingActionButton:
+          content.floatingActionButtonBuilder?.call(context, ref),
     );
   }
+}
+
+NavigationTabContent buildAnalyticsTabContent(
+  BuildContext context,
+  WidgetRef ref,
+) {
+  final AppLocalizations strings = AppLocalizations.of(context)!;
+  return NavigationTabContent(
+    appBarBuilder: (BuildContext context, WidgetRef ref) =>
+        AppBar(title: Text(strings.analyticsTitle)),
+    bodyBuilder: (BuildContext context, WidgetRef ref) => Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Text(
+          strings.analyticsComingSoon,
+          textAlign: TextAlign.center,
+        ),
+      ),
+    ),
+  );
 }

--- a/lib/features/app_shell/presentation/controllers/main_navigation_controller.dart
+++ b/lib/features/app_shell/presentation/controllers/main_navigation_controller.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Controls the active index of the main navigation shell.
+class MainNavigationController extends StateNotifier<int> {
+  MainNavigationController() : super(0);
+
+  void setIndex(int index) {
+    if (index == state) {
+      return;
+    }
+    state = index;
+  }
+}
+
+final mainNavigationControllerProvider =
+    StateNotifierProvider<MainNavigationController, int>((Ref ref) {
+  return MainNavigationController();
+});

--- a/lib/features/app_shell/presentation/models/navigation_tab_config.dart
+++ b/lib/features/app_shell/presentation/models/navigation_tab_config.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'navigation_tab_content.dart';
+
+typedef NavigationTabContentBuilder = NavigationTabContent Function(
+  BuildContext context,
+  WidgetRef ref,
+);
+
+typedef NavigationTabLabelBuilder = String Function(BuildContext context);
+
+class NavigationTabConfig {
+  const NavigationTabConfig({
+    required this.id,
+    required this.icon,
+    required this.activeIcon,
+    required this.labelBuilder,
+    required this.contentBuilder,
+  });
+
+  final String id;
+  final IconData icon;
+  final IconData activeIcon;
+  final NavigationTabLabelBuilder labelBuilder;
+  final NavigationTabContentBuilder contentBuilder;
+}

--- a/lib/features/app_shell/presentation/models/navigation_tab_content.dart
+++ b/lib/features/app_shell/presentation/models/navigation_tab_content.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Describes the widgets that compose a single tab in the main navigation shell.
+class NavigationTabContent {
+  const NavigationTabContent({
+    this.appBarBuilder,
+    required this.bodyBuilder,
+    this.floatingActionButtonBuilder,
+  });
+
+  final PreferredSizeWidget? Function(BuildContext context, WidgetRef ref)?
+      appBarBuilder;
+  final Widget Function(BuildContext context, WidgetRef ref) bodyBuilder;
+  final Widget? Function(BuildContext context, WidgetRef ref)?
+      floatingActionButtonBuilder;
+}

--- a/lib/features/app_shell/presentation/providers/main_navigation_tabs_provider.dart
+++ b/lib/features/app_shell/presentation/providers/main_navigation_tabs_provider.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:kopim/features/analytics/presentation/analytics_screen.dart';
+import 'package:kopim/features/home/presentation/screens/home_screen.dart';
+import 'package:kopim/features/profile/presentation/screens/profile_screen.dart';
+import 'package:kopim/l10n/app_localizations.dart';
+
+import '../models/navigation_tab_config.dart';
+import '../models/navigation_tab_content.dart';
+
+final mainNavigationTabsProvider =
+    Provider<List<NavigationTabConfig>>((Ref ref) {
+  return <NavigationTabConfig>[
+    NavigationTabConfig(
+      id: 'home',
+      icon: Icons.home_outlined,
+      activeIcon: Icons.home,
+      labelBuilder: (BuildContext context) =>
+          AppLocalizations.of(context)!.homeNavHome,
+      contentBuilder: buildHomeTabContent,
+    ),
+    NavigationTabConfig(
+      id: 'analytics',
+      icon: Icons.show_chart_outlined,
+      activeIcon: Icons.show_chart,
+      labelBuilder: (BuildContext context) =>
+          AppLocalizations.of(context)!.homeNavAnalytics,
+      contentBuilder: buildAnalyticsTabContent,
+    ),
+    NavigationTabConfig(
+      id: 'settings',
+      icon: Icons.settings_outlined,
+      activeIcon: Icons.settings,
+      labelBuilder: (BuildContext context) =>
+          AppLocalizations.of(context)!.homeNavSettings,
+      contentBuilder: buildProfileTabContent,
+    ),
+  ];
+});

--- a/lib/features/app_shell/presentation/widgets/main_navigation_shell.dart
+++ b/lib/features/app_shell/presentation/widgets/main_navigation_shell.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../controllers/main_navigation_controller.dart';
+import '../models/navigation_tab_config.dart';
+import '../models/navigation_tab_content.dart';
+import '../providers/main_navigation_tabs_provider.dart';
+
+class MainNavigationShell extends ConsumerWidget {
+  const MainNavigationShell({super.key});
+
+  static const String routeName = '/home';
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final List<NavigationTabConfig> tabs =
+        ref.watch(mainNavigationTabsProvider);
+    final int currentIndex = ref.watch(mainNavigationControllerProvider);
+    final List<NavigationTabContent> contents = <NavigationTabContent>[
+      for (final NavigationTabConfig config in tabs)
+        config.contentBuilder(context, ref),
+    ];
+    final NavigationTabContent activeContent = contents[currentIndex];
+    final PreferredSizeWidget? appBar =
+        activeContent.appBarBuilder?.call(context, ref);
+    final Widget? floatingActionButton =
+        activeContent.floatingActionButtonBuilder?.call(context, ref);
+
+    return Scaffold(
+      appBar: appBar,
+      body: IndexedStack(
+        index: currentIndex,
+        children: <Widget>[
+          for (final NavigationTabContent content in contents)
+            content.bodyBuilder(context, ref),
+        ],
+      ),
+      floatingActionButton: floatingActionButton,
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: currentIndex,
+        onTap: (int index) =>
+            ref.read(mainNavigationControllerProvider.notifier).setIndex(index),
+        items: <BottomNavigationBarItem>[
+          for (final NavigationTabConfig config in tabs)
+            BottomNavigationBarItem(
+              icon: Icon(config.icon),
+              activeIcon: Icon(config.activeIcon),
+              label: config.labelBuilder(context),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:kopim/core/config/app_config.dart';
+import 'package:kopim/features/app_shell/presentation/models/navigation_tab_content.dart';
 import 'package:kopim/features/categories/presentation/screens/manage_categories_screen.dart';
 import 'package:kopim/features/profile/domain/entities/auth_user.dart';
 import 'package:kopim/features/profile/domain/entities/profile.dart';
@@ -18,13 +19,29 @@ class ProfileScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final AppLocalizations strings = AppLocalizations.of(context)!;
-    final ThemeData theme = ref.watch(appThemeProvider);
-    final AsyncValue<AuthUser?> authState = ref.watch(authControllerProvider);
-
+    final NavigationTabContent content = buildProfileTabContent(context, ref);
     return Scaffold(
-      appBar: AppBar(title: Text(strings.profileTitle)),
-      body: authState.when(
+      appBar: content.appBarBuilder?.call(context, ref),
+      body: content.bodyBuilder(context, ref),
+      floatingActionButton:
+          content.floatingActionButtonBuilder?.call(context, ref),
+    );
+  }
+}
+
+NavigationTabContent buildProfileTabContent(
+  BuildContext context,
+  WidgetRef ref,
+) {
+  return NavigationTabContent(
+    appBarBuilder: (BuildContext context, WidgetRef ref) =>
+        AppBar(title: Text(AppLocalizations.of(context)!.profileTitle)),
+    bodyBuilder: (BuildContext context, WidgetRef ref) {
+      final AppLocalizations strings = AppLocalizations.of(context)!;
+      final ThemeData theme = ref.watch(appThemeProvider);
+      final AsyncValue<AuthUser?> authState = ref.watch(authControllerProvider);
+
+      return authState.when(
         loading: () => const _CenteredProgress(),
         error: (Object error, StackTrace? stackTrace) =>
             _ErrorView(message: error.toString()),
@@ -61,9 +78,9 @@ class ProfileScreen extends ConsumerWidget {
             },
           );
         },
-      ),
-    );
-  }
+      );
+    },
+  );
 }
 
 class _ProfileForm extends ConsumerWidget {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,7 +10,7 @@ import 'core/di/injectors.dart';
 import 'features/profile/presentation/controllers/auth_controller.dart';
 import 'features/analytics/presentation/analytics_screen.dart';
 import 'features/accounts/presentation/accounts_add_screen.dart';
-import 'features/home/presentation/screens/home_screen.dart';
+import 'features/app_shell/presentation/widgets/main_navigation_shell.dart';
 import 'features/categories/presentation/screens/manage_categories_screen.dart';
 import 'features/profile/presentation/screens/profile_screen.dart';
 import 'features/profile/presentation/screens/sign_in_screen.dart';
@@ -47,7 +47,7 @@ class MyApp extends ConsumerWidget {
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       routes: <String, WidgetBuilder>{
-        HomeScreen.routeName: (_) => const HomeScreen(),
+        MainNavigationShell.routeName: (_) => const MainNavigationShell(),
         AnalyticsScreen.routeName: (_) => const AnalyticsScreen(),
         AddAccountScreen.routeName: (_) => const AddAccountScreen(),
         AddTransactionScreen.routeName: (_) => const AddTransactionScreen(),
@@ -56,7 +56,7 @@ class MyApp extends ConsumerWidget {
       },
       home: authState.when(
         data: (AuthUser? user) =>
-            user == null ? const SignInScreen() : const HomeScreen(),
+            user == null ? const SignInScreen() : const MainNavigationShell(),
         loading: () =>
             const Scaffold(body: Center(child: CircularProgressIndicator())),
         error: (Object error, _) => Scaffold(

--- a/test/features/app_shell/presentation/main_navigation_shell_test.dart
+++ b/test/features/app_shell/presentation/main_navigation_shell_test.dart
@@ -1,0 +1,207 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kopim/core/di/injectors.dart';
+import 'package:kopim/features/accounts/domain/entities/account_entity.dart';
+import 'package:kopim/features/accounts/domain/repositories/account_repository.dart';
+import 'package:kopim/features/accounts/domain/use_cases/watch_accounts_use_case.dart';
+import 'package:kopim/features/app_shell/presentation/widgets/main_navigation_shell.dart';
+import 'package:kopim/features/categories/domain/entities/category.dart';
+import 'package:kopim/features/categories/domain/repositories/category_repository.dart';
+import 'package:kopim/features/categories/domain/use_cases/watch_categories_use_case.dart';
+import 'package:kopim/features/categories/presentation/controllers/categories_list_controller.dart';
+import 'package:kopim/features/profile/domain/entities/auth_user.dart';
+import 'package:kopim/features/profile/presentation/controllers/auth_controller.dart';
+import 'package:kopim/features/transactions/domain/entities/transaction.dart';
+import 'package:kopim/features/transactions/domain/repositories/transaction_repository.dart';
+import 'package:kopim/features/transactions/domain/use_cases/watch_recent_transactions_use_case.dart';
+import 'package:kopim/l10n/app_localizations.dart';
+
+class _FakeAuthController extends AuthController {
+  _FakeAuthController(this._user);
+
+  final AuthUser? _user;
+
+  @override
+  FutureOr<AuthUser?> build() => _user;
+}
+
+class _StreamAccountRepository implements AccountRepository {
+  _StreamAccountRepository(this._stream);
+
+  final Stream<List<AccountEntity>> _stream;
+
+  @override
+  Stream<List<AccountEntity>> watchAccounts() => _stream;
+
+  @override
+  Future<AccountEntity?> findById(String id) => throw UnimplementedError();
+
+  @override
+  Future<List<AccountEntity>> loadAccounts() => throw UnimplementedError();
+
+  @override
+  Future<void> softDelete(String id) => throw UnimplementedError();
+
+  @override
+  Future<void> upsert(AccountEntity account) => throw UnimplementedError();
+}
+
+class _StreamTransactionRepository implements TransactionRepository {
+  _StreamTransactionRepository(this._stream);
+
+  final Stream<List<TransactionEntity>> _stream;
+
+  @override
+  Stream<List<TransactionEntity>> watchTransactions() => _stream;
+
+  @override
+  Future<TransactionEntity?> findById(String id) => throw UnimplementedError();
+
+  @override
+  Future<List<TransactionEntity>> loadTransactions() =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> softDelete(String id) => throw UnimplementedError();
+
+  @override
+  Future<void> upsert(TransactionEntity transaction) =>
+      throw UnimplementedError();
+}
+
+class _StreamCategoryRepository implements CategoryRepository {
+  _StreamCategoryRepository(this._stream);
+
+  final Stream<List<Category>> _stream;
+
+  @override
+  Stream<List<Category>> watchCategories() => _stream;
+
+  @override
+  Future<Category?> findById(String id) => throw UnimplementedError();
+
+  @override
+  Future<List<Category>> loadCategories() => throw UnimplementedError();
+
+  @override
+  Future<void> softDelete(String id) => throw UnimplementedError();
+
+  @override
+  Future<void> upsert(Category category) => throw UnimplementedError();
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final DateTime now = DateTime.utc(2024, 1, 1);
+  final AccountEntity account = AccountEntity(
+    id: 'acc-1',
+    name: 'Wallet',
+    balance: 1200,
+    currency: 'USD',
+    type: 'cash',
+    createdAt: now,
+    updatedAt: now,
+  );
+
+  const AuthUser? anonymousUser = null;
+
+  ProviderScope _buildShell(Widget child) {
+    return ProviderScope(
+      overrides: [
+        authControllerProvider.overrideWith(
+          () => _FakeAuthController(anonymousUser),
+        ),
+        watchAccountsUseCaseProvider.overrideWithValue(
+          WatchAccountsUseCase(
+            _StreamAccountRepository(Stream.value(<AccountEntity>[account])),
+          ),
+        ),
+        watchRecentTransactionsUseCaseProvider.overrideWithValue(
+          WatchRecentTransactionsUseCase(
+            _StreamTransactionRepository(
+              Stream<List<TransactionEntity>>.value(const <TransactionEntity>[]),
+            ),
+          ),
+        ),
+        watchCategoriesUseCaseProvider.overrideWithValue(
+          WatchCategoriesUseCase(
+            _StreamCategoryRepository(
+              Stream<List<Category>>.value(const <Category>[]),
+            ),
+          ),
+        ),
+        manageCategoriesListProvider.overrideWith(
+          (Ref ref) => Stream<List<Category>>.value(const <Category>[]),
+        ),
+      ],
+      child: child,
+    );
+  }
+
+  testWidgets('displays bottom navigation bar on every primary tab', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      _buildShell(
+        const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: MainNavigationShell(),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    final Finder bottomNavFinder = find.byType(BottomNavigationBar);
+    expect(bottomNavFinder, findsOneWidget);
+
+    await tester.tap(find.text('Analytics'));
+    await tester.pumpAndSettle();
+    expect(bottomNavFinder, findsOneWidget);
+
+    await tester.tap(find.text('Settings'));
+    await tester.pumpAndSettle();
+    expect(bottomNavFinder, findsOneWidget);
+  });
+
+  testWidgets('hides bottom navigation when a secondary route is pushed', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      _buildShell(
+        const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: MainNavigationShell(),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    final NavigatorState navigator =
+        tester.state(find.byType(Navigator)) as NavigatorState;
+
+    navigator.push(
+      MaterialPageRoute<void>(
+        builder: (BuildContext context) => const Scaffold(
+          body: Center(child: Text('Child screen')),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.byType(BottomNavigationBar), findsNothing);
+
+    navigator.pop();
+    await tester.pumpAndSettle();
+
+    expect(find.byType(BottomNavigationBar), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add a MainNavigationShell with Riverpod-driven bottom navigation shared across primary tabs
- refactor home, analytics, and profile presentations to expose tab content for the shell instead of standalone scaffolds
- cover the new navigation shell with widget tests to ensure the bottom bar persists on main tabs and disappears on pushed routes

## Testing
- flutter test *(fails: flutter command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dcdd6d92d8832ea0cf92a6680a91e5