### PR TITLE
feat: enable deleting categories from management screen

### DIFF
--- a/lib/core/di/injectors.dart
+++ b/lib/core/di/injectors.dart
@@ -22,6 +22,7 @@ import 'package:kopim/features/categories/data/repositories/category_repository_
 import 'package:kopim/features/categories/data/sources/local/category_dao.dart';
 import 'package:kopim/features/categories/data/sources/remote/category_remote_data_source.dart';
 import 'package:kopim/features/categories/domain/repositories/category_repository.dart';
+import 'package:kopim/features/categories/domain/use_cases/delete_category_use_case.dart';
 import 'package:kopim/features/categories/domain/use_cases/save_category_use_case.dart';
 import 'package:kopim/features/categories/domain/use_cases/watch_categories_use_case.dart';
 import 'package:kopim/features/categories/domain/use_cases/watch_category_tree_use_case.dart';
@@ -126,6 +127,10 @@ CategoryRepository categoryRepository(Ref ref) => CategoryRepositoryImpl(
 @riverpod
 SaveCategoryUseCase saveCategoryUseCase(Ref ref) =>
     SaveCategoryUseCase(ref.watch(categoryRepositoryProvider));
+
+@riverpod
+DeleteCategoryUseCase deleteCategoryUseCase(Ref ref) =>
+    DeleteCategoryUseCase(ref.watch(categoryRepositoryProvider));
 
 final rp.Provider<WatchCategoriesUseCase> watchCategoriesUseCaseProvider =
     rp.Provider<WatchCategoriesUseCase>((rp.Ref ref) {

--- a/lib/core/di/injectors.g.dart
+++ b/lib/core/di/injectors.g.dart
@@ -983,6 +983,55 @@ final class SaveCategoryUseCaseProvider
 String _$saveCategoryUseCaseHash() =>
     r'c9df54f4aa3bfc8cf852a4007a254d499e0b60b9';
 
+
+@ProviderFor(deleteCategoryUseCase)
+const deleteCategoryUseCaseProvider = DeleteCategoryUseCaseProvider._();
+
+final class DeleteCategoryUseCaseProvider
+    extends
+        $FunctionalProvider<
+          DeleteCategoryUseCase,
+          DeleteCategoryUseCase,
+          DeleteCategoryUseCase
+        >
+    with $Provider<DeleteCategoryUseCase> {
+  const DeleteCategoryUseCaseProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'deleteCategoryUseCaseProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$deleteCategoryUseCaseHash();
+
+  @$internal
+  @override
+  $ProviderElement<DeleteCategoryUseCase> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  DeleteCategoryUseCase create(Ref ref) {
+    return deleteCategoryUseCase(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(DeleteCategoryUseCase value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<DeleteCategoryUseCase>(value),
+    );
+  }
+}
+
+String _$deleteCategoryUseCaseHash() =>
+    r'f82c2ef624c4c0a4f98e77c4fa64b45d67a3eabc';
+
 @ProviderFor(transactionRepository)
 const transactionRepositoryProvider = TransactionRepositoryProvider._();
 

--- a/lib/features/categories/domain/use_cases/delete_category_use_case.dart
+++ b/lib/features/categories/domain/use_cases/delete_category_use_case.dart
@@ -1,0 +1,13 @@
+import 'package:kopim/features/categories/domain/repositories/category_repository.dart';
+
+/// Use case responsible for deleting a category and all of its descendants.
+class DeleteCategoryUseCase {
+  const DeleteCategoryUseCase(this._repository);
+
+  final CategoryRepository _repository;
+
+  /// Marks the category and its descendants as deleted.
+  Future<void> call(String id) {
+    return _repository.softDelete(id);
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -102,13 +102,17 @@
   "@manageCategoriesTypeIncome": {
     "description": "Label for income category type"
   },
-  "manageCategoriesIconLabel": "Icon (optional)",
+  "manageCategoriesIconLabel": "Icon",
   "@manageCategoriesIconLabel": {
-    "description": "Label for the optional icon input"
+    "description": "Label for the icon input"
   },
   "manageCategoriesIconNone": "No icon selected",
   "@manageCategoriesIconNone": {
     "description": "Subtitle shown when no icon has been selected"
+  },
+  "manageCategoriesIconSelected": "Icon selected",
+  "@manageCategoriesIconSelected": {
+    "description": "Subtitle shown when an icon has been selected"
   },
   "manageCategoriesIconSelect": "Choose icon",
   "@manageCategoriesIconSelect": {
@@ -150,13 +154,17 @@
   "@manageCategoriesIconStyleFill": {
     "description": "Label for the fill icon style filter"
   },
-  "manageCategoriesColorLabel": "Color (optional)",
+  "manageCategoriesColorLabel": "Color",
   "@manageCategoriesColorLabel": {
-    "description": "Label for the optional color input"
+    "description": "Label for the color input"
   },
   "manageCategoriesColorNone": "No color selected",
   "@manageCategoriesColorNone": {
     "description": "Subtitle shown when no color has been selected"
+  },
+  "manageCategoriesColorSelected": "Color selected",
+  "@manageCategoriesColorSelected": {
+    "description": "Subtitle shown when a color has been selected"
   },
   "manageCategoriesColorSelect": "Choose color",
   "@manageCategoriesColorSelect": {
@@ -190,6 +198,36 @@
   "manageCategoriesSuccessUpdate": "Category updated successfully.",
   "@manageCategoriesSuccessUpdate": {
     "description": "Snackbar message shown when a category is updated"
+  },
+  "manageCategoriesDeleteAction": "Delete",
+  "@manageCategoriesDeleteAction": {
+    "description": "Label for the delete category action"
+  },
+  "manageCategoriesDeleteConfirmTitle": "Delete category",
+  "@manageCategoriesDeleteConfirmTitle": {
+    "description": "Title for the delete category confirmation dialog"
+  },
+  "manageCategoriesDeleteConfirmMessage": "Are you sure you want to delete the category \"{name}\"? All subcategories will also be removed.",
+  "@manageCategoriesDeleteConfirmMessage": {
+    "description": "Confirmation message shown before deleting a category",
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "manageCategoriesDeleteSuccess": "Category deleted successfully.",
+  "@manageCategoriesDeleteSuccess": {
+    "description": "Snackbar message shown when a category is deleted"
+  },
+  "manageCategoriesDeleteError": "Unable to delete category: {error}",
+  "@manageCategoriesDeleteError": {
+    "description": "Error message shown when deleting a category fails",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
   },
   "@profileSectionAccount": {
     "description": "Section header for account information"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -248,10 +248,10 @@ abstract class AppLocalizations {
   /// **'Income'**
   String get manageCategoriesTypeIncome;
 
-  /// Label for the optional icon input
+  /// Label for the icon input
   ///
   /// In en, this message translates to:
-  /// **'Icon (optional)'**
+  /// **'Icon'**
   String get manageCategoriesIconLabel;
 
   /// Subtitle shown when no icon has been selected
@@ -259,6 +259,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'No icon selected'**
   String get manageCategoriesIconNone;
+
+  /// Subtitle shown when an icon has been selected
+  ///
+  /// In en, this message translates to:
+  /// **'Icon selected'**
+  String get manageCategoriesIconSelected;
 
   /// Tooltip for the action that opens the icon picker
   ///
@@ -320,10 +326,10 @@ abstract class AppLocalizations {
   /// **'Fill'**
   String get manageCategoriesIconStyleFill;
 
-  /// Label for the optional color input
+  /// Label for the color input
   ///
   /// In en, this message translates to:
-  /// **'Color (optional)'**
+  /// **'Color'**
   String get manageCategoriesColorLabel;
 
   /// Subtitle shown when no color has been selected
@@ -331,6 +337,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'No color selected'**
   String get manageCategoriesColorNone;
+
+  /// Subtitle shown when a color has been selected
+  ///
+  /// In en, this message translates to:
+  /// **'Color selected'**
+  String get manageCategoriesColorSelected;
 
   /// Tooltip for the action that opens the color picker
   ///
@@ -373,6 +385,36 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Category updated successfully.'**
   String get manageCategoriesSuccessUpdate;
+
+  /// Label for the delete category action
+  ///
+  /// In en, this message translates to:
+  /// **'Delete'**
+  String get manageCategoriesDeleteAction;
+
+  /// Title for the delete category confirmation dialog
+  ///
+  /// In en, this message translates to:
+  /// **'Delete category'**
+  String get manageCategoriesDeleteConfirmTitle;
+
+  /// Confirmation message shown before deleting a category
+  ///
+  /// In en, this message translates to:
+  /// **'Are you sure you want to delete the category "{name}"? All subcategories will also be removed.'**
+  String manageCategoriesDeleteConfirmMessage(String name);
+
+  /// Snackbar message shown when a category is deleted
+  ///
+  /// In en, this message translates to:
+  /// **'Category deleted successfully.'**
+  String get manageCategoriesDeleteSuccess;
+
+  /// Error message shown when deleting a category fails
+  ///
+  /// In en, this message translates to:
+  /// **'Unable to delete category: {error}'**
+  String manageCategoriesDeleteError(String error);
 
   /// Label for the profile name input
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -88,10 +88,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get manageCategoriesTypeIncome => 'Income';
 
   @override
-  String get manageCategoriesIconLabel => 'Icon (optional)';
+  String get manageCategoriesIconLabel => 'Icon';
 
   @override
   String get manageCategoriesIconNone => 'No icon selected';
+
+  @override
+  String get manageCategoriesIconSelected => 'Icon selected';
 
   @override
   String get manageCategoriesIconSelect => 'Choose icon';
@@ -124,10 +127,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get manageCategoriesIconStyleFill => 'Fill';
 
   @override
-  String get manageCategoriesColorLabel => 'Color (optional)';
+  String get manageCategoriesColorLabel => 'Color';
 
   @override
   String get manageCategoriesColorNone => 'No color selected';
+
+  @override
+  String get manageCategoriesColorSelected => 'Color selected';
 
   @override
   String get manageCategoriesColorSelect => 'Choose color';
@@ -151,6 +157,25 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get manageCategoriesSuccessUpdate => 'Category updated successfully.';
+
+  @override
+  String get manageCategoriesDeleteAction => 'Delete';
+
+  @override
+  String get manageCategoriesDeleteConfirmTitle => 'Delete category';
+
+  @override
+  String manageCategoriesDeleteConfirmMessage(String name) {
+    return 'Are you sure you want to delete the category "$name"? All subcategories will also be removed.';
+  }
+
+  @override
+  String get manageCategoriesDeleteSuccess => 'Category deleted successfully.';
+
+  @override
+  String manageCategoriesDeleteError(String error) {
+    return 'Unable to delete category: $error';
+  }
 
   @override
   String get profileNameLabel => 'Name';

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -91,10 +91,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get manageCategoriesTypeIncome => 'Доход';
 
   @override
-  String get manageCategoriesIconLabel => 'Иконка (необязательно)';
+  String get manageCategoriesIconLabel => 'Иконка';
 
   @override
   String get manageCategoriesIconNone => 'Иконка не выбрана';
+
+  @override
+  String get manageCategoriesIconSelected => 'Иконка выбрана';
 
   @override
   String get manageCategoriesIconSelect => 'Выбрать иконку';
@@ -127,10 +130,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get manageCategoriesIconStyleFill => 'Заливка';
 
   @override
-  String get manageCategoriesColorLabel => 'Цвет (необязательно)';
+  String get manageCategoriesColorLabel => 'Цвет';
 
   @override
   String get manageCategoriesColorNone => 'Цвет не выбран';
+
+  @override
+  String get manageCategoriesColorSelected => 'Цвет выбран';
 
   @override
   String get manageCategoriesColorSelect => 'Выбрать цвет';
@@ -154,6 +160,25 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get manageCategoriesSuccessUpdate => 'Категория обновлена.';
+
+  @override
+  String get manageCategoriesDeleteAction => 'Удалить';
+
+  @override
+  String get manageCategoriesDeleteConfirmTitle => 'Удалить категорию';
+
+  @override
+  String manageCategoriesDeleteConfirmMessage(String name) {
+    return 'Вы действительно хотите удалить категорию «$name»? Все подкатегории также будут удалены.';
+  }
+
+  @override
+  String get manageCategoriesDeleteSuccess => 'Категория удалена.';
+
+  @override
+  String manageCategoriesDeleteError(String error) {
+    return 'Не удалось удалить категорию: $error';
+  }
 
   @override
   String get profileNameLabel => 'Имя';

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -102,13 +102,17 @@
   "@manageCategoriesTypeIncome": {
     "description": "Подпись типа категории для доходов"
   },
-  "manageCategoriesIconLabel": "Иконка (необязательно)",
+  "manageCategoriesIconLabel": "Иконка",
   "@manageCategoriesIconLabel": {
     "description": "Подпись поля иконки"
   },
   "manageCategoriesIconNone": "Иконка не выбрана",
   "@manageCategoriesIconNone": {
     "description": "Подпись, когда иконка не выбрана"
+  },
+  "manageCategoriesIconSelected": "Иконка выбрана",
+  "@manageCategoriesIconSelected": {
+    "description": "Подпись, когда иконка выбрана"
   },
   "manageCategoriesIconSelect": "Выбрать иконку",
   "@manageCategoriesIconSelect": {
@@ -150,13 +154,17 @@
   "@manageCategoriesIconStyleFill": {
     "description": "Подпись фильтра заливного стиля"
   },
-  "manageCategoriesColorLabel": "Цвет (необязательно)",
+  "manageCategoriesColorLabel": "Цвет",
   "@manageCategoriesColorLabel": {
     "description": "Подпись поля цвета"
   },
   "manageCategoriesColorNone": "Цвет не выбран",
   "@manageCategoriesColorNone": {
     "description": "Подпись, когда цвет категории не выбран"
+  },
+  "manageCategoriesColorSelected": "Цвет выбран",
+  "@manageCategoriesColorSelected": {
+    "description": "Подпись, когда цвет выбран"
   },
   "manageCategoriesColorSelect": "Выбрать цвет",
   "@manageCategoriesColorSelect": {
@@ -190,6 +198,36 @@
   "manageCategoriesSuccessUpdate": "Категория обновлена.",
   "@manageCategoriesSuccessUpdate": {
     "description": "Сообщение после успешного обновления категории"
+  },
+  "manageCategoriesDeleteAction": "Удалить",
+  "@manageCategoriesDeleteAction": {
+    "description": "Подпись для действия удаления категории"
+  },
+  "manageCategoriesDeleteConfirmTitle": "Удалить категорию",
+  "@manageCategoriesDeleteConfirmTitle": {
+    "description": "Заголовок диалога подтверждения удаления категории"
+  },
+  "manageCategoriesDeleteConfirmMessage": "Вы действительно хотите удалить категорию «{name}»? Все подкатегории также будут удалены.",
+  "@manageCategoriesDeleteConfirmMessage": {
+    "description": "Сообщение подтверждения перед удалением категории",
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "manageCategoriesDeleteSuccess": "Категория удалена.",
+  "@manageCategoriesDeleteSuccess": {
+    "description": "Сообщение после успешного удаления категории"
+  },
+  "manageCategoriesDeleteError": "Не удалось удалить категорию: {error}",
+  "@manageCategoriesDeleteError": {
+    "description": "Сообщение об ошибке при удалении категории",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
   },
   "@profileSectionAccount": {
     "description": "Заголовок блока с учетной записью"

--- a/test/features/categories/domain/use_cases/delete_category_use_case_test.dart
+++ b/test/features/categories/domain/use_cases/delete_category_use_case_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kopim/features/categories/domain/repositories/category_repository.dart';
+import 'package:kopim/features/categories/domain/use_cases/delete_category_use_case.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockCategoryRepository extends Mock implements CategoryRepository {}
+
+void main() {
+  late _MockCategoryRepository repository;
+  late DeleteCategoryUseCase useCase;
+
+  setUp(() {
+    repository = _MockCategoryRepository();
+    useCase = DeleteCategoryUseCase(repository);
+  });
+
+  test('delegates to repository for soft delete', () async {
+    when(() => repository.softDelete('cat-1')).thenAnswer((_) async {});
+
+    await useCase('cat-1');
+
+    verify(() => repository.softDelete('cat-1')).called(1);
+  });
+
+  test('bubbles up repository errors', () async {
+    when(() => repository.softDelete('cat-2')).thenThrow(StateError('failed'));
+
+    expect(() => useCase('cat-2'), throwsStateError);
+    verify(() => repository.softDelete('cat-2')).called(1);
+  });
+}


### PR DESCRIPTION
## Summary
- add delete actions with confirmation dialogs and snackbars on the manage categories screen
- simplify the category editor by removing parent selection and clarifying icon/color labels
- wire a delete-category use case into DI, update localizations, and cover the use case with tests

## Testing
- flutter test *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd151ec5b0832e86dddbd96510568d