### PR TITLE
Simplify category creation and refresh icon picker

### DIFF
--- a/lib/core/widgets/phosphor_icon_picker.dart
+++ b/lib/core/widgets/phosphor_icon_picker.dart
@@ -6,18 +6,120 @@ import 'package:phosphor_flutter/phosphor_flutter.dart';
 class PhosphorIconPickerLabels {
   const PhosphorIconPickerLabels({
     required this.title,
-    required this.searchPlaceholder,
     required this.clearButtonLabel,
     required this.emptyStateLabel,
     required this.styleLabels,
+    required this.groupLabels,
   });
 
   final String title;
-  final String searchPlaceholder;
   final String clearButtonLabel;
   final String emptyStateLabel;
   final Map<PhosphorIconStyle, String> styleLabels;
+  final Map<String, String> groupLabels;
 }
+
+const int _kPhosphorIconPickerLimit = 60;
+
+class _IconGroup {
+  const _IconGroup({required this.id, required this.iconNames});
+
+  final String id;
+  final List<String> iconNames;
+}
+
+const List<_IconGroup> _iconGroups = <_IconGroup>[
+  _IconGroup(
+    id: 'finance',
+    iconNames: <String>[
+      'wallet',
+      'coins',
+      'piggyBank',
+      'bank',
+      'briefcase',
+      'currencyDollar',
+      'currencyEur',
+      'currencyRub',
+      'creditCard',
+      'chartLineUp',
+    ],
+  ),
+  _IconGroup(
+    id: 'shopping',
+    iconNames: <String>[
+      'shoppingBag',
+      'shoppingBagOpen',
+      'shoppingCart',
+      'shoppingCartSimple',
+      'tag',
+      'tShirt',
+      'dress',
+      'handbag',
+      'storefront',
+      'gift',
+    ],
+  ),
+  _IconGroup(
+    id: 'food',
+    iconNames: <String>[
+      'forkKnife',
+      'pizza',
+      'hamburger',
+      'cake',
+      'iceCream',
+      'coffee',
+      'beerBottle',
+      'wine',
+      'carrot',
+      'fish',
+    ],
+  ),
+  _IconGroup(
+    id: 'transport',
+    iconNames: <String>[
+      'car',
+      'carSimple',
+      'bus',
+      'train',
+      'subway',
+      'bicycle',
+      'motorcycle',
+      'scooter',
+      'airplane',
+      'gasPump',
+    ],
+  ),
+  _IconGroup(
+    id: 'home',
+    iconNames: <String>[
+      'house',
+      'houseLine',
+      'bed',
+      'bathtub',
+      'shower',
+      'lamp',
+      'plug',
+      'drop',
+      'flame',
+      'washingMachine',
+    ],
+  ),
+  _IconGroup(
+    id: 'leisure',
+    iconNames: <String>[
+      'musicNotes',
+      'headphones',
+      'filmSlate',
+      'gameController',
+      'bookOpen',
+      'soccerBall',
+      'basketball',
+      'ticket',
+      'microphone',
+      'barbell',
+    ],
+  ),
+];
 
 Future<PhosphorIconDescriptor?> showPhosphorIconPicker({
   required BuildContext context,
@@ -45,31 +147,45 @@ class _PhosphorIconPickerSheet extends StatefulWidget {
       _PhosphorIconPickerSheetState();
 }
 
-class _PhosphorIconPickerSheetState extends State<_PhosphorIconPickerSheet> {
+class _PhosphorIconPickerSheetState extends State<_PhosphorIconPickerSheet>
+    with SingleTickerProviderStateMixin {
   late PhosphorIconStyle _selectedStyle;
-  late final TextEditingController _controller;
-  String _query = '';
+  late final TabController _tabController;
 
   @override
   void initState() {
     super.initState();
     _selectedStyle = widget.initial?.style ?? PhosphorIconStyle.regular;
-    _controller = TextEditingController();
-    _controller.addListener(_onQueryChanged);
+    _tabController = TabController(
+      length: _iconGroups.length,
+      vsync: this,
+      initialIndex: _findInitialGroupIndex(),
+    );
+    assert(
+      _iconGroups.fold<int>(
+            0,
+            (int total, _IconGroup group) => total + group.iconNames.length,
+          ) ==
+          _kPhosphorIconPickerLimit,
+      'Icon groups must contain exactly $_kPhosphorIconPickerLimit icons.',
+    );
   }
 
   @override
   void dispose() {
-    _controller
-      ..removeListener(_onQueryChanged)
-      ..dispose();
+    _tabController.dispose();
     super.dispose();
   }
 
-  void _onQueryChanged() {
-    setState(() {
-      _query = _controller.text;
-    });
+  int _findInitialGroupIndex() {
+    final String? initialName = widget.initial?.name;
+    if (initialName == null) {
+      return 0;
+    }
+    final int index = _iconGroups.indexWhere(
+      (_IconGroup group) => group.iconNames.contains(initialName),
+    );
+    return index >= 0 ? index : 0;
   }
 
   void _selectStyle(PhosphorIconStyle style) {
@@ -96,7 +212,6 @@ class _PhosphorIconPickerSheetState extends State<_PhosphorIconPickerSheet> {
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
-    final List<String> results = filterPhosphorIconNames(_query);
     final EdgeInsets viewInsets = MediaQuery.of(context).viewInsets;
     return Padding(
       padding: EdgeInsets.only(bottom: viewInsets.bottom),
@@ -126,76 +241,88 @@ class _PhosphorIconPickerSheetState extends State<_PhosphorIconPickerSheet> {
                   ],
                 ),
                 const SizedBox(height: 16),
-                TextField(
-                  controller: _controller,
-                  decoration: InputDecoration(
-                    prefixIcon: const Icon(Icons.search),
-                    labelText: widget.labels.searchPlaceholder,
-                  ),
-                ),
-                const SizedBox(height: 16),
                 _StyleSelector(
                   selected: _selectedStyle,
                   labels: widget.labels.styleLabels,
                   onSelected: _selectStyle,
                 ),
-                const SizedBox(height: 16),
-                if (results.isEmpty)
-                  Expanded(
-                    child: Center(
-                      child: Text(
-                        widget.labels.emptyStateLabel,
-                        style: theme.textTheme.bodyMedium,
-                      ),
-                    ),
-                  )
-                else
-                  Expanded(
-                    child: LayoutBuilder(
-                      builder:
-                          (BuildContext context, BoxConstraints constraints) {
-                            final double maxWidth = constraints.maxWidth;
-                            final int crossAxisCount = maxWidth < 480
-                                ? 4
-                                : (maxWidth ~/ 72).clamp(4, 10);
-                            return GridView.builder(
-                              gridDelegate:
-                                  SliverGridDelegateWithFixedCrossAxisCount(
-                                    crossAxisCount: crossAxisCount,
-                                    crossAxisSpacing: 12,
-                                    mainAxisSpacing: 12,
-                                    childAspectRatio: 0.8,
-                                  ),
-                              itemCount: results.length,
-                              itemBuilder: (BuildContext context, int index) {
-                                final String name = results[index];
-                                final PhosphorIconDescriptor descriptor =
-                                    PhosphorIconDescriptor(
-                                      name: name,
-                                      style: _selectedStyle,
-                                    );
-                                final PhosphorIconData? iconData =
-                                    resolvePhosphorIconData(descriptor);
-                                final bool isCurrent =
-                                    widget.initial != null &&
-                                    widget.initial!.name == name &&
-                                    widget.initial!.style == _selectedStyle;
-                                return _IconGridTile(
-                                  iconData: iconData,
-                                  name: name,
-                                  isSelected: isCurrent,
-                                  onTap: () => _selectIcon(name),
-                                );
-                              },
-                            );
-                          },
-                    ),
+                const SizedBox(height: 12),
+                TabBar(
+                  controller: _tabController,
+                  isScrollable: true,
+                  labelPadding: const EdgeInsets.symmetric(horizontal: 12),
+                  tabs: _iconGroups
+                      .map(
+                        (_IconGroup group) => Tab(
+                          text: widget.labels.groupLabels[group.id] ?? group.id,
+                        ),
+                      )
+                      .toList(growable: false),
+                ),
+                const SizedBox(height: 12),
+                Expanded(
+                  child: TabBarView(
+                    controller: _tabController,
+                    children: _iconGroups
+                        .map(_buildGroupGrid)
+                        .toList(growable: false),
                   ),
+                ),
               ],
             ),
           ),
         ),
       ),
+    );
+  }
+
+  Widget _buildGroupGrid(_IconGroup group) {
+    final ThemeData theme = Theme.of(context);
+    final List<String> icons = group.iconNames;
+    if (icons.isEmpty) {
+      return Center(
+        child: Text(
+          widget.labels.emptyStateLabel,
+          style: theme.textTheme.bodyMedium,
+          textAlign: TextAlign.center,
+        ),
+      );
+    }
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        final double maxWidth = constraints.maxWidth;
+        final int crossAxisCount = maxWidth < 480
+            ? 4
+            : (maxWidth ~/ 72).clamp(4, 10);
+        return GridView.builder(
+          padding: const EdgeInsets.symmetric(vertical: 4),
+          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+            crossAxisCount: crossAxisCount,
+            crossAxisSpacing: 12,
+            mainAxisSpacing: 12,
+            childAspectRatio: 0.8,
+          ),
+          itemCount: icons.length,
+          itemBuilder: (BuildContext context, int index) {
+            final String name = icons[index];
+            final PhosphorIconDescriptor descriptor = PhosphorIconDescriptor(
+              name: name,
+              style: _selectedStyle,
+            );
+            final PhosphorIconData? iconData =
+                resolvePhosphorIconData(descriptor);
+            final bool isCurrent = widget.initial != null &&
+                widget.initial!.name == name &&
+                widget.initial!.style == _selectedStyle;
+            return _IconGridTile(
+              iconData: iconData,
+              name: name,
+              isSelected: isCurrent,
+              onTap: () => _selectIcon(name),
+            );
+          },
+        );
+      },
     );
   }
 }

--- a/lib/core/widgets/phosphor_icon_utils.dart
+++ b/lib/core/widgets/phosphor_icon_utils.dart
@@ -42,14 +42,3 @@ String formatPhosphorIconName(String name) {
   return buffer.toString().toLowerCase();
 }
 
-List<String> filterPhosphorIconNames(String query) {
-  if (query.trim().isEmpty) {
-    return phosphorIconNames;
-  }
-  final String normalized = query.trim().toLowerCase();
-  final List<String> matches = phosphorIconNames
-      .where((String name) => name.toLowerCase().contains(normalized))
-      .toList(growable: false);
-  matches.sort((String a, String b) => a.compareTo(b));
-  return matches;
-}

--- a/lib/features/categories/presentation/screens/manage_categories_screen.dart
+++ b/lib/features/categories/presentation/screens/manage_categories_screen.dart
@@ -36,7 +36,12 @@ class ManageCategoriesScreen extends ConsumerWidget {
     return Scaffold(
       appBar: AppBar(title: Text(strings.profileManageCategoriesTitle)),
       floatingActionButton: FloatingActionButton(
-        onPressed: () => _showCreateMenu(context, ref, strings, rootCategories),
+        onPressed: () => _showCategoryEditor(
+          context,
+          ref,
+          strings: strings,
+          parents: rootCategories,
+        ),
         tooltip: strings.manageCategoriesAddAction,
         child: const Icon(Icons.add),
       ),
@@ -81,104 +86,6 @@ class ManageCategoriesScreen extends ConsumerWidget {
       ),
     );
   }
-}
-
-Future<void> _showCreateMenu(
-  BuildContext context,
-  WidgetRef ref,
-  AppLocalizations strings,
-  List<Category> parents,
-) async {
-  final ThemeData theme = Theme.of(context);
-  final String? selection = await showModalBottomSheet<String>(
-    context: context,
-    useSafeArea: true,
-    builder: (BuildContext context) {
-      return SafeArea(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: <Widget>[
-            ListTile(
-              leading: const Icon(Icons.category_outlined),
-              title: Text(strings.manageCategoriesCreateRootAction),
-              onTap: () => Navigator.of(context).pop('root'),
-            ),
-            ListTile(
-              leading: const Icon(Icons.subdirectory_arrow_right),
-              title: Text(strings.manageCategoriesCreateSubAction),
-              enabled: parents.isNotEmpty,
-              subtitle: parents.isEmpty
-                  ? Text(
-                      strings.manageCategoriesCreateSubDisabled,
-                      style: theme.textTheme.bodySmall,
-                    )
-                  : null,
-              onTap: parents.isEmpty
-                  ? null
-                  : () => Navigator.of(context).pop('sub'),
-            ),
-            const SizedBox(height: 12),
-          ],
-        ),
-      );
-    },
-  );
-
-  if (selection == 'root') {
-    await _showCategoryEditor(context, ref, strings: strings, parents: parents);
-    return;
-  }
-  if (selection == 'sub' && parents.isNotEmpty) {
-    final Category? parent = await _selectParentCategory(
-      context,
-      strings,
-      parents,
-    );
-    if (parent != null) {
-      await _showCategoryEditor(
-        context,
-        ref,
-        strings: strings,
-        parents: parents,
-        defaultParentId: parent.id,
-      );
-    }
-  }
-}
-
-Future<Category?> _selectParentCategory(
-  BuildContext context,
-  AppLocalizations strings,
-  List<Category> parents,
-) async {
-  return showDialog<Category>(
-    context: context,
-    builder: (BuildContext context) {
-      return AlertDialog(
-        title: Text(strings.manageCategoriesSelectParentTitle),
-        content: ConstrainedBox(
-          constraints: const BoxConstraints(maxHeight: 320),
-          child: ListView.builder(
-            itemCount: parents.length,
-            itemBuilder: (BuildContext context, int index) {
-              final Category category = parents[index];
-              return ListTile(
-                leading: const Icon(Icons.folder_outlined),
-                title: Text(category.name),
-                onTap: () => Navigator.of(context).pop(category),
-              );
-            },
-          ),
-        ),
-        actions: <Widget>[
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(),
-            child: Text(strings.dialogCancel),
-          ),
-        ],
-      );
-    },
-  );
 }
 
 Future<void> _showCategoryEditor(
@@ -543,7 +450,6 @@ class _CategoryEditorSheet extends ConsumerWidget {
 
     final PhosphorIconPickerLabels pickerLabels = PhosphorIconPickerLabels(
       title: strings.manageCategoriesIconPickerTitle,
-      searchPlaceholder: strings.manageCategoriesIconSearchHint,
       clearButtonLabel: strings.manageCategoriesIconClear,
       emptyStateLabel: strings.manageCategoriesIconEmpty,
       styleLabels: <PhosphorIconStyle, String>{
@@ -552,6 +458,14 @@ class _CategoryEditorSheet extends ConsumerWidget {
         PhosphorIconStyle.regular: strings.manageCategoriesIconStyleRegular,
         PhosphorIconStyle.bold: strings.manageCategoriesIconStyleBold,
         PhosphorIconStyle.fill: strings.manageCategoriesIconStyleFill,
+      },
+      groupLabels: <String, String>{
+        'finance': strings.manageCategoriesIconGroupFinance,
+        'shopping': strings.manageCategoriesIconGroupShopping,
+        'food': strings.manageCategoriesIconGroupFood,
+        'transport': strings.manageCategoriesIconGroupTransport,
+        'home': strings.manageCategoriesIconGroupHome,
+        'leisure': strings.manageCategoriesIconGroupLeisure,
       },
     );
 
@@ -669,7 +583,7 @@ class _CategoryEditorSheet extends ConsumerWidget {
                       onPressed: () => controller.updateIcon(null),
                     ),
                   IconButton(
-                    icon: const Icon(Icons.search),
+                    icon: const Icon(Icons.grid_view),
                     tooltip: strings.manageCategoriesIconSelect,
                     onPressed: () async {
                       final PhosphorIconDescriptor? selection =

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -21,21 +21,9 @@
   "@manageCategoriesAddAction": {
     "description": "Tooltip for the button that starts creating a new category"
   },
-  "manageCategoriesCreateRootAction": "Create parent category",
-  "@manageCategoriesCreateRootAction": {
-    "description": "Action label to create a top-level category from the manage categories menu"
-  },
   "manageCategoriesCreateSubAction": "Create subcategory",
   "@manageCategoriesCreateSubAction": {
     "description": "Action label to create a subcategory from the manage categories menu"
-  },
-  "manageCategoriesCreateSubDisabled": "Add a parent category first to create subcategories.",
-  "@manageCategoriesCreateSubDisabled": {
-    "description": "Helper text shown when user cannot create subcategory because there are no parents"
-  },
-  "manageCategoriesSelectParentTitle": "Select parent category",
-  "@manageCategoriesSelectParentTitle": {
-    "description": "Dialog title prompting the user to select a parent category"
   },
   "dialogCancel": "Cancel",
   "@dialogCancel": {
@@ -122,17 +110,13 @@
   "@manageCategoriesIconPickerTitle": {
     "description": "Title for the bottom sheet that lists available icons"
   },
-  "manageCategoriesIconSearchHint": "Search icons",
-  "@manageCategoriesIconSearchHint": {
-    "description": "Placeholder text for the icon search field"
-  },
   "manageCategoriesIconClear": "Clear selection",
   "@manageCategoriesIconClear": {
     "description": "Label for the button that clears the selected icon"
   },
-  "manageCategoriesIconEmpty": "No icons match your search.",
+  "manageCategoriesIconEmpty": "No icons available.",
   "@manageCategoriesIconEmpty": {
-    "description": "Empty state when icon search returns no results"
+    "description": "Empty state shown when the selected icon group has no items"
   },
   "manageCategoriesIconStyleThin": "Thin",
   "@manageCategoriesIconStyleThin": {
@@ -153,6 +137,30 @@
   "manageCategoriesIconStyleFill": "Fill",
   "@manageCategoriesIconStyleFill": {
     "description": "Label for the fill icon style filter"
+  },
+  "manageCategoriesIconGroupFinance": "Finance & work",
+  "@manageCategoriesIconGroupFinance": {
+    "description": "Tab label for finance-related icons"
+  },
+  "manageCategoriesIconGroupShopping": "Shopping & clothing",
+  "@manageCategoriesIconGroupShopping": {
+    "description": "Tab label for shopping and clothing icons"
+  },
+  "manageCategoriesIconGroupFood": "Food & dining",
+  "@manageCategoriesIconGroupFood": {
+    "description": "Tab label for food-related icons"
+  },
+  "manageCategoriesIconGroupTransport": "Transport & travel",
+  "@manageCategoriesIconGroupTransport": {
+    "description": "Tab label for transport icons"
+  },
+  "manageCategoriesIconGroupHome": "Home & utilities",
+  "@manageCategoriesIconGroupHome": {
+    "description": "Tab label for home and utility icons"
+  },
+  "manageCategoriesIconGroupLeisure": "Leisure & sports",
+  "@manageCategoriesIconGroupLeisure": {
+    "description": "Tab label for leisure icons"
   },
   "manageCategoriesColorLabel": "Color",
   "@manageCategoriesColorLabel": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -134,29 +134,11 @@ abstract class AppLocalizations {
   /// **'Add category'**
   String get manageCategoriesAddAction;
 
-  /// Action label to create a top-level category from the manage categories menu
-  ///
-  /// In en, this message translates to:
-  /// **'Create parent category'**
-  String get manageCategoriesCreateRootAction;
-
   /// Action label to create a subcategory from the manage categories menu
   ///
   /// In en, this message translates to:
   /// **'Create subcategory'**
   String get manageCategoriesCreateSubAction;
-
-  /// Helper text shown when user cannot create subcategory because there are no parents
-  ///
-  /// In en, this message translates to:
-  /// **'Add a parent category first to create subcategories.'**
-  String get manageCategoriesCreateSubDisabled;
-
-  /// Dialog title prompting the user to select a parent category
-  ///
-  /// In en, this message translates to:
-  /// **'Select parent category'**
-  String get manageCategoriesSelectParentTitle;
 
   /// Generic cancel button label
   ///
@@ -278,22 +260,16 @@ abstract class AppLocalizations {
   /// **'Pick a category icon'**
   String get manageCategoriesIconPickerTitle;
 
-  /// Placeholder text for the icon search field
-  ///
-  /// In en, this message translates to:
-  /// **'Search icons'**
-  String get manageCategoriesIconSearchHint;
-
   /// Label for the button that clears the selected icon
   ///
   /// In en, this message translates to:
   /// **'Clear selection'**
   String get manageCategoriesIconClear;
 
-  /// Empty state when icon search returns no results
+  /// Empty state shown when the selected icon group has no entries
   ///
   /// In en, this message translates to:
-  /// **'No icons match your search.'**
+  /// **'No icons available.'**
   String get manageCategoriesIconEmpty;
 
   /// Label for the thin icon style filter
@@ -325,6 +301,42 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Fill'**
   String get manageCategoriesIconStyleFill;
+
+  /// Tab label for finance-related icons
+  ///
+  /// In en, this message translates to:
+  /// **'Finance & work'**
+  String get manageCategoriesIconGroupFinance;
+
+  /// Tab label for shopping and clothing icons
+  ///
+  /// In en, this message translates to:
+  /// **'Shopping & clothing'**
+  String get manageCategoriesIconGroupShopping;
+
+  /// Tab label for food-related icons
+  ///
+  /// In en, this message translates to:
+  /// **'Food & dining'**
+  String get manageCategoriesIconGroupFood;
+
+  /// Tab label for transport icons
+  ///
+  /// In en, this message translates to:
+  /// **'Transport & travel'**
+  String get manageCategoriesIconGroupTransport;
+
+  /// Tab label for home and utility icons
+  ///
+  /// In en, this message translates to:
+  /// **'Home & utilities'**
+  String get manageCategoriesIconGroupHome;
+
+  /// Tab label for leisure icons
+  ///
+  /// In en, this message translates to:
+  /// **'Leisure & sports'**
+  String get manageCategoriesIconGroupLeisure;
 
   /// Label for the color input
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -27,17 +27,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get manageCategoriesAddAction => 'Add category';
 
   @override
-  String get manageCategoriesCreateRootAction => 'Create parent category';
-
-  @override
   String get manageCategoriesCreateSubAction => 'Create subcategory';
-
-  @override
-  String get manageCategoriesCreateSubDisabled =>
-      'Add a parent category first to create subcategories.';
-
-  @override
-  String get manageCategoriesSelectParentTitle => 'Select parent category';
 
   @override
   String get dialogCancel => 'Cancel';
@@ -103,13 +93,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get manageCategoriesIconPickerTitle => 'Pick a category icon';
 
   @override
-  String get manageCategoriesIconSearchHint => 'Search icons';
-
-  @override
   String get manageCategoriesIconClear => 'Clear selection';
 
   @override
-  String get manageCategoriesIconEmpty => 'No icons match your search.';
+  String get manageCategoriesIconEmpty => 'No icons available.';
 
   @override
   String get manageCategoriesIconStyleThin => 'Thin';
@@ -125,6 +112,24 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get manageCategoriesIconStyleFill => 'Fill';
+
+  @override
+  String get manageCategoriesIconGroupFinance => 'Finance & work';
+
+  @override
+  String get manageCategoriesIconGroupShopping => 'Shopping & clothing';
+
+  @override
+  String get manageCategoriesIconGroupFood => 'Food & dining';
+
+  @override
+  String get manageCategoriesIconGroupTransport => 'Transport & travel';
+
+  @override
+  String get manageCategoriesIconGroupHome => 'Home & utilities';
+
+  @override
+  String get manageCategoriesIconGroupLeisure => 'Leisure & sports';
 
   @override
   String get manageCategoriesColorLabel => 'Color';

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -28,19 +28,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get manageCategoriesAddAction => 'Добавить категорию';
 
   @override
-  String get manageCategoriesCreateRootAction =>
-      'Создать категорию верхнего уровня';
-
-  @override
   String get manageCategoriesCreateSubAction => 'Создать подкатегорию';
-
-  @override
-  String get manageCategoriesCreateSubDisabled =>
-      'Сначала добавьте родительскую категорию, чтобы создать подкатегории.';
-
-  @override
-  String get manageCategoriesSelectParentTitle =>
-      'Выберите родительскую категорию';
 
   @override
   String get dialogCancel => 'Отмена';
@@ -106,13 +94,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get manageCategoriesIconPickerTitle => 'Выбор иконки категории';
 
   @override
-  String get manageCategoriesIconSearchHint => 'Поиск иконки';
-
-  @override
   String get manageCategoriesIconClear => 'Очистить выбор';
 
   @override
-  String get manageCategoriesIconEmpty => 'Подходящих иконок не найдено.';
+  String get manageCategoriesIconEmpty => 'Доступные иконки отсутствуют.';
 
   @override
   String get manageCategoriesIconStyleThin => 'Тонкая';
@@ -128,6 +113,24 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get manageCategoriesIconStyleFill => 'Заливка';
+
+  @override
+  String get manageCategoriesIconGroupFinance => 'Финансы и работа';
+
+  @override
+  String get manageCategoriesIconGroupShopping => 'Покупки и одежда';
+
+  @override
+  String get manageCategoriesIconGroupFood => 'Еда и кафе';
+
+  @override
+  String get manageCategoriesIconGroupTransport => 'Транспорт и поездки';
+
+  @override
+  String get manageCategoriesIconGroupHome => 'Дом и быт';
+
+  @override
+  String get manageCategoriesIconGroupLeisure => 'Развлечения и спорт';
 
   @override
   String get manageCategoriesColorLabel => 'Цвет';

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -21,21 +21,9 @@
   "@manageCategoriesAddAction": {
     "description": "Подсказка к кнопке добавления новой категории"
   },
-  "manageCategoriesCreateRootAction": "Создать категорию верхнего уровня",
-  "@manageCategoriesCreateRootAction": {
-    "description": "Подпись действия создания родительской категории в меню управления"
-  },
   "manageCategoriesCreateSubAction": "Создать подкатегорию",
   "@manageCategoriesCreateSubAction": {
     "description": "Подпись действия создания подкатегории в меню управления"
-  },
-  "manageCategoriesCreateSubDisabled": "Сначала добавьте родительскую категорию, чтобы создать подкатегории.",
-  "@manageCategoriesCreateSubDisabled": {
-    "description": "Подсказка, когда невозможно создать подкатегорию без родителя"
-  },
-  "manageCategoriesSelectParentTitle": "Выберите родительскую категорию",
-  "@manageCategoriesSelectParentTitle": {
-    "description": "Заголовок диалога выбора родительской категории"
   },
   "dialogCancel": "Отмена",
   "@dialogCancel": {
@@ -122,17 +110,13 @@
   "@manageCategoriesIconPickerTitle": {
     "description": "Заголовок листа с выбором иконок"
   },
-  "manageCategoriesIconSearchHint": "Поиск иконки",
-  "@manageCategoriesIconSearchHint": {
-    "description": "Подпись поля поиска иконок"
-  },
   "manageCategoriesIconClear": "Очистить выбор",
   "@manageCategoriesIconClear": {
     "description": "Подпись кнопки очистки выбранной иконки"
   },
-  "manageCategoriesIconEmpty": "Подходящих иконок не найдено.",
+  "manageCategoriesIconEmpty": "Доступные иконки отсутствуют.",
   "@manageCategoriesIconEmpty": {
-    "description": "Сообщение пустого состояния поиска иконок"
+    "description": "Сообщение пустого состояния при отсутствии иконок"
   },
   "manageCategoriesIconStyleThin": "Тонкая",
   "@manageCategoriesIconStyleThin": {
@@ -153,6 +137,30 @@
   "manageCategoriesIconStyleFill": "Заливка",
   "@manageCategoriesIconStyleFill": {
     "description": "Подпись фильтра заливного стиля"
+  },
+  "manageCategoriesIconGroupFinance": "Финансы и работа",
+  "@manageCategoriesIconGroupFinance": {
+    "description": "Название вкладки с иконками финансов"
+  },
+  "manageCategoriesIconGroupShopping": "Покупки и одежда",
+  "@manageCategoriesIconGroupShopping": {
+    "description": "Название вкладки с иконками для покупок и одежды"
+  },
+  "manageCategoriesIconGroupFood": "Еда и кафе",
+  "@manageCategoriesIconGroupFood": {
+    "description": "Название вкладки с иконками питания"
+  },
+  "manageCategoriesIconGroupTransport": "Транспорт и поездки",
+  "@manageCategoriesIconGroupTransport": {
+    "description": "Название вкладки с иконками транспорта"
+  },
+  "manageCategoriesIconGroupHome": "Дом и быт",
+  "@manageCategoriesIconGroupHome": {
+    "description": "Название вкладки с иконками для дома"
+  },
+  "manageCategoriesIconGroupLeisure": "Развлечения и спорт",
+  "@manageCategoriesIconGroupLeisure": {
+    "description": "Название вкладки с иконками досуга"
   },
   "manageCategoriesColorLabel": "Цвет",
   "@manageCategoriesColorLabel": {


### PR DESCRIPTION
## Summary
- make the manage categories action button open the root category editor directly
- redesign the Phosphor icon picker with six curated tabs and remove free-form search
- update localized resources to cover the new grouped icon selector strings

## Testing
- `flutter test` *(fails: flutter command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd1be7145c832e85d0f06831925494