### PR TITLE
Add account details screen with filtering and editing

### DIFF
--- a/lib/core/di/injectors.dart
+++ b/lib/core/di/injectors.dart
@@ -42,6 +42,7 @@ import 'package:kopim/features/transactions/domain/repositories/transaction_repo
 
 import 'package:kopim/features/transactions/domain/use_cases/add_transaction_use_case.dart';
 import 'package:uuid/uuid.dart';
+import 'package:kopim/features/transactions/domain/use_cases/watch_account_transactions_use_case.dart';
 import 'package:kopim/features/transactions/domain/use_cases/watch_recent_transactions_use_case.dart';
 
 part 'injectors.g.dart';
@@ -157,6 +158,10 @@ final rp.Provider<AddTransactionUseCase> addTransactionUseCaseProvider =
         accountRepository: ref.watch(accountRepositoryProvider),
       );
     });
+
+@riverpod
+WatchAccountTransactionsUseCase watchAccountTransactionsUseCase(Ref ref) =>
+    WatchAccountTransactionsUseCase(ref.watch(transactionRepositoryProvider));
 
 @riverpod
 WatchRecentTransactionsUseCase watchRecentTransactionsUseCase(Ref ref) =>

--- a/lib/core/di/injectors.g.dart
+++ b/lib/core/di/injectors.g.dart
@@ -983,7 +983,6 @@ final class SaveCategoryUseCaseProvider
 String _$saveCategoryUseCaseHash() =>
     r'c9df54f4aa3bfc8cf852a4007a254d499e0b60b9';
 
-
 @ProviderFor(deleteCategoryUseCase)
 const deleteCategoryUseCaseProvider = DeleteCategoryUseCaseProvider._();
 
@@ -1030,7 +1029,7 @@ final class DeleteCategoryUseCaseProvider
 }
 
 String _$deleteCategoryUseCaseHash() =>
-    r'f82c2ef624c4c0a4f98e77c4fa64b45d67a3eabc';
+    r'35134c5968610d737615af311aef0bb6b72cefb8';
 
 @ProviderFor(transactionRepository)
 const transactionRepositoryProvider = TransactionRepositoryProvider._();
@@ -1079,6 +1078,57 @@ final class TransactionRepositoryProvider
 
 String _$transactionRepositoryHash() =>
     r'3799c3525d6954f2ece515445c06171d0fba71ef';
+
+@ProviderFor(watchAccountTransactionsUseCase)
+const watchAccountTransactionsUseCaseProvider =
+    WatchAccountTransactionsUseCaseProvider._();
+
+final class WatchAccountTransactionsUseCaseProvider
+    extends
+        $FunctionalProvider<
+          WatchAccountTransactionsUseCase,
+          WatchAccountTransactionsUseCase,
+          WatchAccountTransactionsUseCase
+        >
+    with $Provider<WatchAccountTransactionsUseCase> {
+  const WatchAccountTransactionsUseCaseProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'watchAccountTransactionsUseCaseProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$watchAccountTransactionsUseCaseHash();
+
+  @$internal
+  @override
+  $ProviderElement<WatchAccountTransactionsUseCase> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  WatchAccountTransactionsUseCase create(Ref ref) {
+    return watchAccountTransactionsUseCase(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(WatchAccountTransactionsUseCase value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<WatchAccountTransactionsUseCase>(
+        value,
+      ),
+    );
+  }
+}
+
+String _$watchAccountTransactionsUseCaseHash() =>
+    r'9bfa7fea3e97b0a6baf894f5a30912f8e5582211';
 
 @ProviderFor(watchRecentTransactionsUseCase)
 const watchRecentTransactionsUseCaseProvider =

--- a/lib/features/accounts/presentation/account_details_screen.dart
+++ b/lib/features/accounts/presentation/account_details_screen.dart
@@ -1,0 +1,663 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+import 'package:kopim/core/utils/helpers.dart';
+import 'package:kopim/core/widgets/phosphor_icon_utils.dart';
+import 'package:kopim/features/accounts/domain/entities/account_entity.dart';
+import 'package:kopim/features/accounts/presentation/controllers/account_details_providers.dart';
+import 'package:kopim/features/accounts/presentation/edit_account_screen.dart';
+import 'package:kopim/features/categories/domain/entities/category.dart';
+import 'package:kopim/features/transactions/domain/entities/transaction.dart';
+import 'package:kopim/features/transactions/domain/entities/transaction_type.dart';
+import 'package:kopim/l10n/app_localizations.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+class AccountDetailsScreen extends ConsumerWidget {
+  const AccountDetailsScreen({super.key, required this.accountId});
+
+  static const String routeName = '/accounts/details';
+
+  final String accountId;
+
+  static Route<void> route({required String accountId}) {
+    return MaterialPageRoute<void>(
+      builder: (_) => AccountDetailsScreen(accountId: accountId),
+      settings: const RouteSettings(name: routeName),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final AppLocalizations strings = AppLocalizations.of(context)!;
+    final AsyncValue<AccountEntity?> accountAsync = ref.watch(
+      accountDetailsProvider(accountId),
+    );
+    final AsyncValue<AccountTransactionSummary> summaryAsync = ref.watch(
+      accountTransactionSummaryProvider(accountId),
+    );
+    final AsyncValue<List<TransactionEntity>> transactionsAsync = ref.watch(
+      filteredAccountTransactionsProvider(accountId),
+    );
+    final AsyncValue<List<Category>> categoriesAsync = ref.watch(
+      accountCategoriesProvider,
+    );
+    final AccountTransactionsFilter filter = ref.watch(
+      accountTransactionsFilterControllerProvider(accountId),
+    );
+
+    return Scaffold(
+      appBar: AppBar(
+        title: accountAsync.maybeWhen(
+          data: (AccountEntity? account) =>
+              Text(account?.name ?? strings.accountDetailsTitle),
+          orElse: () => Text(strings.accountDetailsTitle),
+        ),
+        actions: <Widget>[
+          accountAsync.maybeWhen(
+            data: (AccountEntity? account) => IconButton(
+              icon: const Icon(Icons.settings_outlined),
+              tooltip: strings.accountDetailsEditTooltip,
+              onPressed: account == null
+                  ? null
+                  : () => _openEditScreen(context, account),
+            ),
+            orElse: () => const SizedBox.shrink(),
+          ),
+        ],
+      ),
+      body: SafeArea(
+        child: accountAsync.when(
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (Object error, _) => _ErrorMessage(
+            message: strings.accountDetailsError(error.toString()),
+          ),
+          data: (AccountEntity? account) {
+            if (account == null) {
+              return _ErrorMessage(message: strings.accountDetailsMissing);
+            }
+
+            final NumberFormat currencyFormat = NumberFormat.currency(
+              locale: strings.localeName,
+              symbol: account.currency.toUpperCase(),
+            );
+            final bool isWideLayout = MediaQuery.of(context).size.width >= 720;
+            final EdgeInsets padding = EdgeInsets.symmetric(
+              horizontal: isWideLayout
+                  ? MediaQuery.of(context).size.width * 0.15
+                  : 16,
+              vertical: 16,
+            );
+
+            final Map<String, Category> categoriesById = <String, Category>{
+              for (final Category category
+                  in categoriesAsync.asData?.value ?? const <Category>[])
+                category.id: category,
+            };
+
+            final Widget summarySection = summaryAsync.when(
+              loading: () => const Center(child: CircularProgressIndicator()),
+              error: (Object error, _) => _ErrorMessage(
+                message: strings.accountDetailsSummaryError(error.toString()),
+              ),
+              data: (AccountTransactionSummary summary) => _AccountSummaryCard(
+                account: account,
+                summary: summary,
+                currencyFormat: currencyFormat,
+                strings: strings,
+              ),
+            );
+
+            final Widget filtersSection = categoriesAsync.when(
+              loading: () => const Center(child: CircularProgressIndicator()),
+              error: (Object error, _) => _ErrorMessage(
+                message: strings.accountDetailsCategoriesError(
+                  error.toString(),
+                ),
+              ),
+              data: (List<Category> categories) => _AccountFilters(
+                filter: filter,
+                categories: categories,
+                strings: strings,
+                onDateRangeChanged: (DateTimeRange? range) async {
+                  ref
+                      .read(
+                        accountTransactionsFilterControllerProvider(
+                          accountId,
+                        ).notifier,
+                      )
+                      .setDateRange(range);
+                },
+                onTypeChanged: (TransactionType? type) {
+                  ref
+                      .read(
+                        accountTransactionsFilterControllerProvider(
+                          accountId,
+                        ).notifier,
+                      )
+                      .setType(type);
+                },
+                onCategoryChanged: (String? categoryId) {
+                  ref
+                      .read(
+                        accountTransactionsFilterControllerProvider(
+                          accountId,
+                        ).notifier,
+                      )
+                      .setCategory(categoryId);
+                },
+                onClear: () {
+                  ref
+                      .read(
+                        accountTransactionsFilterControllerProvider(
+                          accountId,
+                        ).notifier,
+                      )
+                      .clear();
+                },
+              ),
+            );
+
+            final Widget transactionsSection = transactionsAsync.when(
+              loading: () => const Center(child: CircularProgressIndicator()),
+              error: (Object error, _) => _ErrorMessage(
+                message: strings.accountDetailsTransactionsError(
+                  error.toString(),
+                ),
+              ),
+              data: (List<TransactionEntity> transactions) {
+                if (transactions.isEmpty) {
+                  return _EmptyMessage(
+                    message: strings.accountDetailsTransactionsEmpty,
+                  );
+                }
+
+                return Column(
+                  children: List<Widget>.generate(transactions.length, (
+                    int index,
+                  ) {
+                    final TransactionEntity transaction = transactions[index];
+                    return _TransactionTile(
+                      transaction: transaction,
+                      account: account,
+                      currencyFormat: currencyFormat,
+                      strings: strings,
+                      category: transaction.categoryId == null
+                          ? null
+                          : categoriesById[transaction.categoryId!],
+                    );
+                  }),
+                );
+              },
+            );
+
+            return ListView(
+              padding: padding,
+              children: <Widget>[
+                summarySection,
+                const SizedBox(height: 24),
+                filtersSection,
+                const SizedBox(height: 24),
+                transactionsSection,
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  void _openEditScreen(BuildContext context, AccountEntity account) {
+    Navigator.of(context).pushNamed(
+      EditAccountScreen.routeName,
+      arguments: EditAccountScreenArgs(account: account),
+    );
+  }
+}
+
+class AccountDetailsScreenArgs {
+  const AccountDetailsScreenArgs({required this.accountId});
+
+  final String accountId;
+}
+
+class _AccountSummaryCard extends StatelessWidget {
+  const _AccountSummaryCard({
+    required this.account,
+    required this.summary,
+    required this.currencyFormat,
+    required this.strings,
+  });
+
+  final AccountEntity account;
+  final AccountTransactionSummary summary;
+  final NumberFormat currencyFormat;
+  final AppLocalizations strings;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(account.name, style: theme.textTheme.titleLarge),
+            const SizedBox(height: 8),
+            Text(
+              strings.accountDetailsBalanceLabel(
+                currencyFormat.format(account.balance),
+              ),
+              style: theme.textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 16),
+            Row(
+              children: <Widget>[
+                Expanded(
+                  child: _SummaryValue(
+                    label: strings.accountDetailsIncomeLabel,
+                    value: currencyFormat.format(summary.totalIncome),
+                    valueColor: theme.colorScheme.primary,
+                  ),
+                ),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: _SummaryValue(
+                    label: strings.accountDetailsExpenseLabel,
+                    value: currencyFormat.format(summary.totalExpense),
+                    valueColor: theme.colorScheme.error,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SummaryValue extends StatelessWidget {
+  const _SummaryValue({
+    required this.label,
+    required this.value,
+    required this.valueColor,
+  });
+
+  final String label;
+  final String value;
+  final Color valueColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text(label, style: theme.textTheme.bodySmall),
+        const SizedBox(height: 4),
+        Text(
+          value,
+          style: theme.textTheme.titleMedium?.copyWith(color: valueColor),
+        ),
+      ],
+    );
+  }
+}
+
+class _AccountFilters extends StatelessWidget {
+  const _AccountFilters({
+    required this.filter,
+    required this.categories,
+    required this.strings,
+    required this.onDateRangeChanged,
+    required this.onTypeChanged,
+    required this.onCategoryChanged,
+    required this.onClear,
+  });
+
+  final AccountTransactionsFilter filter;
+  final List<Category> categories;
+  final AppLocalizations strings;
+  final ValueChanged<DateTimeRange?> onDateRangeChanged;
+  final ValueChanged<TransactionType?> onTypeChanged;
+  final ValueChanged<String?> onCategoryChanged;
+  final VoidCallback onClear;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              strings.accountDetailsFiltersTitle,
+              style: theme.textTheme.titleMedium,
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 12,
+              runSpacing: 12,
+              children: <Widget>[
+                _DateFilterButton(
+                  filter: filter,
+                  strings: strings,
+                  onChanged: onDateRangeChanged,
+                ),
+                _TypeDropdown(
+                  filter: filter,
+                  strings: strings,
+                  onChanged: onTypeChanged,
+                ),
+                _CategoryDropdown(
+                  filter: filter,
+                  strings: strings,
+                  categories: categories,
+                  onChanged: onCategoryChanged,
+                ),
+                if (filter.hasActiveFilters)
+                  TextButton.icon(
+                    onPressed: onClear,
+                    icon: const Icon(Icons.clear),
+                    label: Text(strings.accountDetailsFiltersClear),
+                  ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DateFilterButton extends StatelessWidget {
+  const _DateFilterButton({
+    required this.filter,
+    required this.strings,
+    required this.onChanged,
+  });
+
+  final AccountTransactionsFilter filter;
+  final AppLocalizations strings;
+  final ValueChanged<DateTimeRange?> onChanged;
+
+  Future<void> _selectRange(BuildContext context) async {
+    final DateTime now = DateTime.now();
+    final DateTimeRange? picked = await showDateRangePicker(
+      context: context,
+      firstDate: DateTime(now.year - 5),
+      lastDate: DateTime(now.year + 5),
+      initialDateRange: filter.dateRange,
+    );
+    if (picked != null) {
+      onChanged(picked);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final String label;
+    if (filter.dateRange == null) {
+      label = strings.accountDetailsFiltersDateAny;
+    } else {
+      final Locale locale = Localizations.localeOf(context);
+      final DateFormat formatter = DateFormat.yMMMd(locale.toString());
+      label = strings.accountDetailsFiltersDateValue(
+        formatter.format(filter.dateRange!.start),
+        formatter.format(filter.dateRange!.end),
+      );
+    }
+
+    return OutlinedButton.icon(
+      onPressed: () => _selectRange(context),
+      onLongPress: filter.dateRange == null ? null : () => onChanged(null),
+      icon: const Icon(Icons.calendar_today_outlined),
+      label: Text(label),
+    );
+  }
+}
+
+class _TypeDropdown extends StatelessWidget {
+  const _TypeDropdown({
+    required this.filter,
+    required this.strings,
+    required this.onChanged,
+  });
+
+  final AccountTransactionsFilter filter;
+  final AppLocalizations strings;
+  final ValueChanged<TransactionType?> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 200,
+      child: InputDecorator(
+        decoration: InputDecoration(
+          labelText: strings.accountDetailsFiltersTypeLabel,
+          border: const OutlineInputBorder(),
+          contentPadding: const EdgeInsets.symmetric(
+            horizontal: 12,
+            vertical: 4,
+          ),
+        ),
+        child: DropdownButtonHideUnderline(
+          child: DropdownButton<TransactionType?>(
+            value: filter.type,
+            isExpanded: true,
+            onChanged: onChanged,
+            items: <DropdownMenuItem<TransactionType?>>[
+              DropdownMenuItem<TransactionType?>(
+                value: null,
+                child: Text(strings.accountDetailsFiltersTypeAll),
+              ),
+              DropdownMenuItem<TransactionType?>(
+                value: TransactionType.income,
+                child: Text(strings.accountDetailsFiltersTypeIncome),
+              ),
+              DropdownMenuItem<TransactionType?>(
+                value: TransactionType.expense,
+                child: Text(strings.accountDetailsFiltersTypeExpense),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _CategoryDropdown extends StatelessWidget {
+  const _CategoryDropdown({
+    required this.filter,
+    required this.strings,
+    required this.categories,
+    required this.onChanged,
+  });
+
+  final AccountTransactionsFilter filter;
+  final AppLocalizations strings;
+  final List<Category> categories;
+  final ValueChanged<String?> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 220,
+      child: InputDecorator(
+        decoration: InputDecoration(
+          labelText: strings.accountDetailsFiltersCategoryLabel,
+          border: const OutlineInputBorder(),
+          contentPadding: const EdgeInsets.symmetric(
+            horizontal: 12,
+            vertical: 4,
+          ),
+        ),
+        child: DropdownButtonHideUnderline(
+          child: DropdownButton<String?>(
+            value: filter.categoryId,
+            isExpanded: true,
+            onChanged: onChanged,
+            items: <DropdownMenuItem<String?>>[
+              DropdownMenuItem<String?>(
+                value: null,
+                child: Text(strings.accountDetailsFiltersCategoryAll),
+              ),
+              ...categories.map(
+                (Category category) => DropdownMenuItem<String?>(
+                  value: category.id,
+                  child: Text(category.name),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _TransactionTile extends StatelessWidget {
+  const _TransactionTile({
+    required this.transaction,
+    required this.account,
+    required this.currencyFormat,
+    required this.strings,
+    this.category,
+  });
+
+  final TransactionEntity transaction;
+  final AccountEntity account;
+  final NumberFormat currencyFormat;
+  final AppLocalizations strings;
+  final Category? category;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final bool isIncome =
+        transaction.type == TransactionType.income.storageValue;
+    final Color amountColor = isIncome
+        ? theme.colorScheme.primary
+        : theme.colorScheme.error;
+    final String amountText = currencyFormat.format(transaction.amount.abs());
+    final PhosphorIconData? categoryIcon = resolvePhosphorIconData(
+      category?.icon,
+    );
+    final Color? categoryColor = parseHexColor(category?.color);
+    final Color avatarIconColor = categoryColor != null
+        ? (ThemeData.estimateBrightnessForColor(categoryColor) ==
+                  Brightness.dark
+              ? Colors.white
+              : Colors.black87)
+        : theme.colorScheme.onSurfaceVariant;
+    final DateFormat dateFormat = DateFormat.yMMMd(strings.localeName);
+
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 8),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            CircleAvatar(
+              backgroundColor:
+                  categoryColor ?? theme.colorScheme.surfaceContainerHighest,
+              foregroundColor: avatarIconColor,
+              child: categoryIcon != null
+                  ? Icon(categoryIcon)
+                  : const Icon(Icons.category_outlined),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Text(
+                    category?.name ??
+                        strings.accountDetailsTransactionsUncategorized,
+                    style: theme.textTheme.bodyMedium,
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    dateFormat.format(transaction.date),
+                    style: theme.textTheme.bodySmall,
+                  ),
+                  if (transaction.note != null && transaction.note!.isNotEmpty)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 4),
+                      child: Text(
+                        transaction.note!,
+                        style: theme.textTheme.bodySmall,
+                      ),
+                    ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 12),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: <Widget>[
+                Text(
+                  amountText,
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    color: amountColor,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  isIncome
+                      ? strings.accountDetailsTypeIncome
+                      : strings.accountDetailsTypeExpense,
+                  style: theme.textTheme.bodySmall,
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _EmptyMessage extends StatelessWidget {
+  const _EmptyMessage({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 32),
+        child: Text(message, textAlign: TextAlign.center),
+      ),
+    );
+  }
+}
+
+class _ErrorMessage extends StatelessWidget {
+  const _ErrorMessage({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 32),
+        child: Text(
+          message,
+          textAlign: TextAlign.center,
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: theme.colorScheme.error,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/accounts/presentation/controllers/account_balance_parser.dart
+++ b/lib/features/accounts/presentation/controllers/account_balance_parser.dart
@@ -1,0 +1,14 @@
+/// Parses user-provided balance input into a [double].
+///
+/// Accepts both comma and dot as decimal separators. Returns `null` if the
+/// value cannot be parsed. Empty input is treated as zero to match the
+/// behaviour of the add/edit account forms where balance is optional.
+double? parseBalanceInput(String input) {
+  final String trimmed = input.trim();
+  if (trimmed.isEmpty) {
+    return 0;
+  }
+
+  final String normalized = trimmed.replaceAll(',', '.');
+  return double.tryParse(normalized);
+}

--- a/lib/features/accounts/presentation/controllers/account_details_providers.dart
+++ b/lib/features/accounts/presentation/controllers/account_details_providers.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/material.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:kopim/core/di/injectors.dart';
+import 'package:kopim/features/accounts/domain/entities/account_entity.dart';
+import 'package:kopim/features/categories/domain/entities/category.dart';
+import 'package:kopim/features/transactions/domain/entities/transaction.dart';
+import 'package:kopim/features/transactions/domain/entities/transaction_type.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'account_details_providers.freezed.dart';
+part 'account_details_providers.g.dart';
+
+@freezed
+abstract class AccountTransactionsFilter with _$AccountTransactionsFilter {
+  const factory AccountTransactionsFilter({
+    DateTimeRange? dateRange,
+    TransactionType? type,
+    String? categoryId,
+  }) = _AccountTransactionsFilter;
+
+  const AccountTransactionsFilter._();
+
+  bool get hasActiveFilters =>
+      dateRange != null || type != null || categoryId != null;
+}
+
+@freezed
+abstract class AccountTransactionSummary with _$AccountTransactionSummary {
+  const factory AccountTransactionSummary({
+    required double totalIncome,
+    required double totalExpense,
+  }) = _AccountTransactionSummary;
+
+  const AccountTransactionSummary._();
+
+  double get net => totalIncome - totalExpense;
+}
+
+@riverpod
+Stream<AccountEntity?> accountDetails(Ref ref, String accountId) {
+  return ref
+      .watch(watchAccountsUseCaseProvider)
+      .call()
+      .map((List<AccountEntity> accounts) => _findAccount(accounts, accountId));
+}
+
+@riverpod
+Stream<List<TransactionEntity>> accountTransactions(Ref ref, String accountId) {
+  return ref
+      .watch(watchAccountTransactionsUseCaseProvider)
+      .call(accountId: accountId);
+}
+
+@riverpod
+Stream<List<Category>> accountCategories(Ref ref) {
+  return ref.watch(watchCategoriesUseCaseProvider).call();
+}
+
+@riverpod
+AsyncValue<AccountTransactionSummary> accountTransactionSummary(
+  Ref ref,
+  String accountId,
+) {
+  return ref
+      .watch(accountTransactionsProvider(accountId))
+      .whenData(
+        (List<TransactionEntity> transactions) => _computeSummary(transactions),
+      );
+}
+
+@riverpod
+class AccountTransactionsFilterController
+    extends _$AccountTransactionsFilterController {
+  @override
+  AccountTransactionsFilter build(String accountId) {
+    return const AccountTransactionsFilter();
+  }
+
+  void setDateRange(DateTimeRange? range) {
+    state = state.copyWith(dateRange: range);
+  }
+
+  void setType(TransactionType? type) {
+    state = state.copyWith(type: type);
+  }
+
+  void setCategory(String? categoryId) {
+    state = state.copyWith(categoryId: categoryId);
+  }
+
+  void clear() {
+    state = const AccountTransactionsFilter();
+  }
+}
+
+@riverpod
+AsyncValue<List<TransactionEntity>> filteredAccountTransactions(
+  Ref ref,
+  String accountId,
+) {
+  final AccountTransactionsFilter filter = ref.watch(
+    accountTransactionsFilterControllerProvider(accountId),
+  );
+  final AsyncValue<List<TransactionEntity>> transactionsAsync = ref.watch(
+    accountTransactionsProvider(accountId),
+  );
+
+  return transactionsAsync.whenData((List<TransactionEntity> transactions) {
+    final Iterable<TransactionEntity> filtered = transactions.where((
+      TransactionEntity transaction,
+    ) {
+      final bool matchesType =
+          filter.type == null || transaction.type == filter.type!.storageValue;
+      final bool matchesCategory =
+          filter.categoryId == null ||
+          transaction.categoryId == filter.categoryId;
+      final bool matchesDate =
+          filter.dateRange == null ||
+          !_isBefore(transaction.date, filter.dateRange!.start) &&
+              !_isAfter(transaction.date, filter.dateRange!.end);
+      return matchesType && matchesCategory && matchesDate;
+    });
+    return List<TransactionEntity>.unmodifiable(filtered.toList());
+  });
+}
+
+bool _isBefore(DateTime value, DateTime reference) {
+  return value.isBefore(reference);
+}
+
+bool _isAfter(DateTime value, DateTime reference) {
+  return value.isAfter(reference);
+}
+
+AccountEntity? _findAccount(List<AccountEntity> accounts, String id) {
+  for (final AccountEntity account in accounts) {
+    if (account.id == id) {
+      return account;
+    }
+  }
+  return null;
+}
+
+AccountTransactionSummary _computeSummary(
+  List<TransactionEntity> transactions,
+) {
+  double income = 0;
+  double expense = 0;
+  for (final TransactionEntity transaction in transactions) {
+    if (transaction.type == TransactionType.income.storageValue) {
+      income += transaction.amount.abs();
+    } else if (transaction.type == TransactionType.expense.storageValue) {
+      expense += transaction.amount.abs();
+    }
+  }
+  return AccountTransactionSummary(totalIncome: income, totalExpense: expense);
+}

--- a/lib/features/accounts/presentation/controllers/account_details_providers.freezed.dart
+++ b/lib/features/accounts/presentation/controllers/account_details_providers.freezed.dart
@@ -1,0 +1,537 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'account_details_providers.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$AccountTransactionsFilter {
+
+ DateTimeRange? get dateRange; TransactionType? get type; String? get categoryId;
+/// Create a copy of AccountTransactionsFilter
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$AccountTransactionsFilterCopyWith<AccountTransactionsFilter> get copyWith => _$AccountTransactionsFilterCopyWithImpl<AccountTransactionsFilter>(this as AccountTransactionsFilter, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AccountTransactionsFilter&&(identical(other.dateRange, dateRange) || other.dateRange == dateRange)&&(identical(other.type, type) || other.type == type)&&(identical(other.categoryId, categoryId) || other.categoryId == categoryId));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,dateRange,type,categoryId);
+
+@override
+String toString() {
+  return 'AccountTransactionsFilter(dateRange: $dateRange, type: $type, categoryId: $categoryId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $AccountTransactionsFilterCopyWith<$Res>  {
+  factory $AccountTransactionsFilterCopyWith(AccountTransactionsFilter value, $Res Function(AccountTransactionsFilter) _then) = _$AccountTransactionsFilterCopyWithImpl;
+@useResult
+$Res call({
+ DateTimeRange? dateRange, TransactionType? type, String? categoryId
+});
+
+
+
+
+}
+/// @nodoc
+class _$AccountTransactionsFilterCopyWithImpl<$Res>
+    implements $AccountTransactionsFilterCopyWith<$Res> {
+  _$AccountTransactionsFilterCopyWithImpl(this._self, this._then);
+
+  final AccountTransactionsFilter _self;
+  final $Res Function(AccountTransactionsFilter) _then;
+
+/// Create a copy of AccountTransactionsFilter
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? dateRange = freezed,Object? type = freezed,Object? categoryId = freezed,}) {
+  return _then(_self.copyWith(
+dateRange: freezed == dateRange ? _self.dateRange : dateRange // ignore: cast_nullable_to_non_nullable
+as DateTimeRange?,type: freezed == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as TransactionType?,categoryId: freezed == categoryId ? _self.categoryId : categoryId // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [AccountTransactionsFilter].
+extension AccountTransactionsFilterPatterns on AccountTransactionsFilter {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _AccountTransactionsFilter value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _AccountTransactionsFilter() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _AccountTransactionsFilter value)  $default,){
+final _that = this;
+switch (_that) {
+case _AccountTransactionsFilter():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _AccountTransactionsFilter value)?  $default,){
+final _that = this;
+switch (_that) {
+case _AccountTransactionsFilter() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( DateTimeRange? dateRange,  TransactionType? type,  String? categoryId)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _AccountTransactionsFilter() when $default != null:
+return $default(_that.dateRange,_that.type,_that.categoryId);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( DateTimeRange? dateRange,  TransactionType? type,  String? categoryId)  $default,) {final _that = this;
+switch (_that) {
+case _AccountTransactionsFilter():
+return $default(_that.dateRange,_that.type,_that.categoryId);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( DateTimeRange? dateRange,  TransactionType? type,  String? categoryId)?  $default,) {final _that = this;
+switch (_that) {
+case _AccountTransactionsFilter() when $default != null:
+return $default(_that.dateRange,_that.type,_that.categoryId);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _AccountTransactionsFilter extends AccountTransactionsFilter {
+  const _AccountTransactionsFilter({this.dateRange, this.type, this.categoryId}): super._();
+  
+
+@override final  DateTimeRange? dateRange;
+@override final  TransactionType? type;
+@override final  String? categoryId;
+
+/// Create a copy of AccountTransactionsFilter
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$AccountTransactionsFilterCopyWith<_AccountTransactionsFilter> get copyWith => __$AccountTransactionsFilterCopyWithImpl<_AccountTransactionsFilter>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AccountTransactionsFilter&&(identical(other.dateRange, dateRange) || other.dateRange == dateRange)&&(identical(other.type, type) || other.type == type)&&(identical(other.categoryId, categoryId) || other.categoryId == categoryId));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,dateRange,type,categoryId);
+
+@override
+String toString() {
+  return 'AccountTransactionsFilter(dateRange: $dateRange, type: $type, categoryId: $categoryId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$AccountTransactionsFilterCopyWith<$Res> implements $AccountTransactionsFilterCopyWith<$Res> {
+  factory _$AccountTransactionsFilterCopyWith(_AccountTransactionsFilter value, $Res Function(_AccountTransactionsFilter) _then) = __$AccountTransactionsFilterCopyWithImpl;
+@override @useResult
+$Res call({
+ DateTimeRange? dateRange, TransactionType? type, String? categoryId
+});
+
+
+
+
+}
+/// @nodoc
+class __$AccountTransactionsFilterCopyWithImpl<$Res>
+    implements _$AccountTransactionsFilterCopyWith<$Res> {
+  __$AccountTransactionsFilterCopyWithImpl(this._self, this._then);
+
+  final _AccountTransactionsFilter _self;
+  final $Res Function(_AccountTransactionsFilter) _then;
+
+/// Create a copy of AccountTransactionsFilter
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? dateRange = freezed,Object? type = freezed,Object? categoryId = freezed,}) {
+  return _then(_AccountTransactionsFilter(
+dateRange: freezed == dateRange ? _self.dateRange : dateRange // ignore: cast_nullable_to_non_nullable
+as DateTimeRange?,type: freezed == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as TransactionType?,categoryId: freezed == categoryId ? _self.categoryId : categoryId // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+/// @nodoc
+mixin _$AccountTransactionSummary {
+
+ double get totalIncome; double get totalExpense;
+/// Create a copy of AccountTransactionSummary
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$AccountTransactionSummaryCopyWith<AccountTransactionSummary> get copyWith => _$AccountTransactionSummaryCopyWithImpl<AccountTransactionSummary>(this as AccountTransactionSummary, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AccountTransactionSummary&&(identical(other.totalIncome, totalIncome) || other.totalIncome == totalIncome)&&(identical(other.totalExpense, totalExpense) || other.totalExpense == totalExpense));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,totalIncome,totalExpense);
+
+@override
+String toString() {
+  return 'AccountTransactionSummary(totalIncome: $totalIncome, totalExpense: $totalExpense)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $AccountTransactionSummaryCopyWith<$Res>  {
+  factory $AccountTransactionSummaryCopyWith(AccountTransactionSummary value, $Res Function(AccountTransactionSummary) _then) = _$AccountTransactionSummaryCopyWithImpl;
+@useResult
+$Res call({
+ double totalIncome, double totalExpense
+});
+
+
+
+
+}
+/// @nodoc
+class _$AccountTransactionSummaryCopyWithImpl<$Res>
+    implements $AccountTransactionSummaryCopyWith<$Res> {
+  _$AccountTransactionSummaryCopyWithImpl(this._self, this._then);
+
+  final AccountTransactionSummary _self;
+  final $Res Function(AccountTransactionSummary) _then;
+
+/// Create a copy of AccountTransactionSummary
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? totalIncome = null,Object? totalExpense = null,}) {
+  return _then(_self.copyWith(
+totalIncome: null == totalIncome ? _self.totalIncome : totalIncome // ignore: cast_nullable_to_non_nullable
+as double,totalExpense: null == totalExpense ? _self.totalExpense : totalExpense // ignore: cast_nullable_to_non_nullable
+as double,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [AccountTransactionSummary].
+extension AccountTransactionSummaryPatterns on AccountTransactionSummary {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _AccountTransactionSummary value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _AccountTransactionSummary() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _AccountTransactionSummary value)  $default,){
+final _that = this;
+switch (_that) {
+case _AccountTransactionSummary():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _AccountTransactionSummary value)?  $default,){
+final _that = this;
+switch (_that) {
+case _AccountTransactionSummary() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( double totalIncome,  double totalExpense)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _AccountTransactionSummary() when $default != null:
+return $default(_that.totalIncome,_that.totalExpense);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( double totalIncome,  double totalExpense)  $default,) {final _that = this;
+switch (_that) {
+case _AccountTransactionSummary():
+return $default(_that.totalIncome,_that.totalExpense);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( double totalIncome,  double totalExpense)?  $default,) {final _that = this;
+switch (_that) {
+case _AccountTransactionSummary() when $default != null:
+return $default(_that.totalIncome,_that.totalExpense);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _AccountTransactionSummary extends AccountTransactionSummary {
+  const _AccountTransactionSummary({required this.totalIncome, required this.totalExpense}): super._();
+  
+
+@override final  double totalIncome;
+@override final  double totalExpense;
+
+/// Create a copy of AccountTransactionSummary
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$AccountTransactionSummaryCopyWith<_AccountTransactionSummary> get copyWith => __$AccountTransactionSummaryCopyWithImpl<_AccountTransactionSummary>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AccountTransactionSummary&&(identical(other.totalIncome, totalIncome) || other.totalIncome == totalIncome)&&(identical(other.totalExpense, totalExpense) || other.totalExpense == totalExpense));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,totalIncome,totalExpense);
+
+@override
+String toString() {
+  return 'AccountTransactionSummary(totalIncome: $totalIncome, totalExpense: $totalExpense)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$AccountTransactionSummaryCopyWith<$Res> implements $AccountTransactionSummaryCopyWith<$Res> {
+  factory _$AccountTransactionSummaryCopyWith(_AccountTransactionSummary value, $Res Function(_AccountTransactionSummary) _then) = __$AccountTransactionSummaryCopyWithImpl;
+@override @useResult
+$Res call({
+ double totalIncome, double totalExpense
+});
+
+
+
+
+}
+/// @nodoc
+class __$AccountTransactionSummaryCopyWithImpl<$Res>
+    implements _$AccountTransactionSummaryCopyWith<$Res> {
+  __$AccountTransactionSummaryCopyWithImpl(this._self, this._then);
+
+  final _AccountTransactionSummary _self;
+  final $Res Function(_AccountTransactionSummary) _then;
+
+/// Create a copy of AccountTransactionSummary
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? totalIncome = null,Object? totalExpense = null,}) {
+  return _then(_AccountTransactionSummary(
+totalIncome: null == totalIncome ? _self.totalIncome : totalIncome // ignore: cast_nullable_to_non_nullable
+as double,totalExpense: null == totalExpense ? _self.totalExpense : totalExpense // ignore: cast_nullable_to_non_nullable
+as double,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/features/accounts/presentation/controllers/account_details_providers.g.dart
+++ b/lib/features/accounts/presentation/controllers/account_details_providers.g.dart
@@ -1,0 +1,493 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'account_details_providers.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(accountDetails)
+const accountDetailsProvider = AccountDetailsFamily._();
+
+final class AccountDetailsProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<AccountEntity?>,
+          AccountEntity?,
+          Stream<AccountEntity?>
+        >
+    with $FutureModifier<AccountEntity?>, $StreamProvider<AccountEntity?> {
+  const AccountDetailsProvider._({
+    required AccountDetailsFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'accountDetailsProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$accountDetailsHash();
+
+  @override
+  String toString() {
+    return r'accountDetailsProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $StreamProviderElement<AccountEntity?> $createElement(
+    $ProviderPointer pointer,
+  ) => $StreamProviderElement(pointer);
+
+  @override
+  Stream<AccountEntity?> create(Ref ref) {
+    final argument = this.argument as String;
+    return accountDetails(ref, argument);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is AccountDetailsProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$accountDetailsHash() => r'0c0bb8c45ca729a38f98b36f7d63b3197a9b253e';
+
+final class AccountDetailsFamily extends $Family
+    with $FunctionalFamilyOverride<Stream<AccountEntity?>, String> {
+  const AccountDetailsFamily._()
+    : super(
+        retry: null,
+        name: r'accountDetailsProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  AccountDetailsProvider call(String accountId) =>
+      AccountDetailsProvider._(argument: accountId, from: this);
+
+  @override
+  String toString() => r'accountDetailsProvider';
+}
+
+@ProviderFor(accountTransactions)
+const accountTransactionsProvider = AccountTransactionsFamily._();
+
+final class AccountTransactionsProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<TransactionEntity>>,
+          List<TransactionEntity>,
+          Stream<List<TransactionEntity>>
+        >
+    with
+        $FutureModifier<List<TransactionEntity>>,
+        $StreamProvider<List<TransactionEntity>> {
+  const AccountTransactionsProvider._({
+    required AccountTransactionsFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'accountTransactionsProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$accountTransactionsHash();
+
+  @override
+  String toString() {
+    return r'accountTransactionsProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $StreamProviderElement<List<TransactionEntity>> $createElement(
+    $ProviderPointer pointer,
+  ) => $StreamProviderElement(pointer);
+
+  @override
+  Stream<List<TransactionEntity>> create(Ref ref) {
+    final argument = this.argument as String;
+    return accountTransactions(ref, argument);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is AccountTransactionsProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$accountTransactionsHash() =>
+    r'ef93cea78d14040a94a1b91687be7f5def70b257';
+
+final class AccountTransactionsFamily extends $Family
+    with $FunctionalFamilyOverride<Stream<List<TransactionEntity>>, String> {
+  const AccountTransactionsFamily._()
+    : super(
+        retry: null,
+        name: r'accountTransactionsProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  AccountTransactionsProvider call(String accountId) =>
+      AccountTransactionsProvider._(argument: accountId, from: this);
+
+  @override
+  String toString() => r'accountTransactionsProvider';
+}
+
+@ProviderFor(accountCategories)
+const accountCategoriesProvider = AccountCategoriesProvider._();
+
+final class AccountCategoriesProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<Category>>,
+          List<Category>,
+          Stream<List<Category>>
+        >
+    with $FutureModifier<List<Category>>, $StreamProvider<List<Category>> {
+  const AccountCategoriesProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'accountCategoriesProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$accountCategoriesHash();
+
+  @$internal
+  @override
+  $StreamProviderElement<List<Category>> $createElement(
+    $ProviderPointer pointer,
+  ) => $StreamProviderElement(pointer);
+
+  @override
+  Stream<List<Category>> create(Ref ref) {
+    return accountCategories(ref);
+  }
+}
+
+String _$accountCategoriesHash() => r'a2ff64337d4c3c1bd82315c851a4059ff4edb2b0';
+
+@ProviderFor(accountTransactionSummary)
+const accountTransactionSummaryProvider = AccountTransactionSummaryFamily._();
+
+final class AccountTransactionSummaryProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<AccountTransactionSummary>,
+          AsyncValue<AccountTransactionSummary>,
+          AsyncValue<AccountTransactionSummary>
+        >
+    with $Provider<AsyncValue<AccountTransactionSummary>> {
+  const AccountTransactionSummaryProvider._({
+    required AccountTransactionSummaryFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'accountTransactionSummaryProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$accountTransactionSummaryHash();
+
+  @override
+  String toString() {
+    return r'accountTransactionSummaryProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $ProviderElement<AsyncValue<AccountTransactionSummary>> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  AsyncValue<AccountTransactionSummary> create(Ref ref) {
+    final argument = this.argument as String;
+    return accountTransactionSummary(ref, argument);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<AccountTransactionSummary> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride:
+          $SyncValueProvider<AsyncValue<AccountTransactionSummary>>(value),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is AccountTransactionSummaryProvider &&
+        other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$accountTransactionSummaryHash() =>
+    r'ce346f9db3d29f2e675e88abe2c5870a483c7535';
+
+final class AccountTransactionSummaryFamily extends $Family
+    with
+        $FunctionalFamilyOverride<
+          AsyncValue<AccountTransactionSummary>,
+          String
+        > {
+  const AccountTransactionSummaryFamily._()
+    : super(
+        retry: null,
+        name: r'accountTransactionSummaryProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  AccountTransactionSummaryProvider call(String accountId) =>
+      AccountTransactionSummaryProvider._(argument: accountId, from: this);
+
+  @override
+  String toString() => r'accountTransactionSummaryProvider';
+}
+
+@ProviderFor(AccountTransactionsFilterController)
+const accountTransactionsFilterControllerProvider =
+    AccountTransactionsFilterControllerFamily._();
+
+final class AccountTransactionsFilterControllerProvider
+    extends
+        $NotifierProvider<
+          AccountTransactionsFilterController,
+          AccountTransactionsFilter
+        > {
+  const AccountTransactionsFilterControllerProvider._({
+    required AccountTransactionsFilterControllerFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'accountTransactionsFilterControllerProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() =>
+      _$accountTransactionsFilterControllerHash();
+
+  @override
+  String toString() {
+    return r'accountTransactionsFilterControllerProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  AccountTransactionsFilterController create() =>
+      AccountTransactionsFilterController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AccountTransactionsFilter value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AccountTransactionsFilter>(value),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is AccountTransactionsFilterControllerProvider &&
+        other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$accountTransactionsFilterControllerHash() =>
+    r'700b422f13247983dd284fd1072e7567f4c931cf';
+
+final class AccountTransactionsFilterControllerFamily extends $Family
+    with
+        $ClassFamilyOverride<
+          AccountTransactionsFilterController,
+          AccountTransactionsFilter,
+          AccountTransactionsFilter,
+          AccountTransactionsFilter,
+          String
+        > {
+  const AccountTransactionsFilterControllerFamily._()
+    : super(
+        retry: null,
+        name: r'accountTransactionsFilterControllerProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  AccountTransactionsFilterControllerProvider call(String accountId) =>
+      AccountTransactionsFilterControllerProvider._(
+        argument: accountId,
+        from: this,
+      );
+
+  @override
+  String toString() => r'accountTransactionsFilterControllerProvider';
+}
+
+abstract class _$AccountTransactionsFilterController
+    extends $Notifier<AccountTransactionsFilter> {
+  late final _$args = ref.$arg as String;
+  String get accountId => _$args;
+
+  AccountTransactionsFilter build(String accountId);
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build(_$args);
+    final ref =
+        this.ref as $Ref<AccountTransactionsFilter, AccountTransactionsFilter>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AccountTransactionsFilter, AccountTransactionsFilter>,
+              AccountTransactionsFilter,
+              Object?,
+              Object?
+            >;
+    element.handleValue(ref, created);
+  }
+}
+
+@ProviderFor(filteredAccountTransactions)
+const filteredAccountTransactionsProvider =
+    FilteredAccountTransactionsFamily._();
+
+final class FilteredAccountTransactionsProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<TransactionEntity>>,
+          AsyncValue<List<TransactionEntity>>,
+          AsyncValue<List<TransactionEntity>>
+        >
+    with $Provider<AsyncValue<List<TransactionEntity>>> {
+  const FilteredAccountTransactionsProvider._({
+    required FilteredAccountTransactionsFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'filteredAccountTransactionsProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$filteredAccountTransactionsHash();
+
+  @override
+  String toString() {
+    return r'filteredAccountTransactionsProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $ProviderElement<AsyncValue<List<TransactionEntity>>> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  AsyncValue<List<TransactionEntity>> create(Ref ref) {
+    final argument = this.argument as String;
+    return filteredAccountTransactions(ref, argument);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<List<TransactionEntity>> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AsyncValue<List<TransactionEntity>>>(
+        value,
+      ),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is FilteredAccountTransactionsProvider &&
+        other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$filteredAccountTransactionsHash() =>
+    r'31a02b87aeefe0b2e8d7ebaeb18a527097ef24ff';
+
+final class FilteredAccountTransactionsFamily extends $Family
+    with
+        $FunctionalFamilyOverride<AsyncValue<List<TransactionEntity>>, String> {
+  const FilteredAccountTransactionsFamily._()
+    : super(
+        retry: null,
+        name: r'filteredAccountTransactionsProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  FilteredAccountTransactionsProvider call(String accountId) =>
+      FilteredAccountTransactionsProvider._(argument: accountId, from: this);
+
+  @override
+  String toString() => r'filteredAccountTransactionsProvider';
+}

--- a/lib/features/accounts/presentation/controllers/add_account_form_controller.g.dart
+++ b/lib/features/accounts/presentation/controllers/add_account_form_controller.g.dart
@@ -42,7 +42,7 @@ final class AddAccountFormControllerProvider
 }
 
 String _$addAccountFormControllerHash() =>
-    r'b381f95da77c61ace0b775541a8e46aea0d25381';
+    r'a24cb1ae208b959ec9356fddadf93c4a60ea10bd';
 
 abstract class _$AddAccountFormController
     extends $Notifier<AddAccountFormState> {

--- a/lib/features/accounts/presentation/controllers/edit_account_form_controller.freezed.dart
+++ b/lib/features/accounts/presentation/controllers/edit_account_form_controller.freezed.dart
@@ -1,0 +1,313 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'edit_account_form_controller.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$EditAccountFormState {
+
+ AccountEntity get original; String get name; String get balanceInput; String get currency; bool get isSaving; bool get submissionSuccess; EditAccountFieldError? get nameError; EditAccountFieldError? get balanceError; String? get errorMessage;
+/// Create a copy of EditAccountFormState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$EditAccountFormStateCopyWith<EditAccountFormState> get copyWith => _$EditAccountFormStateCopyWithImpl<EditAccountFormState>(this as EditAccountFormState, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EditAccountFormState&&(identical(other.original, original) || other.original == original)&&(identical(other.name, name) || other.name == name)&&(identical(other.balanceInput, balanceInput) || other.balanceInput == balanceInput)&&(identical(other.currency, currency) || other.currency == currency)&&(identical(other.isSaving, isSaving) || other.isSaving == isSaving)&&(identical(other.submissionSuccess, submissionSuccess) || other.submissionSuccess == submissionSuccess)&&(identical(other.nameError, nameError) || other.nameError == nameError)&&(identical(other.balanceError, balanceError) || other.balanceError == balanceError)&&(identical(other.errorMessage, errorMessage) || other.errorMessage == errorMessage));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,original,name,balanceInput,currency,isSaving,submissionSuccess,nameError,balanceError,errorMessage);
+
+@override
+String toString() {
+  return 'EditAccountFormState(original: $original, name: $name, balanceInput: $balanceInput, currency: $currency, isSaving: $isSaving, submissionSuccess: $submissionSuccess, nameError: $nameError, balanceError: $balanceError, errorMessage: $errorMessage)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $EditAccountFormStateCopyWith<$Res>  {
+  factory $EditAccountFormStateCopyWith(EditAccountFormState value, $Res Function(EditAccountFormState) _then) = _$EditAccountFormStateCopyWithImpl;
+@useResult
+$Res call({
+ AccountEntity original, String name, String balanceInput, String currency, bool isSaving, bool submissionSuccess, EditAccountFieldError? nameError, EditAccountFieldError? balanceError, String? errorMessage
+});
+
+
+$AccountEntityCopyWith<$Res> get original;
+
+}
+/// @nodoc
+class _$EditAccountFormStateCopyWithImpl<$Res>
+    implements $EditAccountFormStateCopyWith<$Res> {
+  _$EditAccountFormStateCopyWithImpl(this._self, this._then);
+
+  final EditAccountFormState _self;
+  final $Res Function(EditAccountFormState) _then;
+
+/// Create a copy of EditAccountFormState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? original = null,Object? name = null,Object? balanceInput = null,Object? currency = null,Object? isSaving = null,Object? submissionSuccess = null,Object? nameError = freezed,Object? balanceError = freezed,Object? errorMessage = freezed,}) {
+  return _then(_self.copyWith(
+original: null == original ? _self.original : original // ignore: cast_nullable_to_non_nullable
+as AccountEntity,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,balanceInput: null == balanceInput ? _self.balanceInput : balanceInput // ignore: cast_nullable_to_non_nullable
+as String,currency: null == currency ? _self.currency : currency // ignore: cast_nullable_to_non_nullable
+as String,isSaving: null == isSaving ? _self.isSaving : isSaving // ignore: cast_nullable_to_non_nullable
+as bool,submissionSuccess: null == submissionSuccess ? _self.submissionSuccess : submissionSuccess // ignore: cast_nullable_to_non_nullable
+as bool,nameError: freezed == nameError ? _self.nameError : nameError // ignore: cast_nullable_to_non_nullable
+as EditAccountFieldError?,balanceError: freezed == balanceError ? _self.balanceError : balanceError // ignore: cast_nullable_to_non_nullable
+as EditAccountFieldError?,errorMessage: freezed == errorMessage ? _self.errorMessage : errorMessage // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+/// Create a copy of EditAccountFormState
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$AccountEntityCopyWith<$Res> get original {
+  
+  return $AccountEntityCopyWith<$Res>(_self.original, (value) {
+    return _then(_self.copyWith(original: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [EditAccountFormState].
+extension EditAccountFormStatePatterns on EditAccountFormState {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _EditAccountFormState value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _EditAccountFormState() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _EditAccountFormState value)  $default,){
+final _that = this;
+switch (_that) {
+case _EditAccountFormState():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _EditAccountFormState value)?  $default,){
+final _that = this;
+switch (_that) {
+case _EditAccountFormState() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( AccountEntity original,  String name,  String balanceInput,  String currency,  bool isSaving,  bool submissionSuccess,  EditAccountFieldError? nameError,  EditAccountFieldError? balanceError,  String? errorMessage)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _EditAccountFormState() when $default != null:
+return $default(_that.original,_that.name,_that.balanceInput,_that.currency,_that.isSaving,_that.submissionSuccess,_that.nameError,_that.balanceError,_that.errorMessage);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( AccountEntity original,  String name,  String balanceInput,  String currency,  bool isSaving,  bool submissionSuccess,  EditAccountFieldError? nameError,  EditAccountFieldError? balanceError,  String? errorMessage)  $default,) {final _that = this;
+switch (_that) {
+case _EditAccountFormState():
+return $default(_that.original,_that.name,_that.balanceInput,_that.currency,_that.isSaving,_that.submissionSuccess,_that.nameError,_that.balanceError,_that.errorMessage);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( AccountEntity original,  String name,  String balanceInput,  String currency,  bool isSaving,  bool submissionSuccess,  EditAccountFieldError? nameError,  EditAccountFieldError? balanceError,  String? errorMessage)?  $default,) {final _that = this;
+switch (_that) {
+case _EditAccountFormState() when $default != null:
+return $default(_that.original,_that.name,_that.balanceInput,_that.currency,_that.isSaving,_that.submissionSuccess,_that.nameError,_that.balanceError,_that.errorMessage);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _EditAccountFormState extends EditAccountFormState {
+  const _EditAccountFormState({required this.original, required this.name, required this.balanceInput, required this.currency, this.isSaving = false, this.submissionSuccess = false, this.nameError, this.balanceError, this.errorMessage}): super._();
+  
+
+@override final  AccountEntity original;
+@override final  String name;
+@override final  String balanceInput;
+@override final  String currency;
+@override@JsonKey() final  bool isSaving;
+@override@JsonKey() final  bool submissionSuccess;
+@override final  EditAccountFieldError? nameError;
+@override final  EditAccountFieldError? balanceError;
+@override final  String? errorMessage;
+
+/// Create a copy of EditAccountFormState
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$EditAccountFormStateCopyWith<_EditAccountFormState> get copyWith => __$EditAccountFormStateCopyWithImpl<_EditAccountFormState>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EditAccountFormState&&(identical(other.original, original) || other.original == original)&&(identical(other.name, name) || other.name == name)&&(identical(other.balanceInput, balanceInput) || other.balanceInput == balanceInput)&&(identical(other.currency, currency) || other.currency == currency)&&(identical(other.isSaving, isSaving) || other.isSaving == isSaving)&&(identical(other.submissionSuccess, submissionSuccess) || other.submissionSuccess == submissionSuccess)&&(identical(other.nameError, nameError) || other.nameError == nameError)&&(identical(other.balanceError, balanceError) || other.balanceError == balanceError)&&(identical(other.errorMessage, errorMessage) || other.errorMessage == errorMessage));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,original,name,balanceInput,currency,isSaving,submissionSuccess,nameError,balanceError,errorMessage);
+
+@override
+String toString() {
+  return 'EditAccountFormState(original: $original, name: $name, balanceInput: $balanceInput, currency: $currency, isSaving: $isSaving, submissionSuccess: $submissionSuccess, nameError: $nameError, balanceError: $balanceError, errorMessage: $errorMessage)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$EditAccountFormStateCopyWith<$Res> implements $EditAccountFormStateCopyWith<$Res> {
+  factory _$EditAccountFormStateCopyWith(_EditAccountFormState value, $Res Function(_EditAccountFormState) _then) = __$EditAccountFormStateCopyWithImpl;
+@override @useResult
+$Res call({
+ AccountEntity original, String name, String balanceInput, String currency, bool isSaving, bool submissionSuccess, EditAccountFieldError? nameError, EditAccountFieldError? balanceError, String? errorMessage
+});
+
+
+@override $AccountEntityCopyWith<$Res> get original;
+
+}
+/// @nodoc
+class __$EditAccountFormStateCopyWithImpl<$Res>
+    implements _$EditAccountFormStateCopyWith<$Res> {
+  __$EditAccountFormStateCopyWithImpl(this._self, this._then);
+
+  final _EditAccountFormState _self;
+  final $Res Function(_EditAccountFormState) _then;
+
+/// Create a copy of EditAccountFormState
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? original = null,Object? name = null,Object? balanceInput = null,Object? currency = null,Object? isSaving = null,Object? submissionSuccess = null,Object? nameError = freezed,Object? balanceError = freezed,Object? errorMessage = freezed,}) {
+  return _then(_EditAccountFormState(
+original: null == original ? _self.original : original // ignore: cast_nullable_to_non_nullable
+as AccountEntity,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,balanceInput: null == balanceInput ? _self.balanceInput : balanceInput // ignore: cast_nullable_to_non_nullable
+as String,currency: null == currency ? _self.currency : currency // ignore: cast_nullable_to_non_nullable
+as String,isSaving: null == isSaving ? _self.isSaving : isSaving // ignore: cast_nullable_to_non_nullable
+as bool,submissionSuccess: null == submissionSuccess ? _self.submissionSuccess : submissionSuccess // ignore: cast_nullable_to_non_nullable
+as bool,nameError: freezed == nameError ? _self.nameError : nameError // ignore: cast_nullable_to_non_nullable
+as EditAccountFieldError?,balanceError: freezed == balanceError ? _self.balanceError : balanceError // ignore: cast_nullable_to_non_nullable
+as EditAccountFieldError?,errorMessage: freezed == errorMessage ? _self.errorMessage : errorMessage // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+/// Create a copy of EditAccountFormState
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$AccountEntityCopyWith<$Res> get original {
+  
+  return $AccountEntityCopyWith<$Res>(_self.original, (value) {
+    return _then(_self.copyWith(original: value));
+  });
+}
+}
+
+// dart format on

--- a/lib/features/accounts/presentation/controllers/edit_account_form_controller.g.dart
+++ b/lib/features/accounts/presentation/controllers/edit_account_form_controller.g.dart
@@ -1,0 +1,111 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'edit_account_form_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(EditAccountFormController)
+const editAccountFormControllerProvider = EditAccountFormControllerFamily._();
+
+final class EditAccountFormControllerProvider
+    extends $NotifierProvider<EditAccountFormController, EditAccountFormState> {
+  const EditAccountFormControllerProvider._({
+    required EditAccountFormControllerFamily super.from,
+    required AccountEntity super.argument,
+  }) : super(
+         retry: null,
+         name: r'editAccountFormControllerProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$editAccountFormControllerHash();
+
+  @override
+  String toString() {
+    return r'editAccountFormControllerProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  EditAccountFormController create() => EditAccountFormController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(EditAccountFormState value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<EditAccountFormState>(value),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is EditAccountFormControllerProvider &&
+        other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$editAccountFormControllerHash() =>
+    r'159ca8a7cf94783b469ea93c5488b5b52efe7b1a';
+
+final class EditAccountFormControllerFamily extends $Family
+    with
+        $ClassFamilyOverride<
+          EditAccountFormController,
+          EditAccountFormState,
+          EditAccountFormState,
+          EditAccountFormState,
+          AccountEntity
+        > {
+  const EditAccountFormControllerFamily._()
+    : super(
+        retry: null,
+        name: r'editAccountFormControllerProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  EditAccountFormControllerProvider call(AccountEntity account) =>
+      EditAccountFormControllerProvider._(argument: account, from: this);
+
+  @override
+  String toString() => r'editAccountFormControllerProvider';
+}
+
+abstract class _$EditAccountFormController
+    extends $Notifier<EditAccountFormState> {
+  late final _$args = ref.$arg as AccountEntity;
+  AccountEntity get account => _$args;
+
+  EditAccountFormState build(AccountEntity account);
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build(_$args);
+    final ref = this.ref as $Ref<EditAccountFormState, EditAccountFormState>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<EditAccountFormState, EditAccountFormState>,
+              EditAccountFormState,
+              Object?,
+              Object?
+            >;
+    element.handleValue(ref, created);
+  }
+}

--- a/lib/features/accounts/presentation/edit_account_screen.dart
+++ b/lib/features/accounts/presentation/edit_account_screen.dart
@@ -1,0 +1,204 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:kopim/features/accounts/domain/entities/account_entity.dart';
+import 'package:kopim/features/accounts/presentation/controllers/edit_account_form_controller.dart';
+import 'package:kopim/l10n/app_localizations.dart';
+
+class EditAccountScreen extends ConsumerStatefulWidget {
+  const EditAccountScreen({super.key, required this.account});
+
+  static const String routeName = '/accounts/edit';
+
+  final AccountEntity account;
+
+  static Route<void> route(AccountEntity account) {
+    return MaterialPageRoute<void>(
+      builder: (_) => EditAccountScreen(account: account),
+      settings: const RouteSettings(name: routeName),
+    );
+  }
+
+  @override
+  ConsumerState<EditAccountScreen> createState() => _EditAccountScreenState();
+}
+
+class EditAccountScreenArgs {
+  const EditAccountScreenArgs({required this.account});
+
+  final AccountEntity account;
+}
+
+class _EditAccountScreenState extends ConsumerState<EditAccountScreen> {
+  late final TextEditingController _nameController;
+  late final TextEditingController _balanceController;
+
+  @override
+  void initState() {
+    super.initState();
+    final EditAccountFormState initialState = ref.read(
+      editAccountFormControllerProvider(widget.account),
+    );
+    _nameController = TextEditingController(text: initialState.name);
+    _balanceController = TextEditingController(text: initialState.balanceInput);
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _balanceController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations strings = AppLocalizations.of(context)!;
+    final EditAccountFormState state = ref.watch(
+      editAccountFormControllerProvider(widget.account),
+    );
+    final EditAccountFormController controller = ref.read(
+      editAccountFormControllerProvider(widget.account).notifier,
+    );
+
+    ref.listen<EditAccountFormState>(
+      editAccountFormControllerProvider(widget.account),
+      (EditAccountFormState? previous, EditAccountFormState next) {
+        if (previous?.name != next.name && _nameController.text != next.name) {
+          _nameController.value = _nameController.value.copyWith(
+            text: next.name,
+            selection: TextSelection.collapsed(offset: next.name.length),
+          );
+        }
+        if (previous?.balanceInput != next.balanceInput &&
+            _balanceController.text != next.balanceInput) {
+          _balanceController.value = _balanceController.value.copyWith(
+            text: next.balanceInput,
+            selection: TextSelection.collapsed(
+              offset: next.balanceInput.length,
+            ),
+          );
+        }
+        final bool submitted =
+            previous?.submissionSuccess != true && next.submissionSuccess;
+        if (submitted && mounted) {
+          Navigator.of(context).pop(true);
+          controller.clearSubmissionFlag();
+        }
+      },
+    );
+
+    const List<String> currencyOptions = <String>['USD', 'EUR', 'RUB'];
+    final Map<String, String> accountTypeLabels = <String, String>{
+      'cash': strings.addAccountTypeCash,
+      'card': strings.addAccountTypeCard,
+      'bank': strings.addAccountTypeBank,
+    };
+
+    final ThemeData theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(title: Text(strings.editAccountTitle)),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              if (state.isSaving) const LinearProgressIndicator(),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _nameController,
+                decoration: InputDecoration(
+                  labelText: strings.editAccountNameLabel,
+                  errorText: state.nameError == EditAccountFieldError.emptyName
+                      ? strings.editAccountNameRequired
+                      : null,
+                ),
+                enabled: !state.isSaving,
+                textInputAction: TextInputAction.next,
+                onChanged: controller.updateName,
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _balanceController,
+                decoration: InputDecoration(
+                  labelText: strings.editAccountBalanceLabel,
+                  errorText:
+                      state.balanceError == EditAccountFieldError.invalidBalance
+                      ? strings.editAccountBalanceInvalid
+                      : null,
+                ),
+                enabled: !state.isSaving,
+                keyboardType: const TextInputType.numberWithOptions(
+                  decimal: true,
+                ),
+                onChanged: controller.updateBalance,
+              ),
+              const SizedBox(height: 16),
+              DropdownButtonFormField<String>(
+                initialValue: state.currency,
+                decoration: InputDecoration(
+                  labelText: strings.editAccountCurrencyLabel,
+                ),
+                items: currencyOptions
+                    .map(
+                      (String code) => DropdownMenuItem<String>(
+                        value: code,
+                        child: Text(code),
+                      ),
+                    )
+                    .toList(),
+                onChanged: state.isSaving
+                    ? null
+                    : (String? value) {
+                        if (value != null) {
+                          controller.updateCurrency(value);
+                        }
+                      },
+              ),
+              const SizedBox(height: 24),
+              ListTile(
+                contentPadding: EdgeInsets.zero,
+                title: Text(strings.editAccountTypeLabel),
+                subtitle: Text(
+                  accountTypeLabels[widget.account.type] ?? widget.account.type,
+                ),
+              ),
+              if (state.errorMessage != null) ...<Widget>[
+                const SizedBox(height: 16),
+                Text(
+                  strings.editAccountGenericError,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: theme.colorScheme.error,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  state.errorMessage!,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.error,
+                  ),
+                ),
+              ],
+              const SizedBox(height: 24),
+              ElevatedButton(
+                onPressed: state.isSaving
+                    ? null
+                    : () {
+                        FocusScope.of(context).unfocus();
+                        controller.submit();
+                      },
+                child: state.isSaving
+                    ? const SizedBox(
+                        height: 20,
+                        width: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : Text(strings.editAccountSaveCta),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/categories/presentation/controllers/category_form_controller.g.dart
+++ b/lib/features/categories/presentation/controllers/category_form_controller.g.dart
@@ -60,7 +60,7 @@ final class CategoryFormControllerProvider
 }
 
 String _$categoryFormControllerHash() =>
-    r'e80b4d8c9cb61d370e1c86007802c61a42163ad3';
+    r'ed2299374b76506e92081239f38f86f52763f449';
 
 final class CategoryFormControllerFamily extends $Family
     with

--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:kopim/features/accounts/domain/entities/account_entity.dart';
+import 'package:kopim/features/accounts/presentation/account_details_screen.dart';
 import 'package:kopim/features/accounts/presentation/accounts_add_screen.dart';
 import 'package:kopim/features/app_shell/presentation/models/navigation_tab_content.dart';
 import 'package:kopim/features/categories/domain/entities/category.dart';
@@ -21,12 +22,15 @@ import '../controllers/home_providers.dart';
 NavigationTabContent buildHomeTabContent(BuildContext context, WidgetRef ref) {
   final AppLocalizations strings = AppLocalizations.of(context)!;
   final AsyncValue<AuthUser?> authState = ref.watch(authControllerProvider);
-  final AsyncValue<List<TransactionEntity>> transactionsAsync =
-  ref.watch(homeRecentTransactionsProvider());
-  final AsyncValue<List<AccountEntity>> accountsAsync =
-  ref.watch(homeAccountsProvider);
-  final AsyncValue<List<Category>> categoriesAsync =
-  ref.watch(homeCategoriesProvider);
+  final AsyncValue<List<TransactionEntity>> transactionsAsync = ref.watch(
+    homeRecentTransactionsProvider(),
+  );
+  final AsyncValue<List<AccountEntity>> accountsAsync = ref.watch(
+    homeAccountsProvider,
+  );
+  final AsyncValue<List<Category>> categoriesAsync = ref.watch(
+    homeCategoriesProvider,
+  );
   final double totalBalance = ref.watch(homeTotalBalanceProvider);
   final bool isWideLayout = MediaQuery.of(context).size.width >= 720;
   final NumberFormat currencyFormat = NumberFormat.simpleCurrency(
@@ -103,8 +107,9 @@ class _HomeBody extends StatelessWidget {
                   action: IconButton(
                     icon: const Icon(Icons.add),
                     tooltip: strings.homeAccountsAddTooltip,
-                    onPressed: () => Navigator.of(context)
-                        .pushNamed(AddAccountScreen.routeName),
+                    onPressed: () => Navigator.of(
+                      context,
+                    ).pushNamed(AddAccountScreen.routeName),
                   ),
                 ),
                 const SizedBox(height: 12),
@@ -149,7 +154,9 @@ class _HomeBody extends StatelessWidget {
                         ),
                       ),
                       error: (Object error, _) => _ErrorMessage(
-                        message: strings.homeTransactionsError(error.toString()),
+                        message: strings.homeTransactionsError(
+                          error.toString(),
+                        ),
                       ),
                     );
                   },
@@ -160,9 +167,7 @@ class _HomeBody extends StatelessWidget {
                     ),
                   ),
                   error: (Object error, _) => _ErrorMessage(
-                    message: strings.homeTransactionsError(
-                      error.toString(),
-                    ),
+                    message: strings.homeTransactionsError(error.toString()),
                   ),
                 ),
               ],
@@ -184,9 +189,7 @@ class _AddTransactionButton extends StatelessWidget {
     return FloatingActionButton(
       onPressed: () async {
         final bool? created = await Navigator.of(context).push<bool>(
-          MaterialPageRoute<bool>(
-            builder: (_) => const AddTransactionScreen(),
-          ),
+          MaterialPageRoute<bool>(builder: (_) => const AddTransactionScreen()),
         );
         if (created == true && context.mounted) {
           ScaffoldMessenger.of(context)
@@ -231,6 +234,12 @@ class _AccountsList extends StatelessWidget {
             title: Text(account.name),
             subtitle: Text(strings.homeAccountType(account.type)),
             trailing: Text(format.format(account.balance)),
+            onTap: () {
+              Navigator.of(context).pushNamed(
+                AccountDetailsScreen.routeName,
+                arguments: AccountDetailsScreenArgs(accountId: account.id),
+              );
+            },
           ),
         );
       },
@@ -274,7 +283,8 @@ class _TransactionsList extends StatelessWidget {
             : accountsById[transaction.accountId];
         final NumberFormat format = NumberFormat.currency(
           locale: localeName,
-          symbol: account?.currency.toUpperCase() ??
+          symbol:
+              account?.currency.toUpperCase() ??
               NumberFormat.simpleCurrency(locale: localeName).currencySymbol,
         );
         final String amountText = format.format(transaction.amount.abs());
@@ -283,17 +293,19 @@ class _TransactionsList extends StatelessWidget {
             : categoriesById[transaction.categoryId!];
         final String categoryName =
             category?.name ?? strings.homeTransactionsUncategorized;
-        final PhosphorIconData? categoryIcon =
-        resolvePhosphorIconData(category?.icon);
+        final PhosphorIconData? categoryIcon = resolvePhosphorIconData(
+          category?.icon,
+        );
         final Color? categoryColor = parseHexColor(category?.color);
         final String? note = transaction.note;
-        final Color amountColor =
-        isExpense ? theme.colorScheme.error : theme.colorScheme.primary;
+        final Color amountColor = isExpense
+            ? theme.colorScheme.error
+            : theme.colorScheme.primary;
         final Color avatarIconColor = categoryColor != null
             ? (ThemeData.estimateBrightnessForColor(categoryColor) ==
-            Brightness.dark
-            ? Colors.white
-            : Colors.black87)
+                      Brightness.dark
+                  ? Colors.white
+                  : Colors.black87)
             : theme.colorScheme.onSurfaceVariant;
 
         return Card(
@@ -306,7 +318,8 @@ class _TransactionsList extends StatelessWidget {
                 // Иконка слева
                 CircleAvatar(
                   backgroundColor:
-                  categoryColor ?? theme.colorScheme.surfaceContainerHighest,
+                      categoryColor ??
+                      theme.colorScheme.surfaceContainerHighest,
                   foregroundColor: avatarIconColor,
                   child: categoryIcon != null
                       ? Icon(categoryIcon)
@@ -319,15 +332,9 @@ class _TransactionsList extends StatelessWidget {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text(
-                        categoryName,
-                        style: theme.textTheme.bodyMedium,
-                      ),
+                      Text(categoryName, style: theme.textTheme.bodyMedium),
                       if (note != null && note.isNotEmpty)
-                        Text(
-                          note,
-                          style: theme.textTheme.bodySmall,
-                        ),
+                        Text(note, style: theme.textTheme.bodySmall),
                     ],
                   ),
                 ),
@@ -338,14 +345,12 @@ class _TransactionsList extends StatelessWidget {
                   children: [
                     Text(
                       amountText,
-                      style: theme.textTheme.titleMedium
-                          ?.copyWith(color: amountColor),
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        color: amountColor,
+                      ),
                     ),
                     if (account != null)
-                      Text(
-                        account.name,
-                        style: theme.textTheme.bodySmall,
-                      ),
+                      Text(account.name, style: theme.textTheme.bodySmall),
                   ],
                 ),
               ],
@@ -393,11 +398,7 @@ class _ErrorMessage extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 16),
       child: Center(
-        child: Text(
-          message,
-          style: style,
-          textAlign: TextAlign.center,
-        ),
+        child: Text(message, style: style, textAlign: TextAlign.center),
       ),
     );
   }

--- a/lib/features/transactions/domain/use_cases/watch_account_transactions_use_case.dart
+++ b/lib/features/transactions/domain/use_cases/watch_account_transactions_use_case.dart
@@ -1,0 +1,24 @@
+import 'package:kopim/features/transactions/domain/entities/transaction.dart';
+import 'package:kopim/features/transactions/domain/repositories/transaction_repository.dart';
+
+class WatchAccountTransactionsUseCase {
+  WatchAccountTransactionsUseCase(this._repository);
+
+  final TransactionRepository _repository;
+
+  Stream<List<TransactionEntity>> call({required String accountId}) {
+    return _repository.watchTransactions().map((
+      List<TransactionEntity> transactions,
+    ) {
+      final Iterable<TransactionEntity> filtered = transactions.where(
+        (TransactionEntity transaction) => transaction.accountId == accountId,
+      );
+      final List<TransactionEntity> sorted = filtered.toList()
+        ..sort(
+          (TransactionEntity a, TransactionEntity b) =>
+              b.date.compareTo(a.date),
+        );
+      return List<TransactionEntity>.unmodifiable(sorted);
+    });
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -544,6 +544,170 @@
   "addAccountTypeBank": "Bank account",
   "@addAccountTypeBank": {
     "description": "Option label for bank accounts"
-
+  },
+  "accountDetailsTitle": "Account details",
+  "@accountDetailsTitle": {
+    "description": "Title for the account details screen"
+  },
+  "accountDetailsEditTooltip": "Edit account",
+  "@accountDetailsEditTooltip": {
+    "description": "Tooltip for the settings icon on the account details screen"
+  },
+  "accountDetailsError": "Unable to load account: {error}",
+  "@accountDetailsError": {
+    "description": "Error shown when loading the account fails",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "accountDetailsMissing": "This account is no longer available.",
+  "@accountDetailsMissing": {
+    "description": "Shown when the requested account cannot be found"
+  },
+  "accountDetailsSummaryError": "Unable to load summary: {error}",
+  "@accountDetailsSummaryError": {
+    "description": "Error shown when computing income/expense summary fails",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "accountDetailsCategoriesError": "Unable to load categories: {error}",
+  "@accountDetailsCategoriesError": {
+    "description": "Error shown when category stream fails on the account details screen",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "accountDetailsTransactionsError": "Unable to load transactions: {error}",
+  "@accountDetailsTransactionsError": {
+    "description": "Error shown when account transactions fail to load",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "accountDetailsTransactionsEmpty": "No transactions for this account yet.",
+  "@accountDetailsTransactionsEmpty": {
+    "description": "Empty state shown when the account has no transactions"
+  },
+  "accountDetailsBalanceLabel": "Balance: {balance}",
+  "@accountDetailsBalanceLabel": {
+    "description": "Label showing the current balance",
+    "placeholders": {
+      "balance": {
+        "type": "String"
+      }
+    }
+  },
+  "accountDetailsIncomeLabel": "Total income",
+  "@accountDetailsIncomeLabel": {
+    "description": "Label for the total income value"
+  },
+  "accountDetailsExpenseLabel": "Total expenses",
+  "@accountDetailsExpenseLabel": {
+    "description": "Label for the total expense value"
+  },
+  "accountDetailsFiltersTitle": "Filters",
+  "@accountDetailsFiltersTitle": {
+    "description": "Section title for the filter card"
+  },
+  "accountDetailsFiltersClear": "Clear filters",
+  "@accountDetailsFiltersClear": {
+    "description": "Button label that clears all active filters"
+  },
+  "accountDetailsFiltersDateAny": "Any dates",
+  "@accountDetailsFiltersDateAny": {
+    "description": "Label shown when no date range filter is applied"
+  },
+  "accountDetailsFiltersDateValue": "{start} – {end}",
+  "@accountDetailsFiltersDateValue": {
+    "description": "Label showing the selected date range",
+    "placeholders": {
+      "start": {
+        "type": "String"
+      },
+      "end": {
+        "type": "String"
+      }
+    }
+  },
+  "accountDetailsFiltersTypeLabel": "Type",
+  "@accountDetailsFiltersTypeLabel": {
+    "description": "Label for the type dropdown filter"
+  },
+  "accountDetailsFiltersTypeAll": "All types",
+  "@accountDetailsFiltersTypeAll": {
+    "description": "Dropdown option for no type filter"
+  },
+  "accountDetailsFiltersTypeIncome": "Income",
+  "@accountDetailsFiltersTypeIncome": {
+    "description": "Dropdown option to filter income transactions"
+  },
+  "accountDetailsFiltersTypeExpense": "Expense",
+  "@accountDetailsFiltersTypeExpense": {
+    "description": "Dropdown option to filter expense transactions"
+  },
+  "accountDetailsFiltersCategoryLabel": "Category",
+  "@accountDetailsFiltersCategoryLabel": {
+    "description": "Label for the category dropdown"
+  },
+  "accountDetailsFiltersCategoryAll": "All categories",
+  "@accountDetailsFiltersCategoryAll": {
+    "description": "Dropdown option for no category filter"
+  },
+  "accountDetailsTransactionsUncategorized": "Uncategorized",
+  "@accountDetailsTransactionsUncategorized": {
+    "description": "Label for transactions without a category"
+  },
+  "accountDetailsTypeIncome": "Income",
+  "@accountDetailsTypeIncome": {
+    "description": "Label for income transaction type"
+  },
+  "accountDetailsTypeExpense": "Expense",
+  "@accountDetailsTypeExpense": {
+    "description": "Label for expense transaction type"
+  },
+  "editAccountTitle": "Edit account",
+  "@editAccountTitle": {
+    "description": "Title for the edit account screen"
+  },
+  "editAccountNameLabel": "Account name",
+  "@editAccountNameLabel": {
+    "description": "Label for the account name field on edit screen"
+  },
+  "editAccountBalanceLabel": "Balance",
+  "@editAccountBalanceLabel": {
+    "description": "Label for the balance field on edit screen"
+  },
+  "editAccountCurrencyLabel": "Currency",
+  "@editAccountCurrencyLabel": {
+    "description": "Label for the currency dropdown on edit screen"
+  },
+  "editAccountTypeLabel": "Account type",
+  "@editAccountTypeLabel": {
+    "description": "Label for the account type row on edit screen"
+  },
+  "editAccountSaveCta": "Save changes",
+  "@editAccountSaveCta": {
+    "description": "Button label for saving account edits"
+  },
+  "editAccountNameRequired": "Please enter the account name.",
+  "@editAccountNameRequired": {
+    "description": "Validation message when the account name is empty"
+  },
+  "editAccountBalanceInvalid": "Enter a valid amount.",
+  "@editAccountBalanceInvalid": {
+    "description": "Validation message when the balance is invalid"
+  },
+  "editAccountGenericError": "Could not update account. Please try again.",
+  "@editAccountGenericError": {
+    "description": "Generic error shown when updating the account fails"
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -266,7 +266,7 @@ abstract class AppLocalizations {
   /// **'Clear selection'**
   String get manageCategoriesIconClear;
 
-  /// Empty state shown when the selected icon group has no entries
+  /// Empty state shown when the selected icon group has no items
   ///
   /// In en, this message translates to:
   /// **'No icons available.'**
@@ -823,6 +823,204 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Bank account'**
   String get addAccountTypeBank;
+
+  /// Title for the account details screen
+  ///
+  /// In en, this message translates to:
+  /// **'Account details'**
+  String get accountDetailsTitle;
+
+  /// Tooltip for the settings icon on the account details screen
+  ///
+  /// In en, this message translates to:
+  /// **'Edit account'**
+  String get accountDetailsEditTooltip;
+
+  /// Error shown when loading the account fails
+  ///
+  /// In en, this message translates to:
+  /// **'Unable to load account: {error}'**
+  String accountDetailsError(String error);
+
+  /// Shown when the requested account cannot be found
+  ///
+  /// In en, this message translates to:
+  /// **'This account is no longer available.'**
+  String get accountDetailsMissing;
+
+  /// Error shown when computing income/expense summary fails
+  ///
+  /// In en, this message translates to:
+  /// **'Unable to load summary: {error}'**
+  String accountDetailsSummaryError(String error);
+
+  /// Error shown when category stream fails on the account details screen
+  ///
+  /// In en, this message translates to:
+  /// **'Unable to load categories: {error}'**
+  String accountDetailsCategoriesError(String error);
+
+  /// Error shown when account transactions fail to load
+  ///
+  /// In en, this message translates to:
+  /// **'Unable to load transactions: {error}'**
+  String accountDetailsTransactionsError(String error);
+
+  /// Empty state shown when the account has no transactions
+  ///
+  /// In en, this message translates to:
+  /// **'No transactions for this account yet.'**
+  String get accountDetailsTransactionsEmpty;
+
+  /// Label showing the current balance
+  ///
+  /// In en, this message translates to:
+  /// **'Balance: {balance}'**
+  String accountDetailsBalanceLabel(String balance);
+
+  /// Label for the total income value
+  ///
+  /// In en, this message translates to:
+  /// **'Total income'**
+  String get accountDetailsIncomeLabel;
+
+  /// Label for the total expense value
+  ///
+  /// In en, this message translates to:
+  /// **'Total expenses'**
+  String get accountDetailsExpenseLabel;
+
+  /// Section title for the filter card
+  ///
+  /// In en, this message translates to:
+  /// **'Filters'**
+  String get accountDetailsFiltersTitle;
+
+  /// Button label that clears all active filters
+  ///
+  /// In en, this message translates to:
+  /// **'Clear filters'**
+  String get accountDetailsFiltersClear;
+
+  /// Label shown when no date range filter is applied
+  ///
+  /// In en, this message translates to:
+  /// **'Any dates'**
+  String get accountDetailsFiltersDateAny;
+
+  /// Label showing the selected date range
+  ///
+  /// In en, this message translates to:
+  /// **'{start} – {end}'**
+  String accountDetailsFiltersDateValue(String start, String end);
+
+  /// Label for the type dropdown filter
+  ///
+  /// In en, this message translates to:
+  /// **'Type'**
+  String get accountDetailsFiltersTypeLabel;
+
+  /// Dropdown option for no type filter
+  ///
+  /// In en, this message translates to:
+  /// **'All types'**
+  String get accountDetailsFiltersTypeAll;
+
+  /// Dropdown option to filter income transactions
+  ///
+  /// In en, this message translates to:
+  /// **'Income'**
+  String get accountDetailsFiltersTypeIncome;
+
+  /// Dropdown option to filter expense transactions
+  ///
+  /// In en, this message translates to:
+  /// **'Expense'**
+  String get accountDetailsFiltersTypeExpense;
+
+  /// Label for the category dropdown
+  ///
+  /// In en, this message translates to:
+  /// **'Category'**
+  String get accountDetailsFiltersCategoryLabel;
+
+  /// Dropdown option for no category filter
+  ///
+  /// In en, this message translates to:
+  /// **'All categories'**
+  String get accountDetailsFiltersCategoryAll;
+
+  /// Label for transactions without a category
+  ///
+  /// In en, this message translates to:
+  /// **'Uncategorized'**
+  String get accountDetailsTransactionsUncategorized;
+
+  /// Label for income transaction type
+  ///
+  /// In en, this message translates to:
+  /// **'Income'**
+  String get accountDetailsTypeIncome;
+
+  /// Label for expense transaction type
+  ///
+  /// In en, this message translates to:
+  /// **'Expense'**
+  String get accountDetailsTypeExpense;
+
+  /// Title for the edit account screen
+  ///
+  /// In en, this message translates to:
+  /// **'Edit account'**
+  String get editAccountTitle;
+
+  /// Label for the account name field on edit screen
+  ///
+  /// In en, this message translates to:
+  /// **'Account name'**
+  String get editAccountNameLabel;
+
+  /// Label for the balance field on edit screen
+  ///
+  /// In en, this message translates to:
+  /// **'Balance'**
+  String get editAccountBalanceLabel;
+
+  /// Label for the currency dropdown on edit screen
+  ///
+  /// In en, this message translates to:
+  /// **'Currency'**
+  String get editAccountCurrencyLabel;
+
+  /// Label for the account type row on edit screen
+  ///
+  /// In en, this message translates to:
+  /// **'Account type'**
+  String get editAccountTypeLabel;
+
+  /// Button label for saving account edits
+  ///
+  /// In en, this message translates to:
+  /// **'Save changes'**
+  String get editAccountSaveCta;
+
+  /// Validation message when the account name is empty
+  ///
+  /// In en, this message translates to:
+  /// **'Please enter the account name.'**
+  String get editAccountNameRequired;
+
+  /// Validation message when the balance is invalid
+  ///
+  /// In en, this message translates to:
+  /// **'Enter a valid amount.'**
+  String get editAccountBalanceInvalid;
+
+  /// Generic error shown when updating the account fails
+  ///
+  /// In en, this message translates to:
+  /// **'Could not update account. Please try again.'**
+  String get editAccountGenericError;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -402,4 +402,117 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get addAccountTypeBank => 'Bank account';
+
+  @override
+  String get accountDetailsTitle => 'Account details';
+
+  @override
+  String get accountDetailsEditTooltip => 'Edit account';
+
+  @override
+  String accountDetailsError(String error) {
+    return 'Unable to load account: $error';
+  }
+
+  @override
+  String get accountDetailsMissing => 'This account is no longer available.';
+
+  @override
+  String accountDetailsSummaryError(String error) {
+    return 'Unable to load summary: $error';
+  }
+
+  @override
+  String accountDetailsCategoriesError(String error) {
+    return 'Unable to load categories: $error';
+  }
+
+  @override
+  String accountDetailsTransactionsError(String error) {
+    return 'Unable to load transactions: $error';
+  }
+
+  @override
+  String get accountDetailsTransactionsEmpty =>
+      'No transactions for this account yet.';
+
+  @override
+  String accountDetailsBalanceLabel(String balance) {
+    return 'Balance: $balance';
+  }
+
+  @override
+  String get accountDetailsIncomeLabel => 'Total income';
+
+  @override
+  String get accountDetailsExpenseLabel => 'Total expenses';
+
+  @override
+  String get accountDetailsFiltersTitle => 'Filters';
+
+  @override
+  String get accountDetailsFiltersClear => 'Clear filters';
+
+  @override
+  String get accountDetailsFiltersDateAny => 'Any dates';
+
+  @override
+  String accountDetailsFiltersDateValue(String start, String end) {
+    return '$start – $end';
+  }
+
+  @override
+  String get accountDetailsFiltersTypeLabel => 'Type';
+
+  @override
+  String get accountDetailsFiltersTypeAll => 'All types';
+
+  @override
+  String get accountDetailsFiltersTypeIncome => 'Income';
+
+  @override
+  String get accountDetailsFiltersTypeExpense => 'Expense';
+
+  @override
+  String get accountDetailsFiltersCategoryLabel => 'Category';
+
+  @override
+  String get accountDetailsFiltersCategoryAll => 'All categories';
+
+  @override
+  String get accountDetailsTransactionsUncategorized => 'Uncategorized';
+
+  @override
+  String get accountDetailsTypeIncome => 'Income';
+
+  @override
+  String get accountDetailsTypeExpense => 'Expense';
+
+  @override
+  String get editAccountTitle => 'Edit account';
+
+  @override
+  String get editAccountNameLabel => 'Account name';
+
+  @override
+  String get editAccountBalanceLabel => 'Balance';
+
+  @override
+  String get editAccountCurrencyLabel => 'Currency';
+
+  @override
+  String get editAccountTypeLabel => 'Account type';
+
+  @override
+  String get editAccountSaveCta => 'Save changes';
+
+  @override
+  String get editAccountNameRequired => 'Please enter the account name.';
+
+  @override
+  String get editAccountBalanceInvalid => 'Enter a valid amount.';
+
+  @override
+  String get editAccountGenericError =>
+      'Could not update account. Please try again.';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -403,4 +403,117 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get addAccountTypeBank => 'Банковский счёт';
+
+  @override
+  String get accountDetailsTitle => 'Счёт';
+
+  @override
+  String get accountDetailsEditTooltip => 'Настройки счёта';
+
+  @override
+  String accountDetailsError(String error) {
+    return 'Не удалось загрузить счёт: $error';
+  }
+
+  @override
+  String get accountDetailsMissing => 'Счёт не найден или был удалён.';
+
+  @override
+  String accountDetailsSummaryError(String error) {
+    return 'Не удалось загрузить сводку: $error';
+  }
+
+  @override
+  String accountDetailsCategoriesError(String error) {
+    return 'Не удалось загрузить категории: $error';
+  }
+
+  @override
+  String accountDetailsTransactionsError(String error) {
+    return 'Не удалось загрузить транзакции: $error';
+  }
+
+  @override
+  String get accountDetailsTransactionsEmpty =>
+      'Для этого счёта ещё нет транзакций.';
+
+  @override
+  String accountDetailsBalanceLabel(String balance) {
+    return 'Баланс: $balance';
+  }
+
+  @override
+  String get accountDetailsIncomeLabel => 'Доходы';
+
+  @override
+  String get accountDetailsExpenseLabel => 'Расходы';
+
+  @override
+  String get accountDetailsFiltersTitle => 'Фильтры';
+
+  @override
+  String get accountDetailsFiltersClear => 'Сбросить фильтры';
+
+  @override
+  String get accountDetailsFiltersDateAny => 'Любые даты';
+
+  @override
+  String accountDetailsFiltersDateValue(String start, String end) {
+    return '$start — $end';
+  }
+
+  @override
+  String get accountDetailsFiltersTypeLabel => 'Тип';
+
+  @override
+  String get accountDetailsFiltersTypeAll => 'Все типы';
+
+  @override
+  String get accountDetailsFiltersTypeIncome => 'Доход';
+
+  @override
+  String get accountDetailsFiltersTypeExpense => 'Расход';
+
+  @override
+  String get accountDetailsFiltersCategoryLabel => 'Категория';
+
+  @override
+  String get accountDetailsFiltersCategoryAll => 'Все категории';
+
+  @override
+  String get accountDetailsTransactionsUncategorized => 'Без категории';
+
+  @override
+  String get accountDetailsTypeIncome => 'Доход';
+
+  @override
+  String get accountDetailsTypeExpense => 'Расход';
+
+  @override
+  String get editAccountTitle => 'Редактирование счёта';
+
+  @override
+  String get editAccountNameLabel => 'Название счёта';
+
+  @override
+  String get editAccountBalanceLabel => 'Баланс';
+
+  @override
+  String get editAccountCurrencyLabel => 'Валюта';
+
+  @override
+  String get editAccountTypeLabel => 'Тип счёта';
+
+  @override
+  String get editAccountSaveCta => 'Сохранить изменения';
+
+  @override
+  String get editAccountNameRequired => 'Введите название счёта.';
+
+  @override
+  String get editAccountBalanceInvalid => 'Введите корректную сумму.';
+
+  @override
+  String get editAccountGenericError =>
+      'Не удалось обновить счёт. Повторите попытку.';
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -544,6 +544,170 @@
   "addAccountTypeBank": "Банковский счёт",
   "@addAccountTypeBank": {
     "description": "Вариант типа счёта для банковского счёта"
-
+  },
+  "accountDetailsTitle": "Счёт",
+  "@accountDetailsTitle": {
+    "description": "Заголовок экрана деталей счёта"
+  },
+  "accountDetailsEditTooltip": "Настройки счёта",
+  "@accountDetailsEditTooltip": {
+    "description": "Подсказка для кнопки настройки на экране счёта"
+  },
+  "accountDetailsError": "Не удалось загрузить счёт: {error}",
+  "@accountDetailsError": {
+    "description": "Сообщение об ошибке загрузки счёта",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "accountDetailsMissing": "Счёт не найден или был удалён.",
+  "@accountDetailsMissing": {
+    "description": "Сообщение, если счёт недоступен"
+  },
+  "accountDetailsSummaryError": "Не удалось загрузить сводку: {error}",
+  "@accountDetailsSummaryError": {
+    "description": "Сообщение об ошибке расчёта сводных данных",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "accountDetailsCategoriesError": "Не удалось загрузить категории: {error}",
+  "@accountDetailsCategoriesError": {
+    "description": "Сообщение об ошибке загрузки категорий",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "accountDetailsTransactionsError": "Не удалось загрузить транзакции: {error}",
+  "@accountDetailsTransactionsError": {
+    "description": "Сообщение об ошибке загрузки транзакций",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "accountDetailsTransactionsEmpty": "Для этого счёта ещё нет транзакций.",
+  "@accountDetailsTransactionsEmpty": {
+    "description": "Пустое состояние списка транзакций"
+  },
+  "accountDetailsBalanceLabel": "Баланс: {balance}",
+  "@accountDetailsBalanceLabel": {
+    "description": "Подпись текущего баланса",
+    "placeholders": {
+      "balance": {
+        "type": "String"
+      }
+    }
+  },
+  "accountDetailsIncomeLabel": "Доходы",
+  "@accountDetailsIncomeLabel": {
+    "description": "Подпись суммы доходов"
+  },
+  "accountDetailsExpenseLabel": "Расходы",
+  "@accountDetailsExpenseLabel": {
+    "description": "Подпись суммы расходов"
+  },
+  "accountDetailsFiltersTitle": "Фильтры",
+  "@accountDetailsFiltersTitle": {
+    "description": "Заголовок блока фильтров"
+  },
+  "accountDetailsFiltersClear": "Сбросить фильтры",
+  "@accountDetailsFiltersClear": {
+    "description": "Кнопка сброса всех фильтров"
+  },
+  "accountDetailsFiltersDateAny": "Любые даты",
+  "@accountDetailsFiltersDateAny": {
+    "description": "Подпись при отсутствии фильтра по датам"
+  },
+  "accountDetailsFiltersDateValue": "{start} — {end}",
+  "@accountDetailsFiltersDateValue": {
+    "description": "Формат отображения выбранного диапазона дат",
+    "placeholders": {
+      "start": {
+        "type": "String"
+      },
+      "end": {
+        "type": "String"
+      }
+    }
+  },
+  "accountDetailsFiltersTypeLabel": "Тип",
+  "@accountDetailsFiltersTypeLabel": {
+    "description": "Подпись выпадающего списка по типу"
+  },
+  "accountDetailsFiltersTypeAll": "Все типы",
+  "@accountDetailsFiltersTypeAll": {
+    "description": "Опция отключения фильтра по типу"
+  },
+  "accountDetailsFiltersTypeIncome": "Доход",
+  "@accountDetailsFiltersTypeIncome": {
+    "description": "Опция фильтрации доходов"
+  },
+  "accountDetailsFiltersTypeExpense": "Расход",
+  "@accountDetailsFiltersTypeExpense": {
+    "description": "Опция фильтрации расходов"
+  },
+  "accountDetailsFiltersCategoryLabel": "Категория",
+  "@accountDetailsFiltersCategoryLabel": {
+    "description": "Подпись выпадающего списка категорий"
+  },
+  "accountDetailsFiltersCategoryAll": "Все категории",
+  "@accountDetailsFiltersCategoryAll": {
+    "description": "Опция отключения фильтра по категории"
+  },
+  "accountDetailsTransactionsUncategorized": "Без категории",
+  "@accountDetailsTransactionsUncategorized": {
+    "description": "Подпись для транзакций без категории"
+  },
+  "accountDetailsTypeIncome": "Доход",
+  "@accountDetailsTypeIncome": {
+    "description": "Подпись типа транзакции доход"
+  },
+  "accountDetailsTypeExpense": "Расход",
+  "@accountDetailsTypeExpense": {
+    "description": "Подпись типа транзакции расход"
+  },
+  "editAccountTitle": "Редактирование счёта",
+  "@editAccountTitle": {
+    "description": "Заголовок экрана редактирования счёта"
+  },
+  "editAccountNameLabel": "Название счёта",
+  "@editAccountNameLabel": {
+    "description": "Подпись поля названия счёта"
+  },
+  "editAccountBalanceLabel": "Баланс",
+  "@editAccountBalanceLabel": {
+    "description": "Подпись поля баланса на экране редактирования"
+  },
+  "editAccountCurrencyLabel": "Валюта",
+  "@editAccountCurrencyLabel": {
+    "description": "Подпись выбора валюты при редактировании"
+  },
+  "editAccountTypeLabel": "Тип счёта",
+  "@editAccountTypeLabel": {
+    "description": "Подпись строки с типом счёта"
+  },
+  "editAccountSaveCta": "Сохранить изменения",
+  "@editAccountSaveCta": {
+    "description": "Кнопка сохранения изменений"
+  },
+  "editAccountNameRequired": "Введите название счёта.",
+  "@editAccountNameRequired": {
+    "description": "Сообщение об ошибке пустого названия"
+  },
+  "editAccountBalanceInvalid": "Введите корректную сумму.",
+  "@editAccountBalanceInvalid": {
+    "description": "Сообщение об ошибке неверного баланса"
+  },
+  "editAccountGenericError": "Не удалось обновить счёт. Повторите попытку.",
+  "@editAccountGenericError": {
+    "description": "Общее сообщение об ошибке при обновлении счёта"
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,7 +9,9 @@ import 'core/config/app_config.dart';
 import 'core/di/injectors.dart';
 import 'features/profile/presentation/controllers/auth_controller.dart';
 import 'features/analytics/presentation/analytics_screen.dart';
+import 'features/accounts/presentation/account_details_screen.dart';
 import 'features/accounts/presentation/accounts_add_screen.dart';
+import 'features/accounts/presentation/edit_account_screen.dart';
 import 'features/app_shell/presentation/widgets/main_navigation_shell.dart';
 import 'features/categories/presentation/screens/manage_categories_screen.dart';
 import 'features/profile/presentation/screens/profile_screen.dart';
@@ -50,6 +52,20 @@ class MyApp extends ConsumerWidget {
         MainNavigationShell.routeName: (_) => const MainNavigationShell(),
         AnalyticsScreen.routeName: (_) => const AnalyticsScreen(),
         AddAccountScreen.routeName: (_) => const AddAccountScreen(),
+        AccountDetailsScreen.routeName: (BuildContext context) {
+          final Object? args = ModalRoute.of(context)?.settings.arguments;
+          if (args is! AccountDetailsScreenArgs) {
+            throw ArgumentError('AccountDetailsScreenArgs expected');
+          }
+          return AccountDetailsScreen(accountId: args.accountId);
+        },
+        EditAccountScreen.routeName: (BuildContext context) {
+          final Object? args = ModalRoute.of(context)?.settings.arguments;
+          if (args is! EditAccountScreenArgs) {
+            throw ArgumentError('EditAccountScreenArgs expected');
+          }
+          return EditAccountScreen(account: args.account);
+        },
         AddTransactionScreen.routeName: (_) => const AddTransactionScreen(),
         ProfileScreen.routeName: (_) => const ProfileScreen(),
         ManageCategoriesScreen.routeName: (_) => const ManageCategoriesScreen(),

--- a/test/features/accounts/presentation/controllers/account_details_providers_test.dart
+++ b/test/features/accounts/presentation/controllers/account_details_providers_test.dart
@@ -1,0 +1,145 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kopim/features/accounts/presentation/controllers/account_details_providers.dart';
+import 'package:kopim/features/transactions/domain/entities/transaction.dart';
+import 'package:kopim/features/transactions/domain/entities/transaction_type.dart';
+import 'package:riverpod/riverpod.dart';
+
+void main() {
+  const String accountId = 'acc-1';
+  final DateTime now = DateTime.utc(2024, 6, 1);
+
+  TransactionEntity transaction(
+    String id, {
+    required TransactionType type,
+    required double amount,
+    required DateTime date,
+    String? categoryId,
+  }) {
+    return TransactionEntity(
+      id: id,
+      accountId: accountId,
+      categoryId: categoryId,
+      amount: amount,
+      date: date,
+      note: null,
+      type: type.storageValue,
+      createdAt: date,
+      updatedAt: date,
+    );
+  }
+
+  group('filteredAccountTransactionsProvider', () {
+    test('applies type, category and date filters', () async {
+      final List<TransactionEntity> transactions = <TransactionEntity>[
+        transaction(
+          't1',
+          type: TransactionType.income,
+          amount: 120,
+          date: now,
+          categoryId: 'cat-1',
+        ),
+        transaction(
+          't2',
+          type: TransactionType.expense,
+          amount: 80,
+          date: now.subtract(const Duration(days: 5)),
+          categoryId: 'cat-2',
+        ),
+        transaction(
+          't3',
+          type: TransactionType.income,
+          amount: 75,
+          date: now.subtract(const Duration(days: 45)),
+          categoryId: 'cat-1',
+        ),
+      ];
+
+      final ProviderContainer container = ProviderContainer(
+        overrides: [
+          accountTransactionsProvider.overrideWith((Ref ref, String id) {
+            expect(id, accountId);
+            return Stream<List<TransactionEntity>>.value(transactions);
+          }),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final DateTimeRange range = DateTimeRange(
+        start: now.subtract(const Duration(days: 10)),
+        end: now,
+      );
+
+      final AccountTransactionsFilterController controller = container.read(
+        accountTransactionsFilterControllerProvider(accountId).notifier,
+      );
+      controller
+        ..setType(TransactionType.income)
+        ..setCategory('cat-1')
+        ..setDateRange(range);
+
+      final Completer<List<TransactionEntity>> completer =
+          Completer<List<TransactionEntity>>();
+      final ProviderSubscription<AsyncValue<List<TransactionEntity>>> listener =
+          container.listen(filteredAccountTransactionsProvider(accountId), (
+            AsyncValue<List<TransactionEntity>>? previous,
+            AsyncValue<List<TransactionEntity>> next,
+          ) {
+            next.whenData((List<TransactionEntity> data) {
+              if (!completer.isCompleted) {
+                completer.complete(data);
+              }
+            });
+          }, fireImmediately: true);
+      addTearDown(listener.close);
+
+      final List<TransactionEntity> result = await completer.future;
+
+      expect(result, <TransactionEntity>[transactions.first]);
+    });
+  });
+
+  group('accountTransactionSummaryProvider', () {
+    test('aggregates income and expenses', () async {
+      final List<TransactionEntity> transactions = <TransactionEntity>[
+        transaction('t1', type: TransactionType.income, amount: 200, date: now),
+        transaction('t2', type: TransactionType.expense, amount: 50, date: now),
+        transaction('t3', type: TransactionType.expense, amount: 30, date: now),
+      ];
+
+      final ProviderContainer container = ProviderContainer(
+        overrides: [
+          accountTransactionsProvider.overrideWith((Ref ref, String id) {
+            expect(id, accountId);
+            return Stream<List<TransactionEntity>>.value(transactions);
+          }),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final Completer<AccountTransactionSummary> completer =
+          Completer<AccountTransactionSummary>();
+      final ProviderSubscription<AsyncValue<AccountTransactionSummary>>
+      listener = container
+          .listen(accountTransactionSummaryProvider(accountId), (
+            AsyncValue<AccountTransactionSummary>? previous,
+            AsyncValue<AccountTransactionSummary> next,
+          ) {
+            next.whenData((AccountTransactionSummary summary) {
+              if (!completer.isCompleted) {
+                completer.complete(summary);
+              }
+            });
+          }, fireImmediately: true);
+      addTearDown(listener.close);
+
+      final AccountTransactionSummary summary = await completer.future;
+
+      expect(summary.totalIncome, 200);
+      expect(summary.totalExpense, 80);
+      expect(summary.net, 120);
+    });
+  });
+}

--- a/test/features/accounts/presentation/controllers/edit_account_form_controller_test.dart
+++ b/test/features/accounts/presentation/controllers/edit_account_form_controller_test.dart
@@ -1,0 +1,132 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kopim/core/di/injectors.dart';
+import 'package:kopim/features/accounts/domain/entities/account_entity.dart';
+import 'package:kopim/features/accounts/domain/repositories/account_repository.dart';
+import 'package:kopim/features/accounts/domain/use_cases/add_account_use_case.dart';
+import 'package:kopim/features/accounts/presentation/controllers/edit_account_form_controller.dart';
+import 'package:riverpod/riverpod.dart';
+
+void main() {
+  group('EditAccountFormController', () {
+    test('updates account using addAccountUseCase', () async {
+      final _RecordingAccountRepository repository =
+          _RecordingAccountRepository();
+      final ProviderContainer container = ProviderContainer(
+        overrides: [
+          addAccountUseCaseProvider.overrideWithValue(
+            AddAccountUseCase(repository),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final DateTime createdAt = DateTime.utc(2024, 1, 1);
+      final AccountEntity original = AccountEntity(
+        id: 'acc-1',
+        name: 'Wallet',
+        balance: 100,
+        currency: 'USD',
+        type: 'cash',
+        createdAt: createdAt,
+        updatedAt: createdAt,
+      );
+
+      final EditAccountFormController controller = container.read(
+        editAccountFormControllerProvider(original).notifier,
+      );
+
+      controller
+        ..updateName(' Wallet Plus ')
+        ..updateBalance('250,75')
+        ..updateCurrency('EUR');
+
+      await controller.submit();
+
+      expect(repository.lastUpserted, isNotNull);
+      final AccountEntity updated = repository.lastUpserted!;
+      expect(updated.id, original.id);
+      expect(updated.name, 'Wallet Plus');
+      expect(updated.balance, closeTo(250.75, 1e-6));
+      expect(updated.currency, 'EUR');
+      expect(updated.type, original.type);
+      expect(updated.createdAt, original.createdAt);
+      expect(updated.updatedAt.isAfter(original.updatedAt), isTrue);
+
+      final EditAccountFormState state = container.read(
+        editAccountFormControllerProvider(original),
+      );
+      expect(state.submissionSuccess, isTrue);
+    });
+
+    test('validates empty name and invalid balance', () async {
+      final ProviderContainer container = ProviderContainer(
+        overrides: [
+          addAccountUseCaseProvider.overrideWithValue(
+            AddAccountUseCase(_RecordingAccountRepository()),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final DateTime now = DateTime.utc(2024, 1, 1);
+      final AccountEntity original = AccountEntity(
+        id: 'acc-2',
+        name: 'Savings',
+        balance: 500,
+        currency: 'USD',
+        type: 'bank',
+        createdAt: now,
+        updatedAt: now,
+      );
+
+      final EditAccountFormController controller = container.read(
+        editAccountFormControllerProvider(original).notifier,
+      );
+
+      controller
+        ..updateName('   ')
+        ..updateBalance('abc');
+
+      await controller.submit();
+
+      final EditAccountFormState state = container.read(
+        editAccountFormControllerProvider(original),
+      );
+
+      expect(state.nameError, EditAccountFieldError.emptyName);
+      expect(state.balanceError, EditAccountFieldError.invalidBalance);
+      expect(state.submissionSuccess, isFalse);
+    });
+  });
+}
+
+class _RecordingAccountRepository implements AccountRepository {
+  AccountEntity? lastUpserted;
+
+  @override
+  Future<AccountEntity?> findById(String id) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<AccountEntity>> loadAccounts() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> softDelete(String id) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> upsert(AccountEntity account) async {
+    lastUpserted = account;
+  }
+
+  @override
+  Stream<List<AccountEntity>> watchAccounts() {
+    throw UnimplementedError();
+  }
+}


### PR DESCRIPTION
## Summary
- add an account details screen with Riverpod-powered summaries, filters, and navigation hooks from home
- implement account-specific transaction streaming use case plus edit-account form controller/screen that reuse shared balance parsing
- expand localization strings and DI wiring to cover the new flows and add focused unit tests for providers and edit controller

## Testing
- dart format --set-exit-if-changed . (reformatted unrelated files; reverted)
- flutter analyze
- dart run build_runner build --delete-conflicting-outputs
- flutter test --reporter expanded
- flutter pub outdated

------
https://chatgpt.com/codex/tasks/task_e_68dd2ffde494832e8d29c4c73dd30b88