### PR TITLE
Add recurring transactions scheduling and domain support

### DIFF
--- a/lib/core/data/database.g.dart
+++ b/lib/core/data/database.g.dart
@@ -2829,6 +2829,1842 @@ class ProfilesCompanion extends UpdateCompanion<ProfileRow> {
   }
 }
 
+class $RecurringRulesTable extends RecurringRules
+    with TableInfo<$RecurringRulesTable, RecurringRuleRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $RecurringRulesTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<String> id = GeneratedColumn<String>(
+    'id',
+    aliasedName,
+    false,
+    additionalChecks: GeneratedColumn.checkTextLength(
+      minTextLength: 1,
+      maxTextLength: 50,
+    ),
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _titleMeta = const VerificationMeta('title');
+  @override
+  late final GeneratedColumn<String> title = GeneratedColumn<String>(
+    'title',
+    aliasedName,
+    false,
+    additionalChecks: GeneratedColumn.checkTextLength(
+      minTextLength: 1,
+      maxTextLength: 120,
+    ),
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _accountIdMeta = const VerificationMeta(
+    'accountId',
+  );
+  @override
+  late final GeneratedColumn<String> accountId = GeneratedColumn<String>(
+    'account_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'REFERENCES accounts (id) ON DELETE CASCADE',
+    ),
+  );
+  static const VerificationMeta _amountMeta = const VerificationMeta('amount');
+  @override
+  late final GeneratedColumn<double> amount = GeneratedColumn<double>(
+    'amount',
+    aliasedName,
+    false,
+    type: DriftSqlType.double,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _currencyMeta = const VerificationMeta(
+    'currency',
+  );
+  @override
+  late final GeneratedColumn<String> currency = GeneratedColumn<String>(
+    'currency',
+    aliasedName,
+    false,
+    additionalChecks: GeneratedColumn.checkTextLength(
+      minTextLength: 3,
+      maxTextLength: 3,
+    ),
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _startAtMeta = const VerificationMeta(
+    'startAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> startAt = GeneratedColumn<DateTime>(
+    'start_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _timezoneMeta = const VerificationMeta(
+    'timezone',
+  );
+  @override
+  late final GeneratedColumn<String> timezone = GeneratedColumn<String>(
+    'timezone',
+    aliasedName,
+    false,
+    additionalChecks: GeneratedColumn.checkTextLength(
+      minTextLength: 1,
+      maxTextLength: 60,
+    ),
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _rruleMeta = const VerificationMeta('rrule');
+  @override
+  late final GeneratedColumn<String> rrule = GeneratedColumn<String>(
+    'rrule',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _endAtMeta = const VerificationMeta('endAt');
+  @override
+  late final GeneratedColumn<DateTime> endAt = GeneratedColumn<DateTime>(
+    'end_at',
+    aliasedName,
+    true,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _notesMeta = const VerificationMeta('notes');
+  @override
+  late final GeneratedColumn<String> notes = GeneratedColumn<String>(
+    'notes',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _isActiveMeta = const VerificationMeta(
+    'isActive',
+  );
+  @override
+  late final GeneratedColumn<bool> isActive = GeneratedColumn<bool>(
+    'is_active',
+    aliasedName,
+    false,
+    type: DriftSqlType.bool,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'CHECK ("is_active" IN (0, 1))',
+    ),
+    defaultValue: const Constant<bool>(true),
+  );
+  static const VerificationMeta _autoPostMeta = const VerificationMeta(
+    'autoPost',
+  );
+  @override
+  late final GeneratedColumn<bool> autoPost = GeneratedColumn<bool>(
+    'auto_post',
+    aliasedName,
+    false,
+    type: DriftSqlType.bool,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'CHECK ("auto_post" IN (0, 1))',
+    ),
+    defaultValue: const Constant<bool>(false),
+  );
+  static const VerificationMeta _reminderMinutesBeforeMeta =
+      const VerificationMeta('reminderMinutesBefore');
+  @override
+  late final GeneratedColumn<int> reminderMinutesBefore = GeneratedColumn<int>(
+    'reminder_minutes_before',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _shortMonthPolicyMeta = const VerificationMeta(
+    'shortMonthPolicy',
+  );
+  @override
+  late final GeneratedColumn<String> shortMonthPolicy = GeneratedColumn<String>(
+    'short_month_policy',
+    aliasedName,
+    false,
+    additionalChecks: GeneratedColumn.checkTextLength(
+      minTextLength: 1,
+      maxTextLength: 32,
+    ),
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    defaultValue: const Constant<String>('clip_to_last_day'),
+  );
+  static const VerificationMeta _createdAtMeta = const VerificationMeta(
+    'createdAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
+    'created_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+    defaultValue: currentDateAndTime,
+  );
+  static const VerificationMeta _updatedAtMeta = const VerificationMeta(
+    'updatedAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> updatedAt = GeneratedColumn<DateTime>(
+    'updated_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+    defaultValue: currentDateAndTime,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    title,
+    accountId,
+    amount,
+    currency,
+    startAt,
+    timezone,
+    rrule,
+    endAt,
+    notes,
+    isActive,
+    autoPost,
+    reminderMinutesBefore,
+    shortMonthPolicy,
+    createdAt,
+    updatedAt,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'recurring_rules';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<RecurringRuleRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    } else if (isInserting) {
+      context.missing(_idMeta);
+    }
+    if (data.containsKey('title')) {
+      context.handle(
+        _titleMeta,
+        title.isAcceptableOrUnknown(data['title']!, _titleMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_titleMeta);
+    }
+    if (data.containsKey('account_id')) {
+      context.handle(
+        _accountIdMeta,
+        accountId.isAcceptableOrUnknown(data['account_id']!, _accountIdMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_accountIdMeta);
+    }
+    if (data.containsKey('amount')) {
+      context.handle(
+        _amountMeta,
+        amount.isAcceptableOrUnknown(data['amount']!, _amountMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_amountMeta);
+    }
+    if (data.containsKey('currency')) {
+      context.handle(
+        _currencyMeta,
+        currency.isAcceptableOrUnknown(data['currency']!, _currencyMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_currencyMeta);
+    }
+    if (data.containsKey('start_at')) {
+      context.handle(
+        _startAtMeta,
+        startAt.isAcceptableOrUnknown(data['start_at']!, _startAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_startAtMeta);
+    }
+    if (data.containsKey('timezone')) {
+      context.handle(
+        _timezoneMeta,
+        timezone.isAcceptableOrUnknown(data['timezone']!, _timezoneMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_timezoneMeta);
+    }
+    if (data.containsKey('rrule')) {
+      context.handle(
+        _rruleMeta,
+        rrule.isAcceptableOrUnknown(data['rrule']!, _rruleMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_rruleMeta);
+    }
+    if (data.containsKey('end_at')) {
+      context.handle(
+        _endAtMeta,
+        endAt.isAcceptableOrUnknown(data['end_at']!, _endAtMeta),
+      );
+    }
+    if (data.containsKey('notes')) {
+      context.handle(
+        _notesMeta,
+        notes.isAcceptableOrUnknown(data['notes']!, _notesMeta),
+      );
+    }
+    if (data.containsKey('is_active')) {
+      context.handle(
+        _isActiveMeta,
+        isActive.isAcceptableOrUnknown(data['is_active']!, _isActiveMeta),
+      );
+    }
+    if (data.containsKey('auto_post')) {
+      context.handle(
+        _autoPostMeta,
+        autoPost.isAcceptableOrUnknown(data['auto_post']!, _autoPostMeta),
+      );
+    }
+    if (data.containsKey('reminder_minutes_before')) {
+      context.handle(
+        _reminderMinutesBeforeMeta,
+        reminderMinutesBefore.isAcceptableOrUnknown(
+          data['reminder_minutes_before']!,
+          _reminderMinutesBeforeMeta,
+        ),
+      );
+    }
+    if (data.containsKey('short_month_policy')) {
+      context.handle(
+        _shortMonthPolicyMeta,
+        shortMonthPolicy.isAcceptableOrUnknown(
+          data['short_month_policy']!,
+          _shortMonthPolicyMeta,
+        ),
+      );
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(
+        _createdAtMeta,
+        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
+      );
+    }
+    if (data.containsKey('updated_at')) {
+      context.handle(
+        _updatedAtMeta,
+        updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  RecurringRuleRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return RecurringRuleRow(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}id'],
+      )!,
+      title: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}title'],
+      )!,
+      accountId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}account_id'],
+      )!,
+      amount: attachedDatabase.typeMapping.read(
+        DriftSqlType.double,
+        data['${effectivePrefix}amount'],
+      )!,
+      currency: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}currency'],
+      )!,
+      startAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}start_at'],
+      )!,
+      timezone: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}timezone'],
+      )!,
+      rrule: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}rrule'],
+      )!,
+      endAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}end_at'],
+      ),
+      notes: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}notes'],
+      ),
+      isActive: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}is_active'],
+      )!,
+      autoPost: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}auto_post'],
+      )!,
+      reminderMinutesBefore: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}reminder_minutes_before'],
+      ),
+      shortMonthPolicy: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}short_month_policy'],
+      )!,
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}created_at'],
+      )!,
+      updatedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}updated_at'],
+      )!,
+    );
+  }
+
+  @override
+  $RecurringRulesTable createAlias(String alias) {
+    return $RecurringRulesTable(attachedDatabase, alias);
+  }
+}
+
+class RecurringRuleRow extends DataClass
+    implements Insertable<RecurringRuleRow> {
+  final String id;
+  final String title;
+  final String accountId;
+  final double amount;
+  final String currency;
+  final DateTime startAt;
+  final String timezone;
+  final String rrule;
+  final DateTime? endAt;
+  final String? notes;
+  final bool isActive;
+  final bool autoPost;
+  final int? reminderMinutesBefore;
+  final String shortMonthPolicy;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  const RecurringRuleRow({
+    required this.id,
+    required this.title,
+    required this.accountId,
+    required this.amount,
+    required this.currency,
+    required this.startAt,
+    required this.timezone,
+    required this.rrule,
+    this.endAt,
+    this.notes,
+    required this.isActive,
+    required this.autoPost,
+    this.reminderMinutesBefore,
+    required this.shortMonthPolicy,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<String>(id);
+    map['title'] = Variable<String>(title);
+    map['account_id'] = Variable<String>(accountId);
+    map['amount'] = Variable<double>(amount);
+    map['currency'] = Variable<String>(currency);
+    map['start_at'] = Variable<DateTime>(startAt);
+    map['timezone'] = Variable<String>(timezone);
+    map['rrule'] = Variable<String>(rrule);
+    if (!nullToAbsent || endAt != null) {
+      map['end_at'] = Variable<DateTime>(endAt);
+    }
+    if (!nullToAbsent || notes != null) {
+      map['notes'] = Variable<String>(notes);
+    }
+    map['is_active'] = Variable<bool>(isActive);
+    map['auto_post'] = Variable<bool>(autoPost);
+    if (!nullToAbsent || reminderMinutesBefore != null) {
+      map['reminder_minutes_before'] = Variable<int>(reminderMinutesBefore);
+    }
+    map['short_month_policy'] = Variable<String>(shortMonthPolicy);
+    map['created_at'] = Variable<DateTime>(createdAt);
+    map['updated_at'] = Variable<DateTime>(updatedAt);
+    return map;
+  }
+
+  RecurringRulesCompanion toCompanion(bool nullToAbsent) {
+    return RecurringRulesCompanion(
+      id: Value(id),
+      title: Value(title),
+      accountId: Value(accountId),
+      amount: Value(amount),
+      currency: Value(currency),
+      startAt: Value(startAt),
+      timezone: Value(timezone),
+      rrule: Value(rrule),
+      endAt: endAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(endAt),
+      notes: notes == null && nullToAbsent
+          ? const Value.absent()
+          : Value(notes),
+      isActive: Value(isActive),
+      autoPost: Value(autoPost),
+      reminderMinutesBefore: reminderMinutesBefore == null && nullToAbsent
+          ? const Value.absent()
+          : Value(reminderMinutesBefore),
+      shortMonthPolicy: Value(shortMonthPolicy),
+      createdAt: Value(createdAt),
+      updatedAt: Value(updatedAt),
+    );
+  }
+
+  factory RecurringRuleRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return RecurringRuleRow(
+      id: serializer.fromJson<String>(json['id']),
+      title: serializer.fromJson<String>(json['title']),
+      accountId: serializer.fromJson<String>(json['accountId']),
+      amount: serializer.fromJson<double>(json['amount']),
+      currency: serializer.fromJson<String>(json['currency']),
+      startAt: serializer.fromJson<DateTime>(json['startAt']),
+      timezone: serializer.fromJson<String>(json['timezone']),
+      rrule: serializer.fromJson<String>(json['rrule']),
+      endAt: serializer.fromJson<DateTime?>(json['endAt']),
+      notes: serializer.fromJson<String?>(json['notes']),
+      isActive: serializer.fromJson<bool>(json['isActive']),
+      autoPost: serializer.fromJson<bool>(json['autoPost']),
+      reminderMinutesBefore: serializer.fromJson<int?>(
+        json['reminderMinutesBefore'],
+      ),
+      shortMonthPolicy: serializer.fromJson<String>(json['shortMonthPolicy']),
+      createdAt: serializer.fromJson<DateTime>(json['createdAt']),
+      updatedAt: serializer.fromJson<DateTime>(json['updatedAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<String>(id),
+      'title': serializer.toJson<String>(title),
+      'accountId': serializer.toJson<String>(accountId),
+      'amount': serializer.toJson<double>(amount),
+      'currency': serializer.toJson<String>(currency),
+      'startAt': serializer.toJson<DateTime>(startAt),
+      'timezone': serializer.toJson<String>(timezone),
+      'rrule': serializer.toJson<String>(rrule),
+      'endAt': serializer.toJson<DateTime?>(endAt),
+      'notes': serializer.toJson<String?>(notes),
+      'isActive': serializer.toJson<bool>(isActive),
+      'autoPost': serializer.toJson<bool>(autoPost),
+      'reminderMinutesBefore': serializer.toJson<int?>(reminderMinutesBefore),
+      'shortMonthPolicy': serializer.toJson<String>(shortMonthPolicy),
+      'createdAt': serializer.toJson<DateTime>(createdAt),
+      'updatedAt': serializer.toJson<DateTime>(updatedAt),
+    };
+  }
+
+  RecurringRuleRow copyWith({
+    String? id,
+    String? title,
+    String? accountId,
+    double? amount,
+    String? currency,
+    DateTime? startAt,
+    String? timezone,
+    String? rrule,
+    Value<DateTime?> endAt = const Value.absent(),
+    Value<String?> notes = const Value.absent(),
+    bool? isActive,
+    bool? autoPost,
+    Value<int?> reminderMinutesBefore = const Value.absent(),
+    String? shortMonthPolicy,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) => RecurringRuleRow(
+    id: id ?? this.id,
+    title: title ?? this.title,
+    accountId: accountId ?? this.accountId,
+    amount: amount ?? this.amount,
+    currency: currency ?? this.currency,
+    startAt: startAt ?? this.startAt,
+    timezone: timezone ?? this.timezone,
+    rrule: rrule ?? this.rrule,
+    endAt: endAt.present ? endAt.value : this.endAt,
+    notes: notes.present ? notes.value : this.notes,
+    isActive: isActive ?? this.isActive,
+    autoPost: autoPost ?? this.autoPost,
+    reminderMinutesBefore: reminderMinutesBefore.present
+        ? reminderMinutesBefore.value
+        : this.reminderMinutesBefore,
+    shortMonthPolicy: shortMonthPolicy ?? this.shortMonthPolicy,
+    createdAt: createdAt ?? this.createdAt,
+    updatedAt: updatedAt ?? this.updatedAt,
+  );
+  RecurringRuleRow copyWithCompanion(RecurringRulesCompanion data) {
+    return RecurringRuleRow(
+      id: data.id.present ? data.id.value : this.id,
+      title: data.title.present ? data.title.value : this.title,
+      accountId: data.accountId.present ? data.accountId.value : this.accountId,
+      amount: data.amount.present ? data.amount.value : this.amount,
+      currency: data.currency.present ? data.currency.value : this.currency,
+      startAt: data.startAt.present ? data.startAt.value : this.startAt,
+      timezone: data.timezone.present ? data.timezone.value : this.timezone,
+      rrule: data.rrule.present ? data.rrule.value : this.rrule,
+      endAt: data.endAt.present ? data.endAt.value : this.endAt,
+      notes: data.notes.present ? data.notes.value : this.notes,
+      isActive: data.isActive.present ? data.isActive.value : this.isActive,
+      autoPost: data.autoPost.present ? data.autoPost.value : this.autoPost,
+      reminderMinutesBefore: data.reminderMinutesBefore.present
+          ? data.reminderMinutesBefore.value
+          : this.reminderMinutesBefore,
+      shortMonthPolicy: data.shortMonthPolicy.present
+          ? data.shortMonthPolicy.value
+          : this.shortMonthPolicy,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+      updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('RecurringRuleRow(')
+          ..write('id: $id, ')
+          ..write('title: $title, ')
+          ..write('accountId: $accountId, ')
+          ..write('amount: $amount, ')
+          ..write('currency: $currency, ')
+          ..write('startAt: $startAt, ')
+          ..write('timezone: $timezone, ')
+          ..write('rrule: $rrule, ')
+          ..write('endAt: $endAt, ')
+          ..write('notes: $notes, ')
+          ..write('isActive: $isActive, ')
+          ..write('autoPost: $autoPost, ')
+          ..write('reminderMinutesBefore: $reminderMinutesBefore, ')
+          ..write('shortMonthPolicy: $shortMonthPolicy, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('updatedAt: $updatedAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    title,
+    accountId,
+    amount,
+    currency,
+    startAt,
+    timezone,
+    rrule,
+    endAt,
+    notes,
+    isActive,
+    autoPost,
+    reminderMinutesBefore,
+    shortMonthPolicy,
+    createdAt,
+    updatedAt,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is RecurringRuleRow &&
+          other.id == this.id &&
+          other.title == this.title &&
+          other.accountId == this.accountId &&
+          other.amount == this.amount &&
+          other.currency == this.currency &&
+          other.startAt == this.startAt &&
+          other.timezone == this.timezone &&
+          other.rrule == this.rrule &&
+          other.endAt == this.endAt &&
+          other.notes == this.notes &&
+          other.isActive == this.isActive &&
+          other.autoPost == this.autoPost &&
+          other.reminderMinutesBefore == this.reminderMinutesBefore &&
+          other.shortMonthPolicy == this.shortMonthPolicy &&
+          other.createdAt == this.createdAt &&
+          other.updatedAt == this.updatedAt);
+}
+
+class RecurringRulesCompanion extends UpdateCompanion<RecurringRuleRow> {
+  final Value<String> id;
+  final Value<String> title;
+  final Value<String> accountId;
+  final Value<double> amount;
+  final Value<String> currency;
+  final Value<DateTime> startAt;
+  final Value<String> timezone;
+  final Value<String> rrule;
+  final Value<DateTime?> endAt;
+  final Value<String?> notes;
+  final Value<bool> isActive;
+  final Value<bool> autoPost;
+  final Value<int?> reminderMinutesBefore;
+  final Value<String> shortMonthPolicy;
+  final Value<DateTime> createdAt;
+  final Value<DateTime> updatedAt;
+  final Value<int> rowid;
+  const RecurringRulesCompanion({
+    this.id = const Value.absent(),
+    this.title = const Value.absent(),
+    this.accountId = const Value.absent(),
+    this.amount = const Value.absent(),
+    this.currency = const Value.absent(),
+    this.startAt = const Value.absent(),
+    this.timezone = const Value.absent(),
+    this.rrule = const Value.absent(),
+    this.endAt = const Value.absent(),
+    this.notes = const Value.absent(),
+    this.isActive = const Value.absent(),
+    this.autoPost = const Value.absent(),
+    this.reminderMinutesBefore = const Value.absent(),
+    this.shortMonthPolicy = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  RecurringRulesCompanion.insert({
+    required String id,
+    required String title,
+    required String accountId,
+    required double amount,
+    required String currency,
+    required DateTime startAt,
+    required String timezone,
+    required String rrule,
+    this.endAt = const Value.absent(),
+    this.notes = const Value.absent(),
+    this.isActive = const Value.absent(),
+    this.autoPost = const Value.absent(),
+    this.reminderMinutesBefore = const Value.absent(),
+    this.shortMonthPolicy = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  }) : id = Value(id),
+       title = Value(title),
+       accountId = Value(accountId),
+       amount = Value(amount),
+       currency = Value(currency),
+       startAt = Value(startAt),
+       timezone = Value(timezone),
+       rrule = Value(rrule);
+  static Insertable<RecurringRuleRow> custom({
+    Expression<String>? id,
+    Expression<String>? title,
+    Expression<String>? accountId,
+    Expression<double>? amount,
+    Expression<String>? currency,
+    Expression<DateTime>? startAt,
+    Expression<String>? timezone,
+    Expression<String>? rrule,
+    Expression<DateTime>? endAt,
+    Expression<String>? notes,
+    Expression<bool>? isActive,
+    Expression<bool>? autoPost,
+    Expression<int>? reminderMinutesBefore,
+    Expression<String>? shortMonthPolicy,
+    Expression<DateTime>? createdAt,
+    Expression<DateTime>? updatedAt,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (title != null) 'title': title,
+      if (accountId != null) 'account_id': accountId,
+      if (amount != null) 'amount': amount,
+      if (currency != null) 'currency': currency,
+      if (startAt != null) 'start_at': startAt,
+      if (timezone != null) 'timezone': timezone,
+      if (rrule != null) 'rrule': rrule,
+      if (endAt != null) 'end_at': endAt,
+      if (notes != null) 'notes': notes,
+      if (isActive != null) 'is_active': isActive,
+      if (autoPost != null) 'auto_post': autoPost,
+      if (reminderMinutesBefore != null)
+        'reminder_minutes_before': reminderMinutesBefore,
+      if (shortMonthPolicy != null) 'short_month_policy': shortMonthPolicy,
+      if (createdAt != null) 'created_at': createdAt,
+      if (updatedAt != null) 'updated_at': updatedAt,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  RecurringRulesCompanion copyWith({
+    Value<String>? id,
+    Value<String>? title,
+    Value<String>? accountId,
+    Value<double>? amount,
+    Value<String>? currency,
+    Value<DateTime>? startAt,
+    Value<String>? timezone,
+    Value<String>? rrule,
+    Value<DateTime?>? endAt,
+    Value<String?>? notes,
+    Value<bool>? isActive,
+    Value<bool>? autoPost,
+    Value<int?>? reminderMinutesBefore,
+    Value<String>? shortMonthPolicy,
+    Value<DateTime>? createdAt,
+    Value<DateTime>? updatedAt,
+    Value<int>? rowid,
+  }) {
+    return RecurringRulesCompanion(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      accountId: accountId ?? this.accountId,
+      amount: amount ?? this.amount,
+      currency: currency ?? this.currency,
+      startAt: startAt ?? this.startAt,
+      timezone: timezone ?? this.timezone,
+      rrule: rrule ?? this.rrule,
+      endAt: endAt ?? this.endAt,
+      notes: notes ?? this.notes,
+      isActive: isActive ?? this.isActive,
+      autoPost: autoPost ?? this.autoPost,
+      reminderMinutesBefore:
+          reminderMinutesBefore ?? this.reminderMinutesBefore,
+      shortMonthPolicy: shortMonthPolicy ?? this.shortMonthPolicy,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<String>(id.value);
+    }
+    if (title.present) {
+      map['title'] = Variable<String>(title.value);
+    }
+    if (accountId.present) {
+      map['account_id'] = Variable<String>(accountId.value);
+    }
+    if (amount.present) {
+      map['amount'] = Variable<double>(amount.value);
+    }
+    if (currency.present) {
+      map['currency'] = Variable<String>(currency.value);
+    }
+    if (startAt.present) {
+      map['start_at'] = Variable<DateTime>(startAt.value);
+    }
+    if (timezone.present) {
+      map['timezone'] = Variable<String>(timezone.value);
+    }
+    if (rrule.present) {
+      map['rrule'] = Variable<String>(rrule.value);
+    }
+    if (endAt.present) {
+      map['end_at'] = Variable<DateTime>(endAt.value);
+    }
+    if (notes.present) {
+      map['notes'] = Variable<String>(notes.value);
+    }
+    if (isActive.present) {
+      map['is_active'] = Variable<bool>(isActive.value);
+    }
+    if (autoPost.present) {
+      map['auto_post'] = Variable<bool>(autoPost.value);
+    }
+    if (reminderMinutesBefore.present) {
+      map['reminder_minutes_before'] = Variable<int>(
+        reminderMinutesBefore.value,
+      );
+    }
+    if (shortMonthPolicy.present) {
+      map['short_month_policy'] = Variable<String>(shortMonthPolicy.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<DateTime>(createdAt.value);
+    }
+    if (updatedAt.present) {
+      map['updated_at'] = Variable<DateTime>(updatedAt.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('RecurringRulesCompanion(')
+          ..write('id: $id, ')
+          ..write('title: $title, ')
+          ..write('accountId: $accountId, ')
+          ..write('amount: $amount, ')
+          ..write('currency: $currency, ')
+          ..write('startAt: $startAt, ')
+          ..write('timezone: $timezone, ')
+          ..write('rrule: $rrule, ')
+          ..write('endAt: $endAt, ')
+          ..write('notes: $notes, ')
+          ..write('isActive: $isActive, ')
+          ..write('autoPost: $autoPost, ')
+          ..write('reminderMinutesBefore: $reminderMinutesBefore, ')
+          ..write('shortMonthPolicy: $shortMonthPolicy, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $RecurringOccurrencesTable extends RecurringOccurrences
+    with TableInfo<$RecurringOccurrencesTable, RecurringOccurrenceRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $RecurringOccurrencesTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<String> id = GeneratedColumn<String>(
+    'id',
+    aliasedName,
+    false,
+    additionalChecks: GeneratedColumn.checkTextLength(
+      minTextLength: 1,
+      maxTextLength: 60,
+    ),
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _ruleIdMeta = const VerificationMeta('ruleId');
+  @override
+  late final GeneratedColumn<String> ruleId = GeneratedColumn<String>(
+    'rule_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'REFERENCES recurring_rules (id) ON DELETE CASCADE',
+    ),
+  );
+  static const VerificationMeta _dueAtMeta = const VerificationMeta('dueAt');
+  @override
+  late final GeneratedColumn<DateTime> dueAt = GeneratedColumn<DateTime>(
+    'due_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _statusMeta = const VerificationMeta('status');
+  @override
+  late final GeneratedColumn<String> status = GeneratedColumn<String>(
+    'status',
+    aliasedName,
+    false,
+    additionalChecks: GeneratedColumn.checkTextLength(
+      minTextLength: 1,
+      maxTextLength: 16,
+    ),
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _createdAtMeta = const VerificationMeta(
+    'createdAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
+    'created_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+    defaultValue: currentDateAndTime,
+  );
+  static const VerificationMeta _postedTxIdMeta = const VerificationMeta(
+    'postedTxId',
+  );
+  @override
+  late final GeneratedColumn<String> postedTxId = GeneratedColumn<String>(
+    'posted_tx_id',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _updatedAtMeta = const VerificationMeta(
+    'updatedAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> updatedAt = GeneratedColumn<DateTime>(
+    'updated_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+    defaultValue: currentDateAndTime,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    ruleId,
+    dueAt,
+    status,
+    createdAt,
+    postedTxId,
+    updatedAt,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'recurring_occurrences';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<RecurringOccurrenceRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    } else if (isInserting) {
+      context.missing(_idMeta);
+    }
+    if (data.containsKey('rule_id')) {
+      context.handle(
+        _ruleIdMeta,
+        ruleId.isAcceptableOrUnknown(data['rule_id']!, _ruleIdMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_ruleIdMeta);
+    }
+    if (data.containsKey('due_at')) {
+      context.handle(
+        _dueAtMeta,
+        dueAt.isAcceptableOrUnknown(data['due_at']!, _dueAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_dueAtMeta);
+    }
+    if (data.containsKey('status')) {
+      context.handle(
+        _statusMeta,
+        status.isAcceptableOrUnknown(data['status']!, _statusMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_statusMeta);
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(
+        _createdAtMeta,
+        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
+      );
+    }
+    if (data.containsKey('posted_tx_id')) {
+      context.handle(
+        _postedTxIdMeta,
+        postedTxId.isAcceptableOrUnknown(
+          data['posted_tx_id']!,
+          _postedTxIdMeta,
+        ),
+      );
+    }
+    if (data.containsKey('updated_at')) {
+      context.handle(
+        _updatedAtMeta,
+        updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  RecurringOccurrenceRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return RecurringOccurrenceRow(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}id'],
+      )!,
+      ruleId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}rule_id'],
+      )!,
+      dueAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}due_at'],
+      )!,
+      status: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}status'],
+      )!,
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}created_at'],
+      )!,
+      postedTxId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}posted_tx_id'],
+      ),
+      updatedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}updated_at'],
+      )!,
+    );
+  }
+
+  @override
+  $RecurringOccurrencesTable createAlias(String alias) {
+    return $RecurringOccurrencesTable(attachedDatabase, alias);
+  }
+}
+
+class RecurringOccurrenceRow extends DataClass
+    implements Insertable<RecurringOccurrenceRow> {
+  final String id;
+  final String ruleId;
+  final DateTime dueAt;
+  final String status;
+  final DateTime createdAt;
+  final String? postedTxId;
+  final DateTime updatedAt;
+  const RecurringOccurrenceRow({
+    required this.id,
+    required this.ruleId,
+    required this.dueAt,
+    required this.status,
+    required this.createdAt,
+    this.postedTxId,
+    required this.updatedAt,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<String>(id);
+    map['rule_id'] = Variable<String>(ruleId);
+    map['due_at'] = Variable<DateTime>(dueAt);
+    map['status'] = Variable<String>(status);
+    map['created_at'] = Variable<DateTime>(createdAt);
+    if (!nullToAbsent || postedTxId != null) {
+      map['posted_tx_id'] = Variable<String>(postedTxId);
+    }
+    map['updated_at'] = Variable<DateTime>(updatedAt);
+    return map;
+  }
+
+  RecurringOccurrencesCompanion toCompanion(bool nullToAbsent) {
+    return RecurringOccurrencesCompanion(
+      id: Value(id),
+      ruleId: Value(ruleId),
+      dueAt: Value(dueAt),
+      status: Value(status),
+      createdAt: Value(createdAt),
+      postedTxId: postedTxId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(postedTxId),
+      updatedAt: Value(updatedAt),
+    );
+  }
+
+  factory RecurringOccurrenceRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return RecurringOccurrenceRow(
+      id: serializer.fromJson<String>(json['id']),
+      ruleId: serializer.fromJson<String>(json['ruleId']),
+      dueAt: serializer.fromJson<DateTime>(json['dueAt']),
+      status: serializer.fromJson<String>(json['status']),
+      createdAt: serializer.fromJson<DateTime>(json['createdAt']),
+      postedTxId: serializer.fromJson<String?>(json['postedTxId']),
+      updatedAt: serializer.fromJson<DateTime>(json['updatedAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<String>(id),
+      'ruleId': serializer.toJson<String>(ruleId),
+      'dueAt': serializer.toJson<DateTime>(dueAt),
+      'status': serializer.toJson<String>(status),
+      'createdAt': serializer.toJson<DateTime>(createdAt),
+      'postedTxId': serializer.toJson<String?>(postedTxId),
+      'updatedAt': serializer.toJson<DateTime>(updatedAt),
+    };
+  }
+
+  RecurringOccurrenceRow copyWith({
+    String? id,
+    String? ruleId,
+    DateTime? dueAt,
+    String? status,
+    DateTime? createdAt,
+    Value<String?> postedTxId = const Value.absent(),
+    DateTime? updatedAt,
+  }) => RecurringOccurrenceRow(
+    id: id ?? this.id,
+    ruleId: ruleId ?? this.ruleId,
+    dueAt: dueAt ?? this.dueAt,
+    status: status ?? this.status,
+    createdAt: createdAt ?? this.createdAt,
+    postedTxId: postedTxId.present ? postedTxId.value : this.postedTxId,
+    updatedAt: updatedAt ?? this.updatedAt,
+  );
+  RecurringOccurrenceRow copyWithCompanion(RecurringOccurrencesCompanion data) {
+    return RecurringOccurrenceRow(
+      id: data.id.present ? data.id.value : this.id,
+      ruleId: data.ruleId.present ? data.ruleId.value : this.ruleId,
+      dueAt: data.dueAt.present ? data.dueAt.value : this.dueAt,
+      status: data.status.present ? data.status.value : this.status,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+      postedTxId: data.postedTxId.present
+          ? data.postedTxId.value
+          : this.postedTxId,
+      updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('RecurringOccurrenceRow(')
+          ..write('id: $id, ')
+          ..write('ruleId: $ruleId, ')
+          ..write('dueAt: $dueAt, ')
+          ..write('status: $status, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('postedTxId: $postedTxId, ')
+          ..write('updatedAt: $updatedAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(id, ruleId, dueAt, status, createdAt, postedTxId, updatedAt);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is RecurringOccurrenceRow &&
+          other.id == this.id &&
+          other.ruleId == this.ruleId &&
+          other.dueAt == this.dueAt &&
+          other.status == this.status &&
+          other.createdAt == this.createdAt &&
+          other.postedTxId == this.postedTxId &&
+          other.updatedAt == this.updatedAt);
+}
+
+class RecurringOccurrencesCompanion
+    extends UpdateCompanion<RecurringOccurrenceRow> {
+  final Value<String> id;
+  final Value<String> ruleId;
+  final Value<DateTime> dueAt;
+  final Value<String> status;
+  final Value<DateTime> createdAt;
+  final Value<String?> postedTxId;
+  final Value<DateTime> updatedAt;
+  final Value<int> rowid;
+  const RecurringOccurrencesCompanion({
+    this.id = const Value.absent(),
+    this.ruleId = const Value.absent(),
+    this.dueAt = const Value.absent(),
+    this.status = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.postedTxId = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  RecurringOccurrencesCompanion.insert({
+    required String id,
+    required String ruleId,
+    required DateTime dueAt,
+    required String status,
+    this.createdAt = const Value.absent(),
+    this.postedTxId = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  }) : id = Value(id),
+       ruleId = Value(ruleId),
+       dueAt = Value(dueAt),
+       status = Value(status);
+  static Insertable<RecurringOccurrenceRow> custom({
+    Expression<String>? id,
+    Expression<String>? ruleId,
+    Expression<DateTime>? dueAt,
+    Expression<String>? status,
+    Expression<DateTime>? createdAt,
+    Expression<String>? postedTxId,
+    Expression<DateTime>? updatedAt,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (ruleId != null) 'rule_id': ruleId,
+      if (dueAt != null) 'due_at': dueAt,
+      if (status != null) 'status': status,
+      if (createdAt != null) 'created_at': createdAt,
+      if (postedTxId != null) 'posted_tx_id': postedTxId,
+      if (updatedAt != null) 'updated_at': updatedAt,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  RecurringOccurrencesCompanion copyWith({
+    Value<String>? id,
+    Value<String>? ruleId,
+    Value<DateTime>? dueAt,
+    Value<String>? status,
+    Value<DateTime>? createdAt,
+    Value<String?>? postedTxId,
+    Value<DateTime>? updatedAt,
+    Value<int>? rowid,
+  }) {
+    return RecurringOccurrencesCompanion(
+      id: id ?? this.id,
+      ruleId: ruleId ?? this.ruleId,
+      dueAt: dueAt ?? this.dueAt,
+      status: status ?? this.status,
+      createdAt: createdAt ?? this.createdAt,
+      postedTxId: postedTxId ?? this.postedTxId,
+      updatedAt: updatedAt ?? this.updatedAt,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<String>(id.value);
+    }
+    if (ruleId.present) {
+      map['rule_id'] = Variable<String>(ruleId.value);
+    }
+    if (dueAt.present) {
+      map['due_at'] = Variable<DateTime>(dueAt.value);
+    }
+    if (status.present) {
+      map['status'] = Variable<String>(status.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<DateTime>(createdAt.value);
+    }
+    if (postedTxId.present) {
+      map['posted_tx_id'] = Variable<String>(postedTxId.value);
+    }
+    if (updatedAt.present) {
+      map['updated_at'] = Variable<DateTime>(updatedAt.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('RecurringOccurrencesCompanion(')
+          ..write('id: $id, ')
+          ..write('ruleId: $ruleId, ')
+          ..write('dueAt: $dueAt, ')
+          ..write('status: $status, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('postedTxId: $postedTxId, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $JobQueueTable extends JobQueue
+    with TableInfo<$JobQueueTable, JobQueueRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $JobQueueTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'PRIMARY KEY AUTOINCREMENT',
+    ),
+  );
+  static const VerificationMeta _typeMeta = const VerificationMeta('type');
+  @override
+  late final GeneratedColumn<String> type = GeneratedColumn<String>(
+    'type',
+    aliasedName,
+    false,
+    additionalChecks: GeneratedColumn.checkTextLength(
+      minTextLength: 1,
+      maxTextLength: 80,
+    ),
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _payloadMeta = const VerificationMeta(
+    'payload',
+  );
+  @override
+  late final GeneratedColumn<String> payload = GeneratedColumn<String>(
+    'payload',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _runAtMeta = const VerificationMeta('runAt');
+  @override
+  late final GeneratedColumn<DateTime> runAt = GeneratedColumn<DateTime>(
+    'run_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _attemptsMeta = const VerificationMeta(
+    'attempts',
+  );
+  @override
+  late final GeneratedColumn<int> attempts = GeneratedColumn<int>(
+    'attempts',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultValue: const Constant<int>(0),
+  );
+  static const VerificationMeta _createdAtMeta = const VerificationMeta(
+    'createdAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
+    'created_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+    defaultValue: currentDateAndTime,
+  );
+  static const VerificationMeta _lastErrorMeta = const VerificationMeta(
+    'lastError',
+  );
+  @override
+  late final GeneratedColumn<String> lastError = GeneratedColumn<String>(
+    'last_error',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    type,
+    payload,
+    runAt,
+    attempts,
+    createdAt,
+    lastError,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'job_queue';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<JobQueueRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('type')) {
+      context.handle(
+        _typeMeta,
+        type.isAcceptableOrUnknown(data['type']!, _typeMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_typeMeta);
+    }
+    if (data.containsKey('payload')) {
+      context.handle(
+        _payloadMeta,
+        payload.isAcceptableOrUnknown(data['payload']!, _payloadMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_payloadMeta);
+    }
+    if (data.containsKey('run_at')) {
+      context.handle(
+        _runAtMeta,
+        runAt.isAcceptableOrUnknown(data['run_at']!, _runAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_runAtMeta);
+    }
+    if (data.containsKey('attempts')) {
+      context.handle(
+        _attemptsMeta,
+        attempts.isAcceptableOrUnknown(data['attempts']!, _attemptsMeta),
+      );
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(
+        _createdAtMeta,
+        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
+      );
+    }
+    if (data.containsKey('last_error')) {
+      context.handle(
+        _lastErrorMeta,
+        lastError.isAcceptableOrUnknown(data['last_error']!, _lastErrorMeta),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  JobQueueRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return JobQueueRow(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}id'],
+      )!,
+      type: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}type'],
+      )!,
+      payload: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}payload'],
+      )!,
+      runAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}run_at'],
+      )!,
+      attempts: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}attempts'],
+      )!,
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}created_at'],
+      )!,
+      lastError: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}last_error'],
+      ),
+    );
+  }
+
+  @override
+  $JobQueueTable createAlias(String alias) {
+    return $JobQueueTable(attachedDatabase, alias);
+  }
+}
+
+class JobQueueRow extends DataClass implements Insertable<JobQueueRow> {
+  final int id;
+  final String type;
+  final String payload;
+  final DateTime runAt;
+  final int attempts;
+  final DateTime createdAt;
+  final String? lastError;
+  const JobQueueRow({
+    required this.id,
+    required this.type,
+    required this.payload,
+    required this.runAt,
+    required this.attempts,
+    required this.createdAt,
+    this.lastError,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['type'] = Variable<String>(type);
+    map['payload'] = Variable<String>(payload);
+    map['run_at'] = Variable<DateTime>(runAt);
+    map['attempts'] = Variable<int>(attempts);
+    map['created_at'] = Variable<DateTime>(createdAt);
+    if (!nullToAbsent || lastError != null) {
+      map['last_error'] = Variable<String>(lastError);
+    }
+    return map;
+  }
+
+  JobQueueCompanion toCompanion(bool nullToAbsent) {
+    return JobQueueCompanion(
+      id: Value(id),
+      type: Value(type),
+      payload: Value(payload),
+      runAt: Value(runAt),
+      attempts: Value(attempts),
+      createdAt: Value(createdAt),
+      lastError: lastError == null && nullToAbsent
+          ? const Value.absent()
+          : Value(lastError),
+    );
+  }
+
+  factory JobQueueRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return JobQueueRow(
+      id: serializer.fromJson<int>(json['id']),
+      type: serializer.fromJson<String>(json['type']),
+      payload: serializer.fromJson<String>(json['payload']),
+      runAt: serializer.fromJson<DateTime>(json['runAt']),
+      attempts: serializer.fromJson<int>(json['attempts']),
+      createdAt: serializer.fromJson<DateTime>(json['createdAt']),
+      lastError: serializer.fromJson<String?>(json['lastError']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'type': serializer.toJson<String>(type),
+      'payload': serializer.toJson<String>(payload),
+      'runAt': serializer.toJson<DateTime>(runAt),
+      'attempts': serializer.toJson<int>(attempts),
+      'createdAt': serializer.toJson<DateTime>(createdAt),
+      'lastError': serializer.toJson<String?>(lastError),
+    };
+  }
+
+  JobQueueRow copyWith({
+    int? id,
+    String? type,
+    String? payload,
+    DateTime? runAt,
+    int? attempts,
+    DateTime? createdAt,
+    Value<String?> lastError = const Value.absent(),
+  }) => JobQueueRow(
+    id: id ?? this.id,
+    type: type ?? this.type,
+    payload: payload ?? this.payload,
+    runAt: runAt ?? this.runAt,
+    attempts: attempts ?? this.attempts,
+    createdAt: createdAt ?? this.createdAt,
+    lastError: lastError.present ? lastError.value : this.lastError,
+  );
+  JobQueueRow copyWithCompanion(JobQueueCompanion data) {
+    return JobQueueRow(
+      id: data.id.present ? data.id.value : this.id,
+      type: data.type.present ? data.type.value : this.type,
+      payload: data.payload.present ? data.payload.value : this.payload,
+      runAt: data.runAt.present ? data.runAt.value : this.runAt,
+      attempts: data.attempts.present ? data.attempts.value : this.attempts,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+      lastError: data.lastError.present ? data.lastError.value : this.lastError,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('JobQueueRow(')
+          ..write('id: $id, ')
+          ..write('type: $type, ')
+          ..write('payload: $payload, ')
+          ..write('runAt: $runAt, ')
+          ..write('attempts: $attempts, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('lastError: $lastError')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(id, type, payload, runAt, attempts, createdAt, lastError);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is JobQueueRow &&
+          other.id == this.id &&
+          other.type == this.type &&
+          other.payload == this.payload &&
+          other.runAt == this.runAt &&
+          other.attempts == this.attempts &&
+          other.createdAt == this.createdAt &&
+          other.lastError == this.lastError);
+}
+
+class JobQueueCompanion extends UpdateCompanion<JobQueueRow> {
+  final Value<int> id;
+  final Value<String> type;
+  final Value<String> payload;
+  final Value<DateTime> runAt;
+  final Value<int> attempts;
+  final Value<DateTime> createdAt;
+  final Value<String?> lastError;
+  const JobQueueCompanion({
+    this.id = const Value.absent(),
+    this.type = const Value.absent(),
+    this.payload = const Value.absent(),
+    this.runAt = const Value.absent(),
+    this.attempts = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.lastError = const Value.absent(),
+  });
+  JobQueueCompanion.insert({
+    this.id = const Value.absent(),
+    required String type,
+    required String payload,
+    required DateTime runAt,
+    this.attempts = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.lastError = const Value.absent(),
+  }) : type = Value(type),
+       payload = Value(payload),
+       runAt = Value(runAt);
+  static Insertable<JobQueueRow> custom({
+    Expression<int>? id,
+    Expression<String>? type,
+    Expression<String>? payload,
+    Expression<DateTime>? runAt,
+    Expression<int>? attempts,
+    Expression<DateTime>? createdAt,
+    Expression<String>? lastError,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (type != null) 'type': type,
+      if (payload != null) 'payload': payload,
+      if (runAt != null) 'run_at': runAt,
+      if (attempts != null) 'attempts': attempts,
+      if (createdAt != null) 'created_at': createdAt,
+      if (lastError != null) 'last_error': lastError,
+    });
+  }
+
+  JobQueueCompanion copyWith({
+    Value<int>? id,
+    Value<String>? type,
+    Value<String>? payload,
+    Value<DateTime>? runAt,
+    Value<int>? attempts,
+    Value<DateTime>? createdAt,
+    Value<String?>? lastError,
+  }) {
+    return JobQueueCompanion(
+      id: id ?? this.id,
+      type: type ?? this.type,
+      payload: payload ?? this.payload,
+      runAt: runAt ?? this.runAt,
+      attempts: attempts ?? this.attempts,
+      createdAt: createdAt ?? this.createdAt,
+      lastError: lastError ?? this.lastError,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (type.present) {
+      map['type'] = Variable<String>(type.value);
+    }
+    if (payload.present) {
+      map['payload'] = Variable<String>(payload.value);
+    }
+    if (runAt.present) {
+      map['run_at'] = Variable<DateTime>(runAt.value);
+    }
+    if (attempts.present) {
+      map['attempts'] = Variable<int>(attempts.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<DateTime>(createdAt.value);
+    }
+    if (lastError.present) {
+      map['last_error'] = Variable<String>(lastError.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('JobQueueCompanion(')
+          ..write('id: $id, ')
+          ..write('type: $type, ')
+          ..write('payload: $payload, ')
+          ..write('runAt: $runAt, ')
+          ..write('attempts: $attempts, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('lastError: $lastError')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$AppDatabase extends GeneratedDatabase {
   _$AppDatabase(QueryExecutor e) : super(e);
   $AppDatabaseManager get managers => $AppDatabaseManager(this);
@@ -2837,6 +4673,10 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final $TransactionsTable transactions = $TransactionsTable(this);
   late final $OutboxEntriesTable outboxEntries = $OutboxEntriesTable(this);
   late final $ProfilesTable profiles = $ProfilesTable(this);
+  late final $RecurringRulesTable recurringRules = $RecurringRulesTable(this);
+  late final $RecurringOccurrencesTable recurringOccurrences =
+      $RecurringOccurrencesTable(this);
+  late final $JobQueueTable jobQueue = $JobQueueTable(this);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
@@ -2847,6 +4687,9 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     transactions,
     outboxEntries,
     profiles,
+    recurringRules,
+    recurringOccurrences,
+    jobQueue,
   ];
   @override
   StreamQueryUpdateRules get streamUpdateRules => const StreamQueryUpdateRules([
@@ -2863,6 +4706,20 @@ abstract class _$AppDatabase extends GeneratedDatabase {
         limitUpdateKind: UpdateKind.delete,
       ),
       result: [TableUpdate('transactions', kind: UpdateKind.update)],
+    ),
+    WritePropagation(
+      on: TableUpdateQuery.onTableName(
+        'accounts',
+        limitUpdateKind: UpdateKind.delete,
+      ),
+      result: [TableUpdate('recurring_rules', kind: UpdateKind.delete)],
+    ),
+    WritePropagation(
+      on: TableUpdateQuery.onTableName(
+        'recurring_rules',
+        limitUpdateKind: UpdateKind.delete,
+      ),
+      result: [TableUpdate('recurring_occurrences', kind: UpdateKind.delete)],
     ),
   ]);
 }
@@ -2909,6 +4766,27 @@ final class $$AccountsTableReferences
     ).filter((f) => f.accountId.id.sqlEquals($_itemColumn<String>('id')!));
 
     final cache = $_typedResult.readTableOrNull(_transactionsRefsTable($_db));
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: cache),
+    );
+  }
+
+  static MultiTypedResultKey<$RecurringRulesTable, List<RecurringRuleRow>>
+  _recurringRulesRefsTable(_$AppDatabase db) => MultiTypedResultKey.fromTable(
+    db.recurringRules,
+    aliasName: $_aliasNameGenerator(
+      db.accounts.id,
+      db.recurringRules.accountId,
+    ),
+  );
+
+  $$RecurringRulesTableProcessedTableManager get recurringRulesRefs {
+    final manager = $$RecurringRulesTableTableManager(
+      $_db,
+      $_db.recurringRules,
+    ).filter((f) => f.accountId.id.sqlEquals($_itemColumn<String>('id')!));
+
+    final cache = $_typedResult.readTableOrNull(_recurringRulesRefsTable($_db));
     return ProcessedTableManager(
       manager.$state.copyWith(prefetchedData: cache),
     );
@@ -2980,6 +4858,31 @@ class $$AccountsTableFilterComposer
           }) => $$TransactionsTableFilterComposer(
             $db: $db,
             $table: $db.transactions,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
+
+  Expression<bool> recurringRulesRefs(
+    Expression<bool> Function($$RecurringRulesTableFilterComposer f) f,
+  ) {
+    final $$RecurringRulesTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.recurringRules,
+      getReferencedColumn: (t) => t.accountId,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$RecurringRulesTableFilterComposer(
+            $db: $db,
+            $table: $db.recurringRules,
             $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
             joinBuilder: joinBuilder,
             $removeJoinBuilderFromRootComposer:
@@ -3097,6 +5000,31 @@ class $$AccountsTableAnnotationComposer
     );
     return f(composer);
   }
+
+  Expression<T> recurringRulesRefs<T extends Object>(
+    Expression<T> Function($$RecurringRulesTableAnnotationComposer a) f,
+  ) {
+    final $$RecurringRulesTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.recurringRules,
+      getReferencedColumn: (t) => t.accountId,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$RecurringRulesTableAnnotationComposer(
+            $db: $db,
+            $table: $db.recurringRules,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
 }
 
 class $$AccountsTableTableManager
@@ -3112,7 +5040,10 @@ class $$AccountsTableTableManager
           $$AccountsTableUpdateCompanionBuilder,
           (AccountRow, $$AccountsTableReferences),
           AccountRow,
-          PrefetchHooks Function({bool transactionsRefs})
+          PrefetchHooks Function({
+            bool transactionsRefs,
+            bool recurringRulesRefs,
+          })
         > {
   $$AccountsTableTableManager(_$AppDatabase db, $AccountsTable table)
     : super(
@@ -3177,35 +5108,63 @@ class $$AccountsTableTableManager
                 ),
               )
               .toList(),
-          prefetchHooksCallback: ({transactionsRefs = false}) {
-            return PrefetchHooks(
-              db: db,
-              explicitlyWatchedTables: [if (transactionsRefs) db.transactions],
-              addJoins: null,
-              getPrefetchedDataCallback: (items) async {
-                return [
-                  if (transactionsRefs)
-                    await $_getPrefetchedData<
-                      AccountRow,
-                      $AccountsTable,
-                      TransactionRow
-                    >(
-                      currentTable: table,
-                      referencedTable: $$AccountsTableReferences
-                          ._transactionsRefsTable(db),
-                      managerFromTypedResult: (p0) => $$AccountsTableReferences(
-                        db,
-                        table,
-                        p0,
-                      ).transactionsRefs,
-                      referencedItemsForCurrentItem: (item, referencedItems) =>
-                          referencedItems.where((e) => e.accountId == item.id),
-                      typedResults: items,
-                    ),
-                ];
+          prefetchHooksCallback:
+              ({transactionsRefs = false, recurringRulesRefs = false}) {
+                return PrefetchHooks(
+                  db: db,
+                  explicitlyWatchedTables: [
+                    if (transactionsRefs) db.transactions,
+                    if (recurringRulesRefs) db.recurringRules,
+                  ],
+                  addJoins: null,
+                  getPrefetchedDataCallback: (items) async {
+                    return [
+                      if (transactionsRefs)
+                        await $_getPrefetchedData<
+                          AccountRow,
+                          $AccountsTable,
+                          TransactionRow
+                        >(
+                          currentTable: table,
+                          referencedTable: $$AccountsTableReferences
+                              ._transactionsRefsTable(db),
+                          managerFromTypedResult: (p0) =>
+                              $$AccountsTableReferences(
+                                db,
+                                table,
+                                p0,
+                              ).transactionsRefs,
+                          referencedItemsForCurrentItem:
+                              (item, referencedItems) => referencedItems.where(
+                                (e) => e.accountId == item.id,
+                              ),
+                          typedResults: items,
+                        ),
+                      if (recurringRulesRefs)
+                        await $_getPrefetchedData<
+                          AccountRow,
+                          $AccountsTable,
+                          RecurringRuleRow
+                        >(
+                          currentTable: table,
+                          referencedTable: $$AccountsTableReferences
+                              ._recurringRulesRefsTable(db),
+                          managerFromTypedResult: (p0) =>
+                              $$AccountsTableReferences(
+                                db,
+                                table,
+                                p0,
+                              ).recurringRulesRefs,
+                          referencedItemsForCurrentItem:
+                              (item, referencedItems) => referencedItems.where(
+                                (e) => e.accountId == item.id,
+                              ),
+                          typedResults: items,
+                        ),
+                    ];
+                  },
+                );
               },
-            );
-          },
         ),
       );
 }
@@ -3222,7 +5181,7 @@ typedef $$AccountsTableProcessedTableManager =
       $$AccountsTableUpdateCompanionBuilder,
       (AccountRow, $$AccountsTableReferences),
       AccountRow,
-      PrefetchHooks Function({bool transactionsRefs})
+      PrefetchHooks Function({bool transactionsRefs, bool recurringRulesRefs})
     >;
 typedef $$CategoriesTableCreateCompanionBuilder =
     CategoriesCompanion Function({
@@ -4653,6 +6612,1264 @@ typedef $$ProfilesTableProcessedTableManager =
       ProfileRow,
       PrefetchHooks Function()
     >;
+typedef $$RecurringRulesTableCreateCompanionBuilder =
+    RecurringRulesCompanion Function({
+      required String id,
+      required String title,
+      required String accountId,
+      required double amount,
+      required String currency,
+      required DateTime startAt,
+      required String timezone,
+      required String rrule,
+      Value<DateTime?> endAt,
+      Value<String?> notes,
+      Value<bool> isActive,
+      Value<bool> autoPost,
+      Value<int?> reminderMinutesBefore,
+      Value<String> shortMonthPolicy,
+      Value<DateTime> createdAt,
+      Value<DateTime> updatedAt,
+      Value<int> rowid,
+    });
+typedef $$RecurringRulesTableUpdateCompanionBuilder =
+    RecurringRulesCompanion Function({
+      Value<String> id,
+      Value<String> title,
+      Value<String> accountId,
+      Value<double> amount,
+      Value<String> currency,
+      Value<DateTime> startAt,
+      Value<String> timezone,
+      Value<String> rrule,
+      Value<DateTime?> endAt,
+      Value<String?> notes,
+      Value<bool> isActive,
+      Value<bool> autoPost,
+      Value<int?> reminderMinutesBefore,
+      Value<String> shortMonthPolicy,
+      Value<DateTime> createdAt,
+      Value<DateTime> updatedAt,
+      Value<int> rowid,
+    });
+
+final class $$RecurringRulesTableReferences
+    extends
+        BaseReferences<_$AppDatabase, $RecurringRulesTable, RecurringRuleRow> {
+  $$RecurringRulesTableReferences(
+    super.$_db,
+    super.$_table,
+    super.$_typedResult,
+  );
+
+  static $AccountsTable _accountIdTable(_$AppDatabase db) =>
+      db.accounts.createAlias(
+        $_aliasNameGenerator(db.recurringRules.accountId, db.accounts.id),
+      );
+
+  $$AccountsTableProcessedTableManager get accountId {
+    final $_column = $_itemColumn<String>('account_id')!;
+
+    final manager = $$AccountsTableTableManager(
+      $_db,
+      $_db.accounts,
+    ).filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_accountIdTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: [item]),
+    );
+  }
+
+  static MultiTypedResultKey<
+    $RecurringOccurrencesTable,
+    List<RecurringOccurrenceRow>
+  >
+  _recurringOccurrencesRefsTable(_$AppDatabase db) =>
+      MultiTypedResultKey.fromTable(
+        db.recurringOccurrences,
+        aliasName: $_aliasNameGenerator(
+          db.recurringRules.id,
+          db.recurringOccurrences.ruleId,
+        ),
+      );
+
+  $$RecurringOccurrencesTableProcessedTableManager
+  get recurringOccurrencesRefs {
+    final manager = $$RecurringOccurrencesTableTableManager(
+      $_db,
+      $_db.recurringOccurrences,
+    ).filter((f) => f.ruleId.id.sqlEquals($_itemColumn<String>('id')!));
+
+    final cache = $_typedResult.readTableOrNull(
+      _recurringOccurrencesRefsTable($_db),
+    );
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: cache),
+    );
+  }
+}
+
+class $$RecurringRulesTableFilterComposer
+    extends Composer<_$AppDatabase, $RecurringRulesTable> {
+  $$RecurringRulesTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get title => $composableBuilder(
+    column: $table.title,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<double> get amount => $composableBuilder(
+    column: $table.amount,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get currency => $composableBuilder(
+    column: $table.currency,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get startAt => $composableBuilder(
+    column: $table.startAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get timezone => $composableBuilder(
+    column: $table.timezone,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get rrule => $composableBuilder(
+    column: $table.rrule,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get endAt => $composableBuilder(
+    column: $table.endAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get notes => $composableBuilder(
+    column: $table.notes,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get isActive => $composableBuilder(
+    column: $table.isActive,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get autoPost => $composableBuilder(
+    column: $table.autoPost,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get reminderMinutesBefore => $composableBuilder(
+    column: $table.reminderMinutesBefore,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get shortMonthPolicy => $composableBuilder(
+    column: $table.shortMonthPolicy,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  $$AccountsTableFilterComposer get accountId {
+    final $$AccountsTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.accountId,
+      referencedTable: $db.accounts,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$AccountsTableFilterComposer(
+            $db: $db,
+            $table: $db.accounts,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  Expression<bool> recurringOccurrencesRefs(
+    Expression<bool> Function($$RecurringOccurrencesTableFilterComposer f) f,
+  ) {
+    final $$RecurringOccurrencesTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.recurringOccurrences,
+      getReferencedColumn: (t) => t.ruleId,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$RecurringOccurrencesTableFilterComposer(
+            $db: $db,
+            $table: $db.recurringOccurrences,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
+}
+
+class $$RecurringRulesTableOrderingComposer
+    extends Composer<_$AppDatabase, $RecurringRulesTable> {
+  $$RecurringRulesTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get title => $composableBuilder(
+    column: $table.title,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<double> get amount => $composableBuilder(
+    column: $table.amount,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get currency => $composableBuilder(
+    column: $table.currency,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get startAt => $composableBuilder(
+    column: $table.startAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get timezone => $composableBuilder(
+    column: $table.timezone,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get rrule => $composableBuilder(
+    column: $table.rrule,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get endAt => $composableBuilder(
+    column: $table.endAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get notes => $composableBuilder(
+    column: $table.notes,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<bool> get isActive => $composableBuilder(
+    column: $table.isActive,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<bool> get autoPost => $composableBuilder(
+    column: $table.autoPost,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get reminderMinutesBefore => $composableBuilder(
+    column: $table.reminderMinutesBefore,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get shortMonthPolicy => $composableBuilder(
+    column: $table.shortMonthPolicy,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  $$AccountsTableOrderingComposer get accountId {
+    final $$AccountsTableOrderingComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.accountId,
+      referencedTable: $db.accounts,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$AccountsTableOrderingComposer(
+            $db: $db,
+            $table: $db.accounts,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$RecurringRulesTableAnnotationComposer
+    extends Composer<_$AppDatabase, $RecurringRulesTable> {
+  $$RecurringRulesTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get title =>
+      $composableBuilder(column: $table.title, builder: (column) => column);
+
+  GeneratedColumn<double> get amount =>
+      $composableBuilder(column: $table.amount, builder: (column) => column);
+
+  GeneratedColumn<String> get currency =>
+      $composableBuilder(column: $table.currency, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get startAt =>
+      $composableBuilder(column: $table.startAt, builder: (column) => column);
+
+  GeneratedColumn<String> get timezone =>
+      $composableBuilder(column: $table.timezone, builder: (column) => column);
+
+  GeneratedColumn<String> get rrule =>
+      $composableBuilder(column: $table.rrule, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get endAt =>
+      $composableBuilder(column: $table.endAt, builder: (column) => column);
+
+  GeneratedColumn<String> get notes =>
+      $composableBuilder(column: $table.notes, builder: (column) => column);
+
+  GeneratedColumn<bool> get isActive =>
+      $composableBuilder(column: $table.isActive, builder: (column) => column);
+
+  GeneratedColumn<bool> get autoPost =>
+      $composableBuilder(column: $table.autoPost, builder: (column) => column);
+
+  GeneratedColumn<int> get reminderMinutesBefore => $composableBuilder(
+    column: $table.reminderMinutesBefore,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get shortMonthPolicy => $composableBuilder(
+    column: $table.shortMonthPolicy,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<DateTime> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get updatedAt =>
+      $composableBuilder(column: $table.updatedAt, builder: (column) => column);
+
+  $$AccountsTableAnnotationComposer get accountId {
+    final $$AccountsTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.accountId,
+      referencedTable: $db.accounts,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$AccountsTableAnnotationComposer(
+            $db: $db,
+            $table: $db.accounts,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  Expression<T> recurringOccurrencesRefs<T extends Object>(
+    Expression<T> Function($$RecurringOccurrencesTableAnnotationComposer a) f,
+  ) {
+    final $$RecurringOccurrencesTableAnnotationComposer composer =
+        $composerBuilder(
+          composer: this,
+          getCurrentColumn: (t) => t.id,
+          referencedTable: $db.recurringOccurrences,
+          getReferencedColumn: (t) => t.ruleId,
+          builder:
+              (
+                joinBuilder, {
+                $addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer,
+              }) => $$RecurringOccurrencesTableAnnotationComposer(
+                $db: $db,
+                $table: $db.recurringOccurrences,
+                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+                joinBuilder: joinBuilder,
+                $removeJoinBuilderFromRootComposer:
+                    $removeJoinBuilderFromRootComposer,
+              ),
+        );
+    return f(composer);
+  }
+}
+
+class $$RecurringRulesTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $RecurringRulesTable,
+          RecurringRuleRow,
+          $$RecurringRulesTableFilterComposer,
+          $$RecurringRulesTableOrderingComposer,
+          $$RecurringRulesTableAnnotationComposer,
+          $$RecurringRulesTableCreateCompanionBuilder,
+          $$RecurringRulesTableUpdateCompanionBuilder,
+          (RecurringRuleRow, $$RecurringRulesTableReferences),
+          RecurringRuleRow,
+          PrefetchHooks Function({
+            bool accountId,
+            bool recurringOccurrencesRefs,
+          })
+        > {
+  $$RecurringRulesTableTableManager(
+    _$AppDatabase db,
+    $RecurringRulesTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$RecurringRulesTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$RecurringRulesTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$RecurringRulesTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<String> id = const Value.absent(),
+                Value<String> title = const Value.absent(),
+                Value<String> accountId = const Value.absent(),
+                Value<double> amount = const Value.absent(),
+                Value<String> currency = const Value.absent(),
+                Value<DateTime> startAt = const Value.absent(),
+                Value<String> timezone = const Value.absent(),
+                Value<String> rrule = const Value.absent(),
+                Value<DateTime?> endAt = const Value.absent(),
+                Value<String?> notes = const Value.absent(),
+                Value<bool> isActive = const Value.absent(),
+                Value<bool> autoPost = const Value.absent(),
+                Value<int?> reminderMinutesBefore = const Value.absent(),
+                Value<String> shortMonthPolicy = const Value.absent(),
+                Value<DateTime> createdAt = const Value.absent(),
+                Value<DateTime> updatedAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => RecurringRulesCompanion(
+                id: id,
+                title: title,
+                accountId: accountId,
+                amount: amount,
+                currency: currency,
+                startAt: startAt,
+                timezone: timezone,
+                rrule: rrule,
+                endAt: endAt,
+                notes: notes,
+                isActive: isActive,
+                autoPost: autoPost,
+                reminderMinutesBefore: reminderMinutesBefore,
+                shortMonthPolicy: shortMonthPolicy,
+                createdAt: createdAt,
+                updatedAt: updatedAt,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String id,
+                required String title,
+                required String accountId,
+                required double amount,
+                required String currency,
+                required DateTime startAt,
+                required String timezone,
+                required String rrule,
+                Value<DateTime?> endAt = const Value.absent(),
+                Value<String?> notes = const Value.absent(),
+                Value<bool> isActive = const Value.absent(),
+                Value<bool> autoPost = const Value.absent(),
+                Value<int?> reminderMinutesBefore = const Value.absent(),
+                Value<String> shortMonthPolicy = const Value.absent(),
+                Value<DateTime> createdAt = const Value.absent(),
+                Value<DateTime> updatedAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => RecurringRulesCompanion.insert(
+                id: id,
+                title: title,
+                accountId: accountId,
+                amount: amount,
+                currency: currency,
+                startAt: startAt,
+                timezone: timezone,
+                rrule: rrule,
+                endAt: endAt,
+                notes: notes,
+                isActive: isActive,
+                autoPost: autoPost,
+                reminderMinutesBefore: reminderMinutesBefore,
+                shortMonthPolicy: shortMonthPolicy,
+                createdAt: createdAt,
+                updatedAt: updatedAt,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map(
+                (e) => (
+                  e.readTable(table),
+                  $$RecurringRulesTableReferences(db, table, e),
+                ),
+              )
+              .toList(),
+          prefetchHooksCallback:
+              ({accountId = false, recurringOccurrencesRefs = false}) {
+                return PrefetchHooks(
+                  db: db,
+                  explicitlyWatchedTables: [
+                    if (recurringOccurrencesRefs) db.recurringOccurrences,
+                  ],
+                  addJoins:
+                      <
+                        T extends TableManagerState<
+                          dynamic,
+                          dynamic,
+                          dynamic,
+                          dynamic,
+                          dynamic,
+                          dynamic,
+                          dynamic,
+                          dynamic,
+                          dynamic,
+                          dynamic,
+                          dynamic
+                        >
+                      >(state) {
+                        if (accountId) {
+                          state =
+                              state.withJoin(
+                                    currentTable: table,
+                                    currentColumn: table.accountId,
+                                    referencedTable:
+                                        $$RecurringRulesTableReferences
+                                            ._accountIdTable(db),
+                                    referencedColumn:
+                                        $$RecurringRulesTableReferences
+                                            ._accountIdTable(db)
+                                            .id,
+                                  )
+                                  as T;
+                        }
+
+                        return state;
+                      },
+                  getPrefetchedDataCallback: (items) async {
+                    return [
+                      if (recurringOccurrencesRefs)
+                        await $_getPrefetchedData<
+                          RecurringRuleRow,
+                          $RecurringRulesTable,
+                          RecurringOccurrenceRow
+                        >(
+                          currentTable: table,
+                          referencedTable: $$RecurringRulesTableReferences
+                              ._recurringOccurrencesRefsTable(db),
+                          managerFromTypedResult: (p0) =>
+                              $$RecurringRulesTableReferences(
+                                db,
+                                table,
+                                p0,
+                              ).recurringOccurrencesRefs,
+                          referencedItemsForCurrentItem:
+                              (item, referencedItems) => referencedItems.where(
+                                (e) => e.ruleId == item.id,
+                              ),
+                          typedResults: items,
+                        ),
+                    ];
+                  },
+                );
+              },
+        ),
+      );
+}
+
+typedef $$RecurringRulesTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $RecurringRulesTable,
+      RecurringRuleRow,
+      $$RecurringRulesTableFilterComposer,
+      $$RecurringRulesTableOrderingComposer,
+      $$RecurringRulesTableAnnotationComposer,
+      $$RecurringRulesTableCreateCompanionBuilder,
+      $$RecurringRulesTableUpdateCompanionBuilder,
+      (RecurringRuleRow, $$RecurringRulesTableReferences),
+      RecurringRuleRow,
+      PrefetchHooks Function({bool accountId, bool recurringOccurrencesRefs})
+    >;
+typedef $$RecurringOccurrencesTableCreateCompanionBuilder =
+    RecurringOccurrencesCompanion Function({
+      required String id,
+      required String ruleId,
+      required DateTime dueAt,
+      required String status,
+      Value<DateTime> createdAt,
+      Value<String?> postedTxId,
+      Value<DateTime> updatedAt,
+      Value<int> rowid,
+    });
+typedef $$RecurringOccurrencesTableUpdateCompanionBuilder =
+    RecurringOccurrencesCompanion Function({
+      Value<String> id,
+      Value<String> ruleId,
+      Value<DateTime> dueAt,
+      Value<String> status,
+      Value<DateTime> createdAt,
+      Value<String?> postedTxId,
+      Value<DateTime> updatedAt,
+      Value<int> rowid,
+    });
+
+final class $$RecurringOccurrencesTableReferences
+    extends
+        BaseReferences<
+          _$AppDatabase,
+          $RecurringOccurrencesTable,
+          RecurringOccurrenceRow
+        > {
+  $$RecurringOccurrencesTableReferences(
+    super.$_db,
+    super.$_table,
+    super.$_typedResult,
+  );
+
+  static $RecurringRulesTable _ruleIdTable(_$AppDatabase db) =>
+      db.recurringRules.createAlias(
+        $_aliasNameGenerator(
+          db.recurringOccurrences.ruleId,
+          db.recurringRules.id,
+        ),
+      );
+
+  $$RecurringRulesTableProcessedTableManager get ruleId {
+    final $_column = $_itemColumn<String>('rule_id')!;
+
+    final manager = $$RecurringRulesTableTableManager(
+      $_db,
+      $_db.recurringRules,
+    ).filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_ruleIdTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: [item]),
+    );
+  }
+}
+
+class $$RecurringOccurrencesTableFilterComposer
+    extends Composer<_$AppDatabase, $RecurringOccurrencesTable> {
+  $$RecurringOccurrencesTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get dueAt => $composableBuilder(
+    column: $table.dueAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get status => $composableBuilder(
+    column: $table.status,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get postedTxId => $composableBuilder(
+    column: $table.postedTxId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  $$RecurringRulesTableFilterComposer get ruleId {
+    final $$RecurringRulesTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.ruleId,
+      referencedTable: $db.recurringRules,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$RecurringRulesTableFilterComposer(
+            $db: $db,
+            $table: $db.recurringRules,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$RecurringOccurrencesTableOrderingComposer
+    extends Composer<_$AppDatabase, $RecurringOccurrencesTable> {
+  $$RecurringOccurrencesTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get dueAt => $composableBuilder(
+    column: $table.dueAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get status => $composableBuilder(
+    column: $table.status,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get postedTxId => $composableBuilder(
+    column: $table.postedTxId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  $$RecurringRulesTableOrderingComposer get ruleId {
+    final $$RecurringRulesTableOrderingComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.ruleId,
+      referencedTable: $db.recurringRules,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$RecurringRulesTableOrderingComposer(
+            $db: $db,
+            $table: $db.recurringRules,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$RecurringOccurrencesTableAnnotationComposer
+    extends Composer<_$AppDatabase, $RecurringOccurrencesTable> {
+  $$RecurringOccurrencesTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get dueAt =>
+      $composableBuilder(column: $table.dueAt, builder: (column) => column);
+
+  GeneratedColumn<String> get status =>
+      $composableBuilder(column: $table.status, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+
+  GeneratedColumn<String> get postedTxId => $composableBuilder(
+    column: $table.postedTxId,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<DateTime> get updatedAt =>
+      $composableBuilder(column: $table.updatedAt, builder: (column) => column);
+
+  $$RecurringRulesTableAnnotationComposer get ruleId {
+    final $$RecurringRulesTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.ruleId,
+      referencedTable: $db.recurringRules,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$RecurringRulesTableAnnotationComposer(
+            $db: $db,
+            $table: $db.recurringRules,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$RecurringOccurrencesTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $RecurringOccurrencesTable,
+          RecurringOccurrenceRow,
+          $$RecurringOccurrencesTableFilterComposer,
+          $$RecurringOccurrencesTableOrderingComposer,
+          $$RecurringOccurrencesTableAnnotationComposer,
+          $$RecurringOccurrencesTableCreateCompanionBuilder,
+          $$RecurringOccurrencesTableUpdateCompanionBuilder,
+          (RecurringOccurrenceRow, $$RecurringOccurrencesTableReferences),
+          RecurringOccurrenceRow,
+          PrefetchHooks Function({bool ruleId})
+        > {
+  $$RecurringOccurrencesTableTableManager(
+    _$AppDatabase db,
+    $RecurringOccurrencesTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$RecurringOccurrencesTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$RecurringOccurrencesTableOrderingComposer(
+                $db: db,
+                $table: table,
+              ),
+          createComputedFieldComposer: () =>
+              $$RecurringOccurrencesTableAnnotationComposer(
+                $db: db,
+                $table: table,
+              ),
+          updateCompanionCallback:
+              ({
+                Value<String> id = const Value.absent(),
+                Value<String> ruleId = const Value.absent(),
+                Value<DateTime> dueAt = const Value.absent(),
+                Value<String> status = const Value.absent(),
+                Value<DateTime> createdAt = const Value.absent(),
+                Value<String?> postedTxId = const Value.absent(),
+                Value<DateTime> updatedAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => RecurringOccurrencesCompanion(
+                id: id,
+                ruleId: ruleId,
+                dueAt: dueAt,
+                status: status,
+                createdAt: createdAt,
+                postedTxId: postedTxId,
+                updatedAt: updatedAt,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String id,
+                required String ruleId,
+                required DateTime dueAt,
+                required String status,
+                Value<DateTime> createdAt = const Value.absent(),
+                Value<String?> postedTxId = const Value.absent(),
+                Value<DateTime> updatedAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => RecurringOccurrencesCompanion.insert(
+                id: id,
+                ruleId: ruleId,
+                dueAt: dueAt,
+                status: status,
+                createdAt: createdAt,
+                postedTxId: postedTxId,
+                updatedAt: updatedAt,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map(
+                (e) => (
+                  e.readTable(table),
+                  $$RecurringOccurrencesTableReferences(db, table, e),
+                ),
+              )
+              .toList(),
+          prefetchHooksCallback: ({ruleId = false}) {
+            return PrefetchHooks(
+              db: db,
+              explicitlyWatchedTables: [],
+              addJoins:
+                  <
+                    T extends TableManagerState<
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic
+                    >
+                  >(state) {
+                    if (ruleId) {
+                      state =
+                          state.withJoin(
+                                currentTable: table,
+                                currentColumn: table.ruleId,
+                                referencedTable:
+                                    $$RecurringOccurrencesTableReferences
+                                        ._ruleIdTable(db),
+                                referencedColumn:
+                                    $$RecurringOccurrencesTableReferences
+                                        ._ruleIdTable(db)
+                                        .id,
+                              )
+                              as T;
+                    }
+
+                    return state;
+                  },
+              getPrefetchedDataCallback: (items) async {
+                return [];
+              },
+            );
+          },
+        ),
+      );
+}
+
+typedef $$RecurringOccurrencesTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $RecurringOccurrencesTable,
+      RecurringOccurrenceRow,
+      $$RecurringOccurrencesTableFilterComposer,
+      $$RecurringOccurrencesTableOrderingComposer,
+      $$RecurringOccurrencesTableAnnotationComposer,
+      $$RecurringOccurrencesTableCreateCompanionBuilder,
+      $$RecurringOccurrencesTableUpdateCompanionBuilder,
+      (RecurringOccurrenceRow, $$RecurringOccurrencesTableReferences),
+      RecurringOccurrenceRow,
+      PrefetchHooks Function({bool ruleId})
+    >;
+typedef $$JobQueueTableCreateCompanionBuilder =
+    JobQueueCompanion Function({
+      Value<int> id,
+      required String type,
+      required String payload,
+      required DateTime runAt,
+      Value<int> attempts,
+      Value<DateTime> createdAt,
+      Value<String?> lastError,
+    });
+typedef $$JobQueueTableUpdateCompanionBuilder =
+    JobQueueCompanion Function({
+      Value<int> id,
+      Value<String> type,
+      Value<String> payload,
+      Value<DateTime> runAt,
+      Value<int> attempts,
+      Value<DateTime> createdAt,
+      Value<String?> lastError,
+    });
+
+class $$JobQueueTableFilterComposer
+    extends Composer<_$AppDatabase, $JobQueueTable> {
+  $$JobQueueTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get type => $composableBuilder(
+    column: $table.type,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get payload => $composableBuilder(
+    column: $table.payload,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get runAt => $composableBuilder(
+    column: $table.runAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get attempts => $composableBuilder(
+    column: $table.attempts,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get lastError => $composableBuilder(
+    column: $table.lastError,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$JobQueueTableOrderingComposer
+    extends Composer<_$AppDatabase, $JobQueueTable> {
+  $$JobQueueTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get type => $composableBuilder(
+    column: $table.type,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get payload => $composableBuilder(
+    column: $table.payload,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get runAt => $composableBuilder(
+    column: $table.runAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get attempts => $composableBuilder(
+    column: $table.attempts,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get lastError => $composableBuilder(
+    column: $table.lastError,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$JobQueueTableAnnotationComposer
+    extends Composer<_$AppDatabase, $JobQueueTable> {
+  $$JobQueueTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get type =>
+      $composableBuilder(column: $table.type, builder: (column) => column);
+
+  GeneratedColumn<String> get payload =>
+      $composableBuilder(column: $table.payload, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get runAt =>
+      $composableBuilder(column: $table.runAt, builder: (column) => column);
+
+  GeneratedColumn<int> get attempts =>
+      $composableBuilder(column: $table.attempts, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+
+  GeneratedColumn<String> get lastError =>
+      $composableBuilder(column: $table.lastError, builder: (column) => column);
+}
+
+class $$JobQueueTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $JobQueueTable,
+          JobQueueRow,
+          $$JobQueueTableFilterComposer,
+          $$JobQueueTableOrderingComposer,
+          $$JobQueueTableAnnotationComposer,
+          $$JobQueueTableCreateCompanionBuilder,
+          $$JobQueueTableUpdateCompanionBuilder,
+          (
+            JobQueueRow,
+            BaseReferences<_$AppDatabase, $JobQueueTable, JobQueueRow>,
+          ),
+          JobQueueRow,
+          PrefetchHooks Function()
+        > {
+  $$JobQueueTableTableManager(_$AppDatabase db, $JobQueueTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$JobQueueTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$JobQueueTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$JobQueueTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                Value<String> type = const Value.absent(),
+                Value<String> payload = const Value.absent(),
+                Value<DateTime> runAt = const Value.absent(),
+                Value<int> attempts = const Value.absent(),
+                Value<DateTime> createdAt = const Value.absent(),
+                Value<String?> lastError = const Value.absent(),
+              }) => JobQueueCompanion(
+                id: id,
+                type: type,
+                payload: payload,
+                runAt: runAt,
+                attempts: attempts,
+                createdAt: createdAt,
+                lastError: lastError,
+              ),
+          createCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                required String type,
+                required String payload,
+                required DateTime runAt,
+                Value<int> attempts = const Value.absent(),
+                Value<DateTime> createdAt = const Value.absent(),
+                Value<String?> lastError = const Value.absent(),
+              }) => JobQueueCompanion.insert(
+                id: id,
+                type: type,
+                payload: payload,
+                runAt: runAt,
+                attempts: attempts,
+                createdAt: createdAt,
+                lastError: lastError,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$JobQueueTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $JobQueueTable,
+      JobQueueRow,
+      $$JobQueueTableFilterComposer,
+      $$JobQueueTableOrderingComposer,
+      $$JobQueueTableAnnotationComposer,
+      $$JobQueueTableCreateCompanionBuilder,
+      $$JobQueueTableUpdateCompanionBuilder,
+      (JobQueueRow, BaseReferences<_$AppDatabase, $JobQueueTable, JobQueueRow>),
+      JobQueueRow,
+      PrefetchHooks Function()
+    >;
 
 class $AppDatabaseManager {
   final _$AppDatabase _db;
@@ -4667,4 +7884,10 @@ class $AppDatabaseManager {
       $$OutboxEntriesTableTableManager(_db, _db.outboxEntries);
   $$ProfilesTableTableManager get profiles =>
       $$ProfilesTableTableManager(_db, _db.profiles);
+  $$RecurringRulesTableTableManager get recurringRules =>
+      $$RecurringRulesTableTableManager(_db, _db.recurringRules);
+  $$RecurringOccurrencesTableTableManager get recurringOccurrences =>
+      $$RecurringOccurrencesTableTableManager(_db, _db.recurringOccurrences);
+  $$JobQueueTableTableManager get jobQueue =>
+      $$JobQueueTableTableManager(_db, _db.jobQueue);
 }

--- a/lib/core/di/injectors.g.dart
+++ b/lib/core/di/injectors.g.dart
@@ -552,6 +552,281 @@ final class ProfileDaoProvider
 
 String _$profileDaoHash() => r'c4fb55deddb24b0dabbb189a18f0e68e259be21c';
 
+@ProviderFor(recurringRuleDao)
+const recurringRuleDaoProvider = RecurringRuleDaoProvider._();
+
+final class RecurringRuleDaoProvider
+    extends
+        $FunctionalProvider<
+          RecurringRuleDao,
+          RecurringRuleDao,
+          RecurringRuleDao
+        >
+    with $Provider<RecurringRuleDao> {
+  const RecurringRuleDaoProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'recurringRuleDaoProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$recurringRuleDaoHash();
+
+  @$internal
+  @override
+  $ProviderElement<RecurringRuleDao> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  RecurringRuleDao create(Ref ref) {
+    return recurringRuleDao(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(RecurringRuleDao value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<RecurringRuleDao>(value),
+    );
+  }
+}
+
+String _$recurringRuleDaoHash() => r'83f2440661655833dfdecc3692fa2232037927b2';
+
+@ProviderFor(recurringOccurrenceDao)
+const recurringOccurrenceDaoProvider = RecurringOccurrenceDaoProvider._();
+
+final class RecurringOccurrenceDaoProvider
+    extends
+        $FunctionalProvider<
+          RecurringOccurrenceDao,
+          RecurringOccurrenceDao,
+          RecurringOccurrenceDao
+        >
+    with $Provider<RecurringOccurrenceDao> {
+  const RecurringOccurrenceDaoProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'recurringOccurrenceDaoProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$recurringOccurrenceDaoHash();
+
+  @$internal
+  @override
+  $ProviderElement<RecurringOccurrenceDao> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  RecurringOccurrenceDao create(Ref ref) {
+    return recurringOccurrenceDao(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(RecurringOccurrenceDao value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<RecurringOccurrenceDao>(value),
+    );
+  }
+}
+
+String _$recurringOccurrenceDaoHash() =>
+    r'396b8cbeb1142f8c5ecaba5af6c8d40f7a98a99c';
+
+@ProviderFor(jobQueueDao)
+const jobQueueDaoProvider = JobQueueDaoProvider._();
+
+final class JobQueueDaoProvider
+    extends $FunctionalProvider<JobQueueDao, JobQueueDao, JobQueueDao>
+    with $Provider<JobQueueDao> {
+  const JobQueueDaoProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'jobQueueDaoProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$jobQueueDaoHash();
+
+  @$internal
+  @override
+  $ProviderElement<JobQueueDao> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  JobQueueDao create(Ref ref) {
+    return jobQueueDao(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(JobQueueDao value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<JobQueueDao>(value),
+    );
+  }
+}
+
+String _$jobQueueDaoHash() => r'8c93af9c3b09afed591a9c33c68b501b7878a2c9';
+
+@ProviderFor(flutterLocalNotificationsPlugin)
+const flutterLocalNotificationsPluginProvider =
+    FlutterLocalNotificationsPluginProvider._();
+
+final class FlutterLocalNotificationsPluginProvider
+    extends
+        $FunctionalProvider<
+          FlutterLocalNotificationsPlugin,
+          FlutterLocalNotificationsPlugin,
+          FlutterLocalNotificationsPlugin
+        >
+    with $Provider<FlutterLocalNotificationsPlugin> {
+  const FlutterLocalNotificationsPluginProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'flutterLocalNotificationsPluginProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$flutterLocalNotificationsPluginHash();
+
+  @$internal
+  @override
+  $ProviderElement<FlutterLocalNotificationsPlugin> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  FlutterLocalNotificationsPlugin create(Ref ref) {
+    return flutterLocalNotificationsPlugin(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(FlutterLocalNotificationsPlugin value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<FlutterLocalNotificationsPlugin>(
+        value,
+      ),
+    );
+  }
+}
+
+String _$flutterLocalNotificationsPluginHash() =>
+    r'270976c2447345deefd91efb7ccfc64878e707f4';
+
+@ProviderFor(workmanager)
+const workmanagerProvider = WorkmanagerProvider._();
+
+final class WorkmanagerProvider
+    extends $FunctionalProvider<Workmanager, Workmanager, Workmanager>
+    with $Provider<Workmanager> {
+  const WorkmanagerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'workmanagerProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$workmanagerHash();
+
+  @$internal
+  @override
+  $ProviderElement<Workmanager> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  Workmanager create(Ref ref) {
+    return workmanager(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(Workmanager value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<Workmanager>(value),
+    );
+  }
+}
+
+String _$workmanagerHash() => r'884c489ccf3eeb94f5d425cc7ab546b9bf48747e';
+
+@ProviderFor(recurringRuleEngine)
+const recurringRuleEngineProvider = RecurringRuleEngineProvider._();
+
+final class RecurringRuleEngineProvider
+    extends
+        $FunctionalProvider<
+          RecurringRuleEngine,
+          RecurringRuleEngine,
+          RecurringRuleEngine
+        >
+    with $Provider<RecurringRuleEngine> {
+  const RecurringRuleEngineProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'recurringRuleEngineProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$recurringRuleEngineHash();
+
+  @$internal
+  @override
+  $ProviderElement<RecurringRuleEngine> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  RecurringRuleEngine create(Ref ref) {
+    return recurringRuleEngine(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(RecurringRuleEngine value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<RecurringRuleEngine>(value),
+    );
+  }
+}
+
+String _$recurringRuleEngineHash() =>
+    r'94d207ac7439ca6dcb8f24b9d37a5644705d6c6a';
+
 @ProviderFor(accountRemoteDataSource)
 const accountRemoteDataSourceProvider = AccountRemoteDataSourceProvider._();
 
@@ -744,6 +1019,55 @@ final class ProfileRemoteDataSourceProvider
 
 String _$profileRemoteDataSourceHash() =>
     r'45baf2527988bcc7389803c7cea36c9fa578effb';
+
+@ProviderFor(recurringNotificationService)
+const recurringNotificationServiceProvider =
+    RecurringNotificationServiceProvider._();
+
+final class RecurringNotificationServiceProvider
+    extends
+        $FunctionalProvider<
+          RecurringNotificationService,
+          RecurringNotificationService,
+          RecurringNotificationService
+        >
+    with $Provider<RecurringNotificationService> {
+  const RecurringNotificationServiceProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'recurringNotificationServiceProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$recurringNotificationServiceHash();
+
+  @$internal
+  @override
+  $ProviderElement<RecurringNotificationService> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  RecurringNotificationService create(Ref ref) {
+    return recurringNotificationService(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(RecurringNotificationService value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<RecurringNotificationService>(value),
+    );
+  }
+}
+
+String _$recurringNotificationServiceHash() =>
+    r'9c3e7734b39e24acdb8e7b72c6414d5a29ec3564';
 
 @ProviderFor(accountRepository)
 const accountRepositoryProvider = AccountRepositoryProvider._();
@@ -1079,6 +1403,57 @@ final class TransactionRepositoryProvider
 String _$transactionRepositoryHash() =>
     r'3799c3525d6954f2ece515445c06171d0fba71ef';
 
+@ProviderFor(recurringTransactionsRepository)
+const recurringTransactionsRepositoryProvider =
+    RecurringTransactionsRepositoryProvider._();
+
+final class RecurringTransactionsRepositoryProvider
+    extends
+        $FunctionalProvider<
+          RecurringTransactionsRepository,
+          RecurringTransactionsRepository,
+          RecurringTransactionsRepository
+        >
+    with $Provider<RecurringTransactionsRepository> {
+  const RecurringTransactionsRepositoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'recurringTransactionsRepositoryProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$recurringTransactionsRepositoryHash();
+
+  @$internal
+  @override
+  $ProviderElement<RecurringTransactionsRepository> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  RecurringTransactionsRepository create(Ref ref) {
+    return recurringTransactionsRepository(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(RecurringTransactionsRepository value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<RecurringTransactionsRepository>(
+        value,
+      ),
+    );
+  }
+}
+
+String _$recurringTransactionsRepositoryHash() =>
+    r'a537392d0484d7b3922a92f905ced3e6a3cbb7ec';
+
 @ProviderFor(watchAccountTransactionsUseCase)
 const watchAccountTransactionsUseCaseProvider =
     WatchAccountTransactionsUseCaseProvider._();
@@ -1229,6 +1604,397 @@ final class WatchMonthlyAnalyticsUseCaseProvider
 
 String _$watchMonthlyAnalyticsUseCaseHash() =>
     r'f1d7c52a9a4fc256b1bd3ae0fff4e7e8666f58e9';
+
+@ProviderFor(watchRecurringRulesUseCase)
+const watchRecurringRulesUseCaseProvider =
+    WatchRecurringRulesUseCaseProvider._();
+
+final class WatchRecurringRulesUseCaseProvider
+    extends
+        $FunctionalProvider<
+          WatchRecurringRulesUseCase,
+          WatchRecurringRulesUseCase,
+          WatchRecurringRulesUseCase
+        >
+    with $Provider<WatchRecurringRulesUseCase> {
+  const WatchRecurringRulesUseCaseProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'watchRecurringRulesUseCaseProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$watchRecurringRulesUseCaseHash();
+
+  @$internal
+  @override
+  $ProviderElement<WatchRecurringRulesUseCase> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  WatchRecurringRulesUseCase create(Ref ref) {
+    return watchRecurringRulesUseCase(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(WatchRecurringRulesUseCase value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<WatchRecurringRulesUseCase>(value),
+    );
+  }
+}
+
+String _$watchRecurringRulesUseCaseHash() =>
+    r'9cb754ec24ae0c6d8f780d6ebee2f1541b3a42a6';
+
+@ProviderFor(watchUpcomingOccurrencesUseCase)
+const watchUpcomingOccurrencesUseCaseProvider =
+    WatchUpcomingOccurrencesUseCaseProvider._();
+
+final class WatchUpcomingOccurrencesUseCaseProvider
+    extends
+        $FunctionalProvider<
+          WatchUpcomingOccurrencesUseCase,
+          WatchUpcomingOccurrencesUseCase,
+          WatchUpcomingOccurrencesUseCase
+        >
+    with $Provider<WatchUpcomingOccurrencesUseCase> {
+  const WatchUpcomingOccurrencesUseCaseProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'watchUpcomingOccurrencesUseCaseProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$watchUpcomingOccurrencesUseCaseHash();
+
+  @$internal
+  @override
+  $ProviderElement<WatchUpcomingOccurrencesUseCase> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  WatchUpcomingOccurrencesUseCase create(Ref ref) {
+    return watchUpcomingOccurrencesUseCase(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(WatchUpcomingOccurrencesUseCase value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<WatchUpcomingOccurrencesUseCase>(
+        value,
+      ),
+    );
+  }
+}
+
+String _$watchUpcomingOccurrencesUseCaseHash() =>
+    r'19f730a003788f792fb58d296f233536fdba9da7';
+
+@ProviderFor(saveRecurringRuleUseCase)
+const saveRecurringRuleUseCaseProvider = SaveRecurringRuleUseCaseProvider._();
+
+final class SaveRecurringRuleUseCaseProvider
+    extends
+        $FunctionalProvider<
+          SaveRecurringRuleUseCase,
+          SaveRecurringRuleUseCase,
+          SaveRecurringRuleUseCase
+        >
+    with $Provider<SaveRecurringRuleUseCase> {
+  const SaveRecurringRuleUseCaseProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'saveRecurringRuleUseCaseProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$saveRecurringRuleUseCaseHash();
+
+  @$internal
+  @override
+  $ProviderElement<SaveRecurringRuleUseCase> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  SaveRecurringRuleUseCase create(Ref ref) {
+    return saveRecurringRuleUseCase(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(SaveRecurringRuleUseCase value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<SaveRecurringRuleUseCase>(value),
+    );
+  }
+}
+
+String _$saveRecurringRuleUseCaseHash() =>
+    r'31453a9183048468b64f4a5241ff547c50fcb185';
+
+@ProviderFor(deleteRecurringRuleUseCase)
+const deleteRecurringRuleUseCaseProvider =
+    DeleteRecurringRuleUseCaseProvider._();
+
+final class DeleteRecurringRuleUseCaseProvider
+    extends
+        $FunctionalProvider<
+          DeleteRecurringRuleUseCase,
+          DeleteRecurringRuleUseCase,
+          DeleteRecurringRuleUseCase
+        >
+    with $Provider<DeleteRecurringRuleUseCase> {
+  const DeleteRecurringRuleUseCaseProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'deleteRecurringRuleUseCaseProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$deleteRecurringRuleUseCaseHash();
+
+  @$internal
+  @override
+  $ProviderElement<DeleteRecurringRuleUseCase> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  DeleteRecurringRuleUseCase create(Ref ref) {
+    return deleteRecurringRuleUseCase(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(DeleteRecurringRuleUseCase value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<DeleteRecurringRuleUseCase>(value),
+    );
+  }
+}
+
+String _$deleteRecurringRuleUseCaseHash() =>
+    r'f0e6197890075b16f2babaaafa0340dbed2309d5';
+
+@ProviderFor(toggleRecurringRuleUseCase)
+const toggleRecurringRuleUseCaseProvider =
+    ToggleRecurringRuleUseCaseProvider._();
+
+final class ToggleRecurringRuleUseCaseProvider
+    extends
+        $FunctionalProvider<
+          ToggleRecurringRuleUseCase,
+          ToggleRecurringRuleUseCase,
+          ToggleRecurringRuleUseCase
+        >
+    with $Provider<ToggleRecurringRuleUseCase> {
+  const ToggleRecurringRuleUseCaseProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'toggleRecurringRuleUseCaseProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$toggleRecurringRuleUseCaseHash();
+
+  @$internal
+  @override
+  $ProviderElement<ToggleRecurringRuleUseCase> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  ToggleRecurringRuleUseCase create(Ref ref) {
+    return toggleRecurringRuleUseCase(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(ToggleRecurringRuleUseCase value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<ToggleRecurringRuleUseCase>(value),
+    );
+  }
+}
+
+String _$toggleRecurringRuleUseCaseHash() =>
+    r'e5f319d11a98dcc7e78da1c2f27a5dbc635a9b82';
+
+@ProviderFor(regenerateRuleWindowUseCase)
+const regenerateRuleWindowUseCaseProvider =
+    RegenerateRuleWindowUseCaseProvider._();
+
+final class RegenerateRuleWindowUseCaseProvider
+    extends
+        $FunctionalProvider<
+          RegenerateRuleWindowUseCase,
+          RegenerateRuleWindowUseCase,
+          RegenerateRuleWindowUseCase
+        >
+    with $Provider<RegenerateRuleWindowUseCase> {
+  const RegenerateRuleWindowUseCaseProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'regenerateRuleWindowUseCaseProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$regenerateRuleWindowUseCaseHash();
+
+  @$internal
+  @override
+  $ProviderElement<RegenerateRuleWindowUseCase> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  RegenerateRuleWindowUseCase create(Ref ref) {
+    return regenerateRuleWindowUseCase(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(RegenerateRuleWindowUseCase value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<RegenerateRuleWindowUseCase>(value),
+    );
+  }
+}
+
+String _$regenerateRuleWindowUseCaseHash() =>
+    r'b2d6210dffdbeeb1d866fcf550d576a5cdb0d6aa';
+
+@ProviderFor(recurringWindowService)
+const recurringWindowServiceProvider = RecurringWindowServiceProvider._();
+
+final class RecurringWindowServiceProvider
+    extends
+        $FunctionalProvider<
+          RecurringWindowService,
+          RecurringWindowService,
+          RecurringWindowService
+        >
+    with $Provider<RecurringWindowService> {
+  const RecurringWindowServiceProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'recurringWindowServiceProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$recurringWindowServiceHash();
+
+  @$internal
+  @override
+  $ProviderElement<RecurringWindowService> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  RecurringWindowService create(Ref ref) {
+    return recurringWindowService(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(RecurringWindowService value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<RecurringWindowService>(value),
+    );
+  }
+}
+
+String _$recurringWindowServiceHash() =>
+    r'66de8c0084f13ae4fb53f7a45cc0135d21c42738';
+
+@ProviderFor(recurringWorkScheduler)
+const recurringWorkSchedulerProvider = RecurringWorkSchedulerProvider._();
+
+final class RecurringWorkSchedulerProvider
+    extends
+        $FunctionalProvider<
+          RecurringWorkScheduler,
+          RecurringWorkScheduler,
+          RecurringWorkScheduler
+        >
+    with $Provider<RecurringWorkScheduler> {
+  const RecurringWorkSchedulerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'recurringWorkSchedulerProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$recurringWorkSchedulerHash();
+
+  @$internal
+  @override
+  $ProviderElement<RecurringWorkScheduler> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  RecurringWorkScheduler create(Ref ref) {
+    return recurringWorkScheduler(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(RecurringWorkScheduler value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<RecurringWorkScheduler>(value),
+    );
+  }
+}
+
+String _$recurringWorkSchedulerHash() =>
+    r'd74ce3d07b58943fffafbe929e3577de776b45bd';
 
 @ProviderFor(profileRepository)
 const profileRepositoryProvider = ProfileRepositoryProvider._();

--- a/lib/features/recurring_transactions/data/repositories/recurring_transactions_repository_impl.dart
+++ b/lib/features/recurring_transactions/data/repositories/recurring_transactions_repository_impl.dart
@@ -1,0 +1,201 @@
+import 'package:kopim/features/recurring_transactions/data/sources/local/job_queue_dao.dart';
+import 'package:kopim/features/recurring_transactions/data/sources/local/recurring_occurrence_dao.dart';
+import 'package:kopim/features/recurring_transactions/data/sources/local/recurring_rule_dao.dart';
+import 'package:kopim/features/recurring_transactions/domain/entities/recurring_job.dart';
+import 'package:kopim/features/recurring_transactions/domain/entities/recurring_occurrence.dart';
+import 'package:kopim/features/recurring_transactions/domain/entities/recurring_rule.dart';
+import 'package:kopim/features/recurring_transactions/domain/repositories/recurring_transactions_repository.dart';
+import 'package:kopim/core/data/database.dart' as db;
+
+class RecurringTransactionsRepositoryImpl
+    implements RecurringTransactionsRepository {
+  RecurringTransactionsRepositoryImpl({
+    required RecurringRuleDao ruleDao,
+    required RecurringOccurrenceDao occurrenceDao,
+    required JobQueueDao jobQueueDao,
+    required db.AppDatabase database,
+  }) : _ruleDao = ruleDao,
+       _occurrenceDao = occurrenceDao,
+       _jobQueueDao = jobQueueDao,
+       _database = database;
+
+  final RecurringRuleDao _ruleDao;
+  final RecurringOccurrenceDao _occurrenceDao;
+  final JobQueueDao _jobQueueDao;
+  final db.AppDatabase _database;
+
+  @override
+  Stream<List<RecurringRule>> watchRules() {
+    return _ruleDao.watchAll().map((List<db.RecurringRuleRow> rows) {
+      return rows.map(_mapRuleRowToEntity).toList();
+    });
+  }
+
+  @override
+  Stream<List<RecurringOccurrence>> watchUpcomingOccurrences({
+    required DateTime from,
+    required DateTime to,
+  }) {
+    return _occurrenceDao
+        .watchWindow(from: from, to: to)
+        .map(
+          (List<db.RecurringOccurrenceRow> rows) =>
+              rows.map(_mapOccurrenceRowToEntity).toList(),
+        );
+  }
+
+  @override
+  Stream<List<RecurringOccurrence>> watchRuleOccurrences(String ruleId) {
+    return _occurrenceDao
+        .watchRule(ruleId)
+        .map(
+          (List<db.RecurringOccurrenceRow> rows) =>
+              rows.map(_mapOccurrenceRowToEntity).toList(),
+        );
+  }
+
+  @override
+  Future<RecurringRule?> getRuleById(String id) async {
+    final db.RecurringRuleRow? row = await _ruleDao.findById(id);
+    return row == null ? null : _mapRuleRowToEntity(row);
+  }
+
+  @override
+  Future<List<RecurringRule>> getAllRules({bool activeOnly = false}) async {
+    final List<db.RecurringRuleRow> rows = await _ruleDao.getAll();
+    final Iterable<RecurringRule> mapped = rows.map(_mapRuleRowToEntity);
+    if (!activeOnly) {
+      return mapped.toList();
+    }
+    return mapped.where((RecurringRule rule) => rule.isActive).toList();
+  }
+
+  @override
+  Future<void> upsertRule(RecurringRule rule, {bool regenerateWindow = true}) {
+    final DateTime now = DateTime.now().toUtc();
+    return _ruleDao.upsert(
+      rule.copyWith(createdAt: rule.createdAt.toUtc(), updatedAt: now),
+    );
+  }
+
+  @override
+  Future<void> deleteRule(String id) async {
+    await _database.transaction(() async {
+      await _occurrenceDao.deleteForRule(id);
+      await _ruleDao.deleteById(id);
+    });
+  }
+
+  @override
+  Future<void> toggleRule({required String id, required bool isActive}) {
+    return _ruleDao.toggle(
+      id: id,
+      isActive: isActive,
+      updatedAt: DateTime.now().toUtc(),
+    );
+  }
+
+  @override
+  Future<void> saveOccurrences(
+    Iterable<RecurringOccurrence> occurrences, {
+    bool replaceExisting = false,
+  }) {
+    if (replaceExisting) {
+      if (occurrences.isEmpty) {
+        return _occurrenceDao.clearAll();
+      }
+      return _occurrenceDao.replaceOccurrences(occurrences);
+    }
+    return _occurrenceDao.upsertAll(occurrences);
+  }
+
+  @override
+  Future<void> updateOccurrenceStatus(
+    String occurrenceId,
+    RecurringOccurrenceStatus status, {
+    String? postedTxId,
+  }) {
+    return _occurrenceDao.updateStatus(
+      occurrenceId,
+      status,
+      postedTxId: postedTxId,
+      updatedAt: DateTime.now().toUtc(),
+    );
+  }
+
+  @override
+  Future<List<RecurringOccurrence>> getDueOccurrences(DateTime forDate) async {
+    final List<db.RecurringOccurrenceRow> rows = await _occurrenceDao.getDueOn(
+      forDate,
+    );
+    return rows.map(_mapOccurrenceRowToEntity).toList();
+  }
+
+  @override
+  Future<void> enqueueJob({
+    required String type,
+    required String payload,
+    required DateTime runAt,
+  }) {
+    return _jobQueueDao.enqueue(type: type, payload: payload, runAt: runAt);
+  }
+
+  @override
+  Future<void> markJobAttempt(int jobId, {String? error}) {
+    return _jobQueueDao.markAttempt(jobId, error: error);
+  }
+
+  @override
+  Stream<List<RecurringJob>> watchPendingJobs() {
+    return _jobQueueDao.watchPending().map(
+      (List<db.JobQueueRow> rows) => rows.map(_mapJobRowToEntity).toList(),
+    );
+  }
+
+  RecurringRule _mapRuleRowToEntity(db.RecurringRuleRow row) {
+    return RecurringRule(
+      id: row.id,
+      title: row.title,
+      accountId: row.accountId,
+      amount: row.amount,
+      currency: row.currency,
+      startAt: row.startAt.toUtc(),
+      timezone: row.timezone,
+      rrule: row.rrule,
+      endAt: row.endAt?.toUtc(),
+      notes: row.notes,
+      isActive: row.isActive,
+      autoPost: row.autoPost,
+      reminderMinutesBefore: row.reminderMinutesBefore,
+      shortMonthPolicy: RecurringRuleShortMonthPolicy.fromValue(
+        row.shortMonthPolicy,
+      ),
+      createdAt: row.createdAt.toUtc(),
+      updatedAt: row.updatedAt.toUtc(),
+    );
+  }
+
+  RecurringOccurrence _mapOccurrenceRowToEntity(db.RecurringOccurrenceRow row) {
+    return RecurringOccurrence(
+      id: row.id,
+      ruleId: row.ruleId,
+      dueAt: row.dueAt.toUtc(),
+      status: RecurringOccurrenceStatus.fromValue(row.status),
+      createdAt: row.createdAt.toUtc(),
+      updatedAt: row.updatedAt.toUtc(),
+      postedTxId: row.postedTxId,
+    );
+  }
+
+  RecurringJob _mapJobRowToEntity(db.JobQueueRow row) {
+    return RecurringJob(
+      id: row.id,
+      type: row.type,
+      payload: row.payload,
+      runAt: row.runAt.toUtc(),
+      attempts: row.attempts,
+      lastError: row.lastError,
+      createdAt: row.createdAt.toUtc(),
+    );
+  }
+}

--- a/lib/features/recurring_transactions/data/services/recurring_notification_service.dart
+++ b/lib/features/recurring_transactions/data/services/recurring_notification_service.dart
@@ -1,0 +1,130 @@
+import 'dart:io';
+
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:kopim/features/recurring_transactions/domain/entities/recurring_occurrence.dart';
+import 'package:kopim/features/recurring_transactions/domain/entities/recurring_rule.dart';
+import 'package:timezone/data/latest.dart' as tzdata;
+import 'package:timezone/timezone.dart' as tz;
+
+class RecurringNotificationService {
+  RecurringNotificationService(this._plugin);
+
+  final FlutterLocalNotificationsPlugin _plugin;
+  static const int _maxNotifications = 3;
+  static const int _notificationBaseId = 4100;
+  bool _initialized = false;
+
+  Future<void> initialize() async {
+    if (_initialized) return;
+    tzdata.initializeTimeZones();
+    const AndroidInitializationSettings androidInitializationSettings =
+        AndroidInitializationSettings('@mipmap/ic_launcher');
+    const DarwinInitializationSettings darwinInitializationSettings =
+        DarwinInitializationSettings();
+    const InitializationSettings settings = InitializationSettings(
+      android: androidInitializationSettings,
+      iOS: darwinInitializationSettings,
+      macOS: darwinInitializationSettings,
+    );
+    await _plugin.initialize(settings);
+    _initialized = true;
+  }
+
+  Future<bool> ensurePermissions() async {
+    if (!Platform.isAndroid) {
+      return true;
+    }
+    final AndroidFlutterLocalNotificationsPlugin? androidImplementation =
+        _plugin
+            .resolvePlatformSpecificImplementation<
+              AndroidFlutterLocalNotificationsPlugin
+            >();
+    if (androidImplementation == null) {
+      return false;
+    }
+    final bool? granted = await androidImplementation
+        .requestNotificationsPermission();
+    return granted ?? false;
+  }
+
+  Future<void> refreshNotifications({
+    required Iterable<RecurringOccurrence> occurrences,
+    required Map<String, RecurringRule> rules,
+  }) async {
+    if (!_initialized) {
+      await initialize();
+    }
+    final bool permissionGranted = await ensurePermissions();
+    if (!permissionGranted) {
+      return;
+    }
+
+    for (int i = 0; i < _maxNotifications; i++) {
+      await _plugin.cancel(_notificationBaseId + i);
+    }
+
+    final DateTime now = DateTime.now().toUtc();
+    final List<RecurringOccurrence> upcoming =
+        occurrences
+            .where(
+              (RecurringOccurrence occurrence) =>
+                  occurrence.status == RecurringOccurrenceStatus.scheduled &&
+                  occurrence.dueAt.isAfter(now),
+            )
+            .toList()
+          ..sort(
+            (RecurringOccurrence a, RecurringOccurrence b) =>
+                a.dueAt.compareTo(b.dueAt),
+          );
+
+    for (
+      int index = 0;
+      index < upcoming.length && index < _maxNotifications;
+      index++
+    ) {
+      final RecurringOccurrence occurrence = upcoming[index];
+      final RecurringRule? rule = rules[occurrence.ruleId];
+      if (rule == null) {
+        continue;
+      }
+      final tz.Location location = tz.getLocation(rule.timezone);
+      final Duration reminderOffset = Duration(
+        minutes: rule.reminderMinutesBefore ?? 0,
+      );
+      final tz.TZDateTime scheduledDate = tz.TZDateTime.from(
+        occurrence.dueAt,
+        location,
+      ).subtract(reminderOffset);
+      if (scheduledDate.isBefore(tz.TZDateTime.now(location))) {
+        continue;
+      }
+      const NotificationDetails details = NotificationDetails(
+        android: AndroidNotificationDetails(
+          'recurring_transactions',
+          'Recurring transactions',
+          channelDescription:
+              'Напоминания о предстоящих повторяющихся транзакциях',
+          category: AndroidNotificationCategory.reminder,
+          importance: Importance.max,
+          priority: Priority.high,
+        ),
+        iOS: DarwinNotificationDetails(),
+      );
+      await _plugin.zonedSchedule(
+        _notificationBaseId + index,
+        rule.title,
+        _buildBody(rule),
+        scheduledDate,
+        details,
+        androidScheduleMode: AndroidScheduleMode.inexactAllowWhileIdle,
+        payload: occurrence.id,
+        matchDateTimeComponents: null,
+      );
+    }
+  }
+
+  String _buildBody(RecurringRule rule) {
+    final String amount = rule.amount.toStringAsFixed(2);
+    return 'Списание $amount ${rule.currency} по счёту ${rule.accountId}';
+  }
+}

--- a/lib/features/recurring_transactions/data/services/recurring_window_service.dart
+++ b/lib/features/recurring_transactions/data/services/recurring_window_service.dart
@@ -1,0 +1,61 @@
+import 'package:kopim/features/recurring_transactions/data/services/recurring_notification_service.dart';
+import 'package:kopim/features/recurring_transactions/domain/entities/recurring_occurrence.dart';
+import 'package:kopim/features/recurring_transactions/domain/entities/recurring_rule.dart';
+import 'package:kopim/features/recurring_transactions/domain/repositories/recurring_transactions_repository.dart';
+import 'package:kopim/features/recurring_transactions/domain/services/recurring_rule_engine.dart';
+
+class RecurringWindowService {
+  RecurringWindowService({
+    required RecurringTransactionsRepository repository,
+    required RecurringRuleEngine engine,
+    required RecurringNotificationService notificationService,
+  }) : _repository = repository,
+       _engine = engine,
+       _notificationService = notificationService;
+
+  final RecurringTransactionsRepository _repository;
+  final RecurringRuleEngine _engine;
+  final RecurringNotificationService _notificationService;
+
+  Future<void> rebuildWindow({int monthsAhead = 6}) async {
+    final List<RecurringRule> rules = await _repository.getAllRules(
+      activeOnly: true,
+    );
+    if (rules.isEmpty) {
+      await _repository.saveOccurrences(
+        const <RecurringOccurrence>[],
+        replaceExisting: true,
+      );
+      await _notificationService.refreshNotifications(
+        occurrences: const <RecurringOccurrence>[],
+        rules: const <String, RecurringRule>{},
+      );
+      return;
+    }
+    final DateTime now = DateTime.now().toUtc();
+    final DateTime windowStart = DateTime.utc(now.year, now.month, now.day);
+    final DateTime windowEnd = DateTime.utc(
+      now.year,
+      now.month + monthsAhead,
+      now.day,
+    );
+
+    final List<RecurringOccurrence> aggregated = <RecurringOccurrence>[];
+    for (final RecurringRule rule in rules) {
+      final List<RecurringOccurrence> occurrences = await _engine
+          .generateOccurrences(
+            rule: rule,
+            windowStart: windowStart,
+            windowEnd: windowEnd,
+          );
+      aggregated.addAll(occurrences);
+    }
+    await _repository.saveOccurrences(aggregated, replaceExisting: true);
+    await _notificationService.refreshNotifications(
+      occurrences: aggregated,
+      rules: <String, RecurringRule>{
+        for (final RecurringRule rule in rules) rule.id: rule,
+      },
+    );
+  }
+}

--- a/lib/features/recurring_transactions/data/services/recurring_work_scheduler.dart
+++ b/lib/features/recurring_transactions/data/services/recurring_work_scheduler.dart
@@ -1,0 +1,225 @@
+import 'dart:io';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:kopim/core/data/database.dart';
+import 'package:kopim/core/data/outbox/outbox_dao.dart';
+import 'package:kopim/core/services/logger_service.dart';
+import 'package:kopim/features/accounts/data/repositories/account_repository_impl.dart';
+import 'package:kopim/features/accounts/data/sources/local/account_dao.dart';
+import 'package:kopim/features/accounts/domain/repositories/account_repository.dart';
+import 'package:kopim/features/recurring_transactions/data/repositories/recurring_transactions_repository_impl.dart';
+import 'package:kopim/features/recurring_transactions/data/services/recurring_notification_service.dart';
+import 'package:kopim/features/recurring_transactions/data/services/recurring_window_service.dart';
+import 'package:kopim/features/recurring_transactions/data/sources/local/job_queue_dao.dart';
+import 'package:kopim/features/recurring_transactions/data/sources/local/recurring_occurrence_dao.dart';
+import 'package:kopim/features/recurring_transactions/data/sources/local/recurring_rule_dao.dart';
+import 'package:kopim/features/recurring_transactions/domain/entities/recurring_occurrence.dart';
+import 'package:kopim/features/recurring_transactions/domain/entities/recurring_rule.dart';
+import 'package:kopim/features/recurring_transactions/domain/repositories/recurring_transactions_repository.dart';
+import 'package:kopim/features/recurring_transactions/domain/services/recurring_rule_engine.dart';
+import 'package:kopim/features/transactions/data/repositories/transaction_repository_impl.dart';
+import 'package:kopim/features/transactions/data/sources/local/transaction_dao.dart';
+import 'package:kopim/features/transactions/domain/entities/add_transaction_request.dart';
+import 'package:kopim/features/transactions/domain/entities/transaction_type.dart';
+import 'package:kopim/features/transactions/domain/repositories/transaction_repository.dart';
+import 'package:kopim/features/transactions/domain/use_cases/add_transaction_use_case.dart';
+import 'package:uuid/uuid.dart';
+import 'package:workmanager/workmanager.dart';
+
+const String kRecurringTaskGenerateWindow = 'recurring_generate_window';
+const String kRecurringTaskMaintainWindow = 'recurring_window_maintenance';
+const String kRecurringTaskPostDueOccurrences =
+    'recurring_post_due_occurrences';
+
+void recurringWorkDispatcher() {
+  Workmanager().executeTask((
+    String task,
+    Map<String, dynamic>? inputData,
+  ) async {
+    WidgetsFlutterBinding.ensureInitialized();
+    final LoggerService logger = LoggerService();
+    final AppDatabase database = AppDatabase();
+    final RecurringTransactionsRepository repository = _buildRepository(
+      database,
+    );
+    final RecurringNotificationService notificationService =
+        RecurringNotificationService(FlutterLocalNotificationsPlugin());
+    final RecurringWindowService windowService = RecurringWindowService(
+      repository: repository,
+      engine: RecurringRuleEngine(),
+      notificationService: notificationService,
+    );
+    bool success = true;
+    try {
+      switch (task) {
+        case kRecurringTaskGenerateWindow:
+        case kRecurringTaskMaintainWindow:
+          await windowService.rebuildWindow();
+          break;
+        case kRecurringTaskPostDueOccurrences:
+          await _postDueOccurrences(
+            repository: repository,
+            database: database,
+            logger: logger,
+          );
+          break;
+        default:
+          logger.logInfo('Unhandled WorkManager task: $task');
+      }
+    } catch (error, stackTrace) {
+      success = false;
+      logger.logError('Recurring task failed: $error\n$stackTrace');
+    }
+    await database.close();
+    return success;
+  });
+}
+
+class RecurringWorkScheduler {
+  RecurringWorkScheduler({
+    required Workmanager workmanager,
+    required LoggerService logger,
+  }) : _workmanager = workmanager,
+       _logger = logger;
+
+  final Workmanager _workmanager;
+  final LoggerService _logger;
+
+  Future<void> initialize() async {
+    if (Platform.isAndroid || Platform.isIOS) {
+      await _workmanager.initialize(recurringWorkDispatcher);
+    }
+  }
+
+  Future<void> scheduleDailyWindowGeneration() async {
+    final Duration initialDelay = _timeUntilNextSixAm();
+    await _workmanager.registerOneOffTask(
+      kRecurringTaskGenerateWindow,
+      kRecurringTaskGenerateWindow,
+      initialDelay: initialDelay,
+      constraints: Constraints(networkType: NetworkType.notRequired),
+      backoffPolicy: BackoffPolicy.exponential,
+      backoffPolicyDelay: const Duration(minutes: 30),
+    );
+    _logger.logInfo(
+      'Scheduled window generation in ${initialDelay.inMinutes} minutes',
+    );
+  }
+
+  Future<void> scheduleMaintenance() async {
+    await _workmanager.registerPeriodicTask(
+      kRecurringTaskMaintainWindow,
+      kRecurringTaskMaintainWindow,
+      frequency: const Duration(hours: 24),
+      backoffPolicy: BackoffPolicy.exponential,
+      backoffPolicyDelay: const Duration(minutes: 30),
+      constraints: Constraints(networkType: NetworkType.notRequired),
+    );
+    _logger.logInfo('Scheduled recurring window maintenance');
+  }
+
+  Future<void> scheduleDuePostings() async {
+    await _workmanager.registerPeriodicTask(
+      kRecurringTaskPostDueOccurrences,
+      kRecurringTaskPostDueOccurrences,
+      frequency: const Duration(hours: 24),
+      initialDelay: const Duration(hours: 1),
+      backoffPolicy: BackoffPolicy.exponential,
+      backoffPolicyDelay: const Duration(minutes: 15),
+      constraints: Constraints(networkType: NetworkType.notRequired),
+    );
+    _logger.logInfo('Scheduled daily auto-posting job');
+  }
+
+  Duration _timeUntilNextSixAm() {
+    final DateTime now = DateTime.now();
+    DateTime next = DateTime(now.year, now.month, now.day, 6);
+    if (!next.isAfter(now)) {
+      next = next.add(const Duration(days: 1));
+    }
+    return next.difference(now);
+  }
+}
+
+RecurringTransactionsRepository _buildRepository(AppDatabase database) {
+  final RecurringRuleDao ruleDao = RecurringRuleDao(database);
+  final RecurringOccurrenceDao occurrenceDao = RecurringOccurrenceDao(database);
+  final JobQueueDao jobQueueDao = JobQueueDao(database);
+  return RecurringTransactionsRepositoryImpl(
+    ruleDao: ruleDao,
+    occurrenceDao: occurrenceDao,
+    jobQueueDao: jobQueueDao,
+    database: database,
+  );
+}
+
+Future<void> _postDueOccurrences({
+  required RecurringTransactionsRepository repository,
+  required AppDatabase database,
+  required LoggerService logger,
+}) async {
+  final DateTime today = DateTime.now();
+  final List<RecurringOccurrence> dueOccurrences = await repository
+      .getDueOccurrences(today);
+  if (dueOccurrences.isEmpty) {
+    return;
+  }
+  final OutboxDao outboxDao = OutboxDao(database);
+  final AccountDao accountDao = AccountDao(database);
+  final TransactionDao transactionDao = TransactionDao(database);
+  final AccountRepository accountRepository = AccountRepositoryImpl(
+    database: database,
+    accountDao: accountDao,
+    outboxDao: outboxDao,
+  );
+  final TransactionRepository transactionRepository = TransactionRepositoryImpl(
+    database: database,
+    transactionDao: transactionDao,
+    outboxDao: outboxDao,
+  );
+  String? lastGeneratedId;
+  final AddTransactionUseCase addTransaction = AddTransactionUseCase(
+    transactionRepository: transactionRepository,
+    accountRepository: accountRepository,
+    idGenerator: () {
+      final String generated = const Uuid().v4();
+      lastGeneratedId = generated;
+      return generated;
+    },
+    clock: () => DateTime.now().toUtc(),
+  );
+  for (final RecurringOccurrence occurrence in dueOccurrences) {
+    final RecurringRule? rule = await repository.getRuleById(occurrence.ruleId);
+    if (rule == null || !rule.autoPost) {
+      continue;
+    }
+    final TransactionType type = rule.amount >= 0
+        ? TransactionType.expense
+        : TransactionType.income;
+    final AddTransactionRequest request = AddTransactionRequest(
+      accountId: rule.accountId,
+      amount: rule.amount.abs(),
+      date: occurrence.dueAt,
+      note: rule.notes,
+      type: type,
+    );
+    try {
+      lastGeneratedId = null;
+      await addTransaction(request);
+      await repository.updateOccurrenceStatus(
+        occurrence.id,
+        RecurringOccurrenceStatus.posted,
+        postedTxId: lastGeneratedId,
+      );
+    } catch (error, stackTrace) {
+      logger.logError(
+        'Failed to auto-post occurrence ${occurrence.id}: $error\n$stackTrace',
+      );
+      await repository.updateOccurrenceStatus(
+        occurrence.id,
+        RecurringOccurrenceStatus.failed,
+      );
+    }
+  }
+}

--- a/lib/features/recurring_transactions/data/sources/local/job_queue_dao.dart
+++ b/lib/features/recurring_transactions/data/sources/local/job_queue_dao.dart
@@ -1,0 +1,49 @@
+import 'package:drift/drift.dart';
+import 'package:kopim/core/data/database.dart' as db;
+
+class JobQueueDao {
+  JobQueueDao(this._database);
+
+  final db.AppDatabase _database;
+
+  Future<int> enqueue({
+    required String type,
+    required String payload,
+    required DateTime runAt,
+  }) {
+    return _database
+        .into(_database.jobQueue)
+        .insert(
+          db.JobQueueCompanion.insert(
+            type: type,
+            payload: payload,
+            runAt: runAt.toUtc(),
+          ),
+        );
+  }
+
+  Stream<List<db.JobQueueRow>> watchPending() {
+    final SimpleSelectStatement<db.$JobQueueTable, db.JobQueueRow> query =
+        _database.select(_database.jobQueue)
+          ..orderBy(<OrderingTerm Function(db.$JobQueueTable)>[
+            (db.$JobQueueTable tbl) => OrderingTerm(expression: tbl.runAt),
+          ]);
+    return query.watch();
+  }
+
+  Future<void> markAttempt(int jobId, {String? error}) async {
+    final db.JobQueueRow? row =
+        await (_database.select(_database.jobQueue)
+              ..where((db.$JobQueueTable tbl) => tbl.id.equals(jobId)))
+            .getSingleOrNull();
+    final int attempts = (row?.attempts ?? 0) + 1;
+    await (_database.update(
+      _database.jobQueue,
+    )..where((db.$JobQueueTable tbl) => tbl.id.equals(jobId))).write(
+      db.JobQueueCompanion(
+        attempts: Value<int>(attempts),
+        lastError: Value<String?>(error),
+      ),
+    );
+  }
+}

--- a/lib/features/recurring_transactions/data/sources/local/recurring_occurrence_dao.dart
+++ b/lib/features/recurring_transactions/data/sources/local/recurring_occurrence_dao.dart
@@ -1,0 +1,133 @@
+import 'package:drift/drift.dart';
+import 'package:kopim/core/data/database.dart' as db;
+import 'package:kopim/features/recurring_transactions/domain/entities/recurring_occurrence.dart';
+
+class RecurringOccurrenceDao {
+  RecurringOccurrenceDao(this._database);
+
+  final db.AppDatabase _database;
+
+  Stream<List<db.RecurringOccurrenceRow>> watchWindow({
+    required DateTime from,
+    required DateTime to,
+  }) {
+    final SimpleSelectStatement<
+      db.$RecurringOccurrencesTable,
+      db.RecurringOccurrenceRow
+    >
+    query = _database.select(_database.recurringOccurrences)
+      ..where(
+        (db.$RecurringOccurrencesTable tbl) =>
+            tbl.dueAt.isBetweenValues(from.toUtc(), to.toUtc()),
+      );
+    return query.watch();
+  }
+
+  Stream<List<db.RecurringOccurrenceRow>> watchRule(String ruleId) {
+    final SimpleSelectStatement<
+      db.$RecurringOccurrencesTable,
+      db.RecurringOccurrenceRow
+    >
+    query = _database.select(_database.recurringOccurrences)
+      ..where((db.$RecurringOccurrencesTable tbl) => tbl.ruleId.equals(ruleId));
+    return query.watch();
+  }
+
+  Future<List<db.RecurringOccurrenceRow>> getDueOn(DateTime date) {
+    final DateTime start = DateTime.utc(date.year, date.month, date.day);
+    final DateTime end = start.add(const Duration(days: 1));
+    final SimpleSelectStatement<
+      db.$RecurringOccurrencesTable,
+      db.RecurringOccurrenceRow
+    >
+    query = _database.select(_database.recurringOccurrences)
+      ..where(
+        (db.$RecurringOccurrencesTable tbl) =>
+            tbl.dueAt.isBetweenValues(start, end),
+      );
+    return query.get();
+  }
+
+  Future<void> replaceOccurrences(
+    Iterable<RecurringOccurrence> occurrences,
+  ) async {
+    await _database.transaction(() async {
+      final List<String> ruleIds = occurrences
+          .map((RecurringOccurrence e) => e.ruleId)
+          .toSet()
+          .toList();
+      for (final String ruleId in ruleIds) {
+        await (_database.delete(_database.recurringOccurrences)..where(
+              (db.$RecurringOccurrencesTable tbl) => tbl.ruleId.equals(ruleId),
+            ))
+            .go();
+      }
+      if (occurrences.isEmpty) {
+        return;
+      }
+      await _database.batch((Batch batch) {
+        batch.insertAllOnConflictUpdate(
+          _database.recurringOccurrences,
+          occurrences.map(_mapToCompanion).toList(),
+        );
+      });
+    });
+  }
+
+  Future<void> upsertAll(Iterable<RecurringOccurrence> occurrences) async {
+    if (occurrences.isEmpty) return;
+    await _database.batch((Batch batch) {
+      batch.insertAllOnConflictUpdate(
+        _database.recurringOccurrences,
+        occurrences.map(_mapToCompanion).toList(),
+      );
+    });
+  }
+
+  Future<void> deleteForRule(String ruleId) {
+    return (_database.delete(_database.recurringOccurrences)..where(
+          (db.$RecurringOccurrencesTable tbl) => tbl.ruleId.equals(ruleId),
+        ))
+        .go();
+  }
+
+  Future<void> clearAll() {
+    return _database.delete(_database.recurringOccurrences).go();
+  }
+
+  Future<void> updateStatus(
+    String occurrenceId,
+    RecurringOccurrenceStatus status, {
+    String? postedTxId,
+    DateTime? updatedAt,
+  }) {
+    return (_database.update(_database.recurringOccurrences)..where(
+          (db.$RecurringOccurrencesTable tbl) => tbl.id.equals(occurrenceId),
+        ))
+        .write(
+          db.RecurringOccurrencesCompanion(
+            status: Value<String>(status.value),
+            postedTxId: Value<String?>(postedTxId),
+            updatedAt: Value<DateTime>(
+              updatedAt?.toUtc() ?? DateTime.now().toUtc(),
+            ),
+          ),
+        );
+  }
+
+  db.RecurringOccurrencesCompanion _mapToCompanion(
+    RecurringOccurrence occurrence,
+  ) {
+    return db.RecurringOccurrencesCompanion(
+      id: Value<String>(occurrence.id),
+      ruleId: Value<String>(occurrence.ruleId),
+      dueAt: Value<DateTime>(occurrence.dueAt.toUtc()),
+      status: Value<String>(occurrence.status.value),
+      createdAt: Value<DateTime>(occurrence.createdAt.toUtc()),
+      postedTxId: Value<String?>(occurrence.postedTxId),
+      updatedAt: Value<DateTime>(
+        occurrence.updatedAt?.toUtc() ?? occurrence.createdAt.toUtc(),
+      ),
+    );
+  }
+}

--- a/lib/features/recurring_transactions/data/sources/local/recurring_rule_dao.dart
+++ b/lib/features/recurring_transactions/data/sources/local/recurring_rule_dao.dart
@@ -1,0 +1,74 @@
+import 'package:drift/drift.dart';
+import 'package:kopim/core/data/database.dart' as db;
+import 'package:kopim/features/recurring_transactions/domain/entities/recurring_rule.dart';
+
+class RecurringRuleDao {
+  RecurringRuleDao(this._database);
+
+  final db.AppDatabase _database;
+
+  Stream<List<db.RecurringRuleRow>> watchAll() {
+    final SimpleSelectStatement<db.$RecurringRulesTable, db.RecurringRuleRow>
+    query = _database.select(_database.recurringRules);
+    return query.watch();
+  }
+
+  Future<List<db.RecurringRuleRow>> getAll() {
+    return _database.select(_database.recurringRules).get();
+  }
+
+  Future<db.RecurringRuleRow?> findById(String id) {
+    final SimpleSelectStatement<db.$RecurringRulesTable, db.RecurringRuleRow>
+    query = _database.select(_database.recurringRules)
+      ..where((db.$RecurringRulesTable tbl) => tbl.id.equals(id));
+    return query.getSingleOrNull();
+  }
+
+  Future<void> upsert(RecurringRule rule) {
+    return _database
+        .into(_database.recurringRules)
+        .insertOnConflictUpdate(_mapRuleToCompanion(rule));
+  }
+
+  Future<void> deleteById(String id) {
+    return (_database.delete(
+      _database.recurringRules,
+    )..where((db.$RecurringRulesTable tbl) => tbl.id.equals(id))).go();
+  }
+
+  Future<void> toggle({
+    required String id,
+    required bool isActive,
+    required DateTime updatedAt,
+  }) {
+    return (_database.update(
+      _database.recurringRules,
+    )..where((db.$RecurringRulesTable tbl) => tbl.id.equals(id))).write(
+      db.RecurringRulesCompanion(
+        isActive: Value<bool>(isActive),
+        updatedAt: Value<DateTime>(updatedAt),
+      ),
+    );
+  }
+
+  db.RecurringRulesCompanion _mapRuleToCompanion(RecurringRule rule) {
+    return db.RecurringRulesCompanion(
+      id: Value<String>(rule.id),
+      title: Value<String>(rule.title),
+      accountId: Value<String>(rule.accountId),
+      amount: Value<double>(rule.amount),
+      currency: Value<String>(rule.currency),
+      startAt: Value<DateTime>(rule.startAt.toUtc()),
+      timezone: Value<String>(rule.timezone),
+      rrule: Value<String>(rule.rrule),
+      endAt: Value<DateTime?>(rule.endAt?.toUtc()),
+      notes: Value<String?>(rule.notes),
+      isActive: Value<bool>(rule.isActive),
+      autoPost: Value<bool>(rule.autoPost),
+      reminderMinutesBefore: Value<int?>(rule.reminderMinutesBefore),
+      shortMonthPolicy: Value<String>(rule.shortMonthPolicy.value),
+      createdAt: Value<DateTime>(rule.createdAt.toUtc()),
+      updatedAt: Value<DateTime>(rule.updatedAt.toUtc()),
+    );
+  }
+}

--- a/lib/features/recurring_transactions/domain/entities/recurring_job.dart
+++ b/lib/features/recurring_transactions/domain/entities/recurring_job.dart
@@ -1,0 +1,22 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'recurring_job.freezed.dart';
+part 'recurring_job.g.dart';
+
+@freezed
+abstract class RecurringJob with _$RecurringJob {
+  const factory RecurringJob({
+    required int id,
+    required String type,
+    required String payload,
+    required DateTime runAt,
+    required int attempts,
+    String? lastError,
+    required DateTime createdAt,
+  }) = _RecurringJob;
+
+  const RecurringJob._();
+
+  factory RecurringJob.fromJson(Map<String, dynamic> json) =>
+      _$RecurringJobFromJson(json);
+}

--- a/lib/features/recurring_transactions/domain/entities/recurring_job.freezed.dart
+++ b/lib/features/recurring_transactions/domain/entities/recurring_job.freezed.dart
@@ -1,0 +1,295 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'recurring_job.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$RecurringJob {
+
+ int get id; String get type; String get payload; DateTime get runAt; int get attempts; String? get lastError; DateTime get createdAt;
+/// Create a copy of RecurringJob
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$RecurringJobCopyWith<RecurringJob> get copyWith => _$RecurringJobCopyWithImpl<RecurringJob>(this as RecurringJob, _$identity);
+
+  /// Serializes this RecurringJob to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RecurringJob&&(identical(other.id, id) || other.id == id)&&(identical(other.type, type) || other.type == type)&&(identical(other.payload, payload) || other.payload == payload)&&(identical(other.runAt, runAt) || other.runAt == runAt)&&(identical(other.attempts, attempts) || other.attempts == attempts)&&(identical(other.lastError, lastError) || other.lastError == lastError)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,type,payload,runAt,attempts,lastError,createdAt);
+
+@override
+String toString() {
+  return 'RecurringJob(id: $id, type: $type, payload: $payload, runAt: $runAt, attempts: $attempts, lastError: $lastError, createdAt: $createdAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $RecurringJobCopyWith<$Res>  {
+  factory $RecurringJobCopyWith(RecurringJob value, $Res Function(RecurringJob) _then) = _$RecurringJobCopyWithImpl;
+@useResult
+$Res call({
+ int id, String type, String payload, DateTime runAt, int attempts, String? lastError, DateTime createdAt
+});
+
+
+
+
+}
+/// @nodoc
+class _$RecurringJobCopyWithImpl<$Res>
+    implements $RecurringJobCopyWith<$Res> {
+  _$RecurringJobCopyWithImpl(this._self, this._then);
+
+  final RecurringJob _self;
+  final $Res Function(RecurringJob) _then;
+
+/// Create a copy of RecurringJob
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? type = null,Object? payload = null,Object? runAt = null,Object? attempts = null,Object? lastError = freezed,Object? createdAt = null,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as int,type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as String,payload: null == payload ? _self.payload : payload // ignore: cast_nullable_to_non_nullable
+as String,runAt: null == runAt ? _self.runAt : runAt // ignore: cast_nullable_to_non_nullable
+as DateTime,attempts: null == attempts ? _self.attempts : attempts // ignore: cast_nullable_to_non_nullable
+as int,lastError: freezed == lastError ? _self.lastError : lastError // ignore: cast_nullable_to_non_nullable
+as String?,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [RecurringJob].
+extension RecurringJobPatterns on RecurringJob {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _RecurringJob value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _RecurringJob() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _RecurringJob value)  $default,){
+final _that = this;
+switch (_that) {
+case _RecurringJob():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _RecurringJob value)?  $default,){
+final _that = this;
+switch (_that) {
+case _RecurringJob() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  String type,  String payload,  DateTime runAt,  int attempts,  String? lastError,  DateTime createdAt)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _RecurringJob() when $default != null:
+return $default(_that.id,_that.type,_that.payload,_that.runAt,_that.attempts,_that.lastError,_that.createdAt);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  String type,  String payload,  DateTime runAt,  int attempts,  String? lastError,  DateTime createdAt)  $default,) {final _that = this;
+switch (_that) {
+case _RecurringJob():
+return $default(_that.id,_that.type,_that.payload,_that.runAt,_that.attempts,_that.lastError,_that.createdAt);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  String type,  String payload,  DateTime runAt,  int attempts,  String? lastError,  DateTime createdAt)?  $default,) {final _that = this;
+switch (_that) {
+case _RecurringJob() when $default != null:
+return $default(_that.id,_that.type,_that.payload,_that.runAt,_that.attempts,_that.lastError,_that.createdAt);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _RecurringJob extends RecurringJob {
+  const _RecurringJob({required this.id, required this.type, required this.payload, required this.runAt, required this.attempts, this.lastError, required this.createdAt}): super._();
+  factory _RecurringJob.fromJson(Map<String, dynamic> json) => _$RecurringJobFromJson(json);
+
+@override final  int id;
+@override final  String type;
+@override final  String payload;
+@override final  DateTime runAt;
+@override final  int attempts;
+@override final  String? lastError;
+@override final  DateTime createdAt;
+
+/// Create a copy of RecurringJob
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$RecurringJobCopyWith<_RecurringJob> get copyWith => __$RecurringJobCopyWithImpl<_RecurringJob>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$RecurringJobToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _RecurringJob&&(identical(other.id, id) || other.id == id)&&(identical(other.type, type) || other.type == type)&&(identical(other.payload, payload) || other.payload == payload)&&(identical(other.runAt, runAt) || other.runAt == runAt)&&(identical(other.attempts, attempts) || other.attempts == attempts)&&(identical(other.lastError, lastError) || other.lastError == lastError)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,type,payload,runAt,attempts,lastError,createdAt);
+
+@override
+String toString() {
+  return 'RecurringJob(id: $id, type: $type, payload: $payload, runAt: $runAt, attempts: $attempts, lastError: $lastError, createdAt: $createdAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$RecurringJobCopyWith<$Res> implements $RecurringJobCopyWith<$Res> {
+  factory _$RecurringJobCopyWith(_RecurringJob value, $Res Function(_RecurringJob) _then) = __$RecurringJobCopyWithImpl;
+@override @useResult
+$Res call({
+ int id, String type, String payload, DateTime runAt, int attempts, String? lastError, DateTime createdAt
+});
+
+
+
+
+}
+/// @nodoc
+class __$RecurringJobCopyWithImpl<$Res>
+    implements _$RecurringJobCopyWith<$Res> {
+  __$RecurringJobCopyWithImpl(this._self, this._then);
+
+  final _RecurringJob _self;
+  final $Res Function(_RecurringJob) _then;
+
+/// Create a copy of RecurringJob
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? type = null,Object? payload = null,Object? runAt = null,Object? attempts = null,Object? lastError = freezed,Object? createdAt = null,}) {
+  return _then(_RecurringJob(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as int,type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as String,payload: null == payload ? _self.payload : payload // ignore: cast_nullable_to_non_nullable
+as String,runAt: null == runAt ? _self.runAt : runAt // ignore: cast_nullable_to_non_nullable
+as DateTime,attempts: null == attempts ? _self.attempts : attempts // ignore: cast_nullable_to_non_nullable
+as int,lastError: freezed == lastError ? _self.lastError : lastError // ignore: cast_nullable_to_non_nullable
+as String?,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/features/recurring_transactions/domain/entities/recurring_job.g.dart
+++ b/lib/features/recurring_transactions/domain/entities/recurring_job.g.dart
@@ -1,0 +1,29 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'recurring_job.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_RecurringJob _$RecurringJobFromJson(Map<String, dynamic> json) =>
+    _RecurringJob(
+      id: (json['id'] as num).toInt(),
+      type: json['type'] as String,
+      payload: json['payload'] as String,
+      runAt: DateTime.parse(json['runAt'] as String),
+      attempts: (json['attempts'] as num).toInt(),
+      lastError: json['lastError'] as String?,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+    );
+
+Map<String, dynamic> _$RecurringJobToJson(_RecurringJob instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'type': instance.type,
+      'payload': instance.payload,
+      'runAt': instance.runAt.toIso8601String(),
+      'attempts': instance.attempts,
+      'lastError': instance.lastError,
+      'createdAt': instance.createdAt.toIso8601String(),
+    };

--- a/lib/features/recurring_transactions/domain/entities/recurring_occurrence.dart
+++ b/lib/features/recurring_transactions/domain/entities/recurring_occurrence.dart
@@ -1,0 +1,40 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'recurring_occurrence.freezed.dart';
+part 'recurring_occurrence.g.dart';
+
+enum RecurringOccurrenceStatus {
+  scheduled('scheduled'),
+  posted('posted'),
+  skipped('skipped'),
+  failed('failed');
+
+  const RecurringOccurrenceStatus(this.value);
+  final String value;
+
+  static RecurringOccurrenceStatus fromValue(String value) {
+    return RecurringOccurrenceStatus.values.firstWhere(
+      (RecurringOccurrenceStatus status) => status.value == value,
+      orElse: () => RecurringOccurrenceStatus.scheduled,
+    );
+  }
+}
+
+@freezed
+abstract class RecurringOccurrence with _$RecurringOccurrence {
+  const factory RecurringOccurrence({
+    required String id,
+    required String ruleId,
+    required DateTime dueAt,
+    @Default(RecurringOccurrenceStatus.scheduled)
+    RecurringOccurrenceStatus status,
+    required DateTime createdAt,
+    DateTime? updatedAt,
+    String? postedTxId,
+  }) = _RecurringOccurrence;
+
+  const RecurringOccurrence._();
+
+  factory RecurringOccurrence.fromJson(Map<String, dynamic> json) =>
+      _$RecurringOccurrenceFromJson(json);
+}

--- a/lib/features/recurring_transactions/domain/entities/recurring_occurrence.freezed.dart
+++ b/lib/features/recurring_transactions/domain/entities/recurring_occurrence.freezed.dart
@@ -1,0 +1,295 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'recurring_occurrence.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$RecurringOccurrence {
+
+ String get id; String get ruleId; DateTime get dueAt; RecurringOccurrenceStatus get status; DateTime get createdAt; DateTime? get updatedAt; String? get postedTxId;
+/// Create a copy of RecurringOccurrence
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$RecurringOccurrenceCopyWith<RecurringOccurrence> get copyWith => _$RecurringOccurrenceCopyWithImpl<RecurringOccurrence>(this as RecurringOccurrence, _$identity);
+
+  /// Serializes this RecurringOccurrence to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RecurringOccurrence&&(identical(other.id, id) || other.id == id)&&(identical(other.ruleId, ruleId) || other.ruleId == ruleId)&&(identical(other.dueAt, dueAt) || other.dueAt == dueAt)&&(identical(other.status, status) || other.status == status)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.postedTxId, postedTxId) || other.postedTxId == postedTxId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,ruleId,dueAt,status,createdAt,updatedAt,postedTxId);
+
+@override
+String toString() {
+  return 'RecurringOccurrence(id: $id, ruleId: $ruleId, dueAt: $dueAt, status: $status, createdAt: $createdAt, updatedAt: $updatedAt, postedTxId: $postedTxId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $RecurringOccurrenceCopyWith<$Res>  {
+  factory $RecurringOccurrenceCopyWith(RecurringOccurrence value, $Res Function(RecurringOccurrence) _then) = _$RecurringOccurrenceCopyWithImpl;
+@useResult
+$Res call({
+ String id, String ruleId, DateTime dueAt, RecurringOccurrenceStatus status, DateTime createdAt, DateTime? updatedAt, String? postedTxId
+});
+
+
+
+
+}
+/// @nodoc
+class _$RecurringOccurrenceCopyWithImpl<$Res>
+    implements $RecurringOccurrenceCopyWith<$Res> {
+  _$RecurringOccurrenceCopyWithImpl(this._self, this._then);
+
+  final RecurringOccurrence _self;
+  final $Res Function(RecurringOccurrence) _then;
+
+/// Create a copy of RecurringOccurrence
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? ruleId = null,Object? dueAt = null,Object? status = null,Object? createdAt = null,Object? updatedAt = freezed,Object? postedTxId = freezed,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,ruleId: null == ruleId ? _self.ruleId : ruleId // ignore: cast_nullable_to_non_nullable
+as String,dueAt: null == dueAt ? _self.dueAt : dueAt // ignore: cast_nullable_to_non_nullable
+as DateTime,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as RecurringOccurrenceStatus,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: freezed == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,postedTxId: freezed == postedTxId ? _self.postedTxId : postedTxId // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [RecurringOccurrence].
+extension RecurringOccurrencePatterns on RecurringOccurrence {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _RecurringOccurrence value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _RecurringOccurrence() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _RecurringOccurrence value)  $default,){
+final _that = this;
+switch (_that) {
+case _RecurringOccurrence():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _RecurringOccurrence value)?  $default,){
+final _that = this;
+switch (_that) {
+case _RecurringOccurrence() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String ruleId,  DateTime dueAt,  RecurringOccurrenceStatus status,  DateTime createdAt,  DateTime? updatedAt,  String? postedTxId)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _RecurringOccurrence() when $default != null:
+return $default(_that.id,_that.ruleId,_that.dueAt,_that.status,_that.createdAt,_that.updatedAt,_that.postedTxId);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String ruleId,  DateTime dueAt,  RecurringOccurrenceStatus status,  DateTime createdAt,  DateTime? updatedAt,  String? postedTxId)  $default,) {final _that = this;
+switch (_that) {
+case _RecurringOccurrence():
+return $default(_that.id,_that.ruleId,_that.dueAt,_that.status,_that.createdAt,_that.updatedAt,_that.postedTxId);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String ruleId,  DateTime dueAt,  RecurringOccurrenceStatus status,  DateTime createdAt,  DateTime? updatedAt,  String? postedTxId)?  $default,) {final _that = this;
+switch (_that) {
+case _RecurringOccurrence() when $default != null:
+return $default(_that.id,_that.ruleId,_that.dueAt,_that.status,_that.createdAt,_that.updatedAt,_that.postedTxId);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _RecurringOccurrence extends RecurringOccurrence {
+  const _RecurringOccurrence({required this.id, required this.ruleId, required this.dueAt, this.status = RecurringOccurrenceStatus.scheduled, required this.createdAt, this.updatedAt, this.postedTxId}): super._();
+  factory _RecurringOccurrence.fromJson(Map<String, dynamic> json) => _$RecurringOccurrenceFromJson(json);
+
+@override final  String id;
+@override final  String ruleId;
+@override final  DateTime dueAt;
+@override@JsonKey() final  RecurringOccurrenceStatus status;
+@override final  DateTime createdAt;
+@override final  DateTime? updatedAt;
+@override final  String? postedTxId;
+
+/// Create a copy of RecurringOccurrence
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$RecurringOccurrenceCopyWith<_RecurringOccurrence> get copyWith => __$RecurringOccurrenceCopyWithImpl<_RecurringOccurrence>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$RecurringOccurrenceToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _RecurringOccurrence&&(identical(other.id, id) || other.id == id)&&(identical(other.ruleId, ruleId) || other.ruleId == ruleId)&&(identical(other.dueAt, dueAt) || other.dueAt == dueAt)&&(identical(other.status, status) || other.status == status)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.postedTxId, postedTxId) || other.postedTxId == postedTxId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,ruleId,dueAt,status,createdAt,updatedAt,postedTxId);
+
+@override
+String toString() {
+  return 'RecurringOccurrence(id: $id, ruleId: $ruleId, dueAt: $dueAt, status: $status, createdAt: $createdAt, updatedAt: $updatedAt, postedTxId: $postedTxId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$RecurringOccurrenceCopyWith<$Res> implements $RecurringOccurrenceCopyWith<$Res> {
+  factory _$RecurringOccurrenceCopyWith(_RecurringOccurrence value, $Res Function(_RecurringOccurrence) _then) = __$RecurringOccurrenceCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, String ruleId, DateTime dueAt, RecurringOccurrenceStatus status, DateTime createdAt, DateTime? updatedAt, String? postedTxId
+});
+
+
+
+
+}
+/// @nodoc
+class __$RecurringOccurrenceCopyWithImpl<$Res>
+    implements _$RecurringOccurrenceCopyWith<$Res> {
+  __$RecurringOccurrenceCopyWithImpl(this._self, this._then);
+
+  final _RecurringOccurrence _self;
+  final $Res Function(_RecurringOccurrence) _then;
+
+/// Create a copy of RecurringOccurrence
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? ruleId = null,Object? dueAt = null,Object? status = null,Object? createdAt = null,Object? updatedAt = freezed,Object? postedTxId = freezed,}) {
+  return _then(_RecurringOccurrence(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,ruleId: null == ruleId ? _self.ruleId : ruleId // ignore: cast_nullable_to_non_nullable
+as String,dueAt: null == dueAt ? _self.dueAt : dueAt // ignore: cast_nullable_to_non_nullable
+as DateTime,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as RecurringOccurrenceStatus,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: freezed == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,postedTxId: freezed == postedTxId ? _self.postedTxId : postedTxId // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/features/recurring_transactions/domain/entities/recurring_occurrence.g.dart
+++ b/lib/features/recurring_transactions/domain/entities/recurring_occurrence.g.dart
@@ -1,0 +1,44 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'recurring_occurrence.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_RecurringOccurrence _$RecurringOccurrenceFromJson(Map<String, dynamic> json) =>
+    _RecurringOccurrence(
+      id: json['id'] as String,
+      ruleId: json['ruleId'] as String,
+      dueAt: DateTime.parse(json['dueAt'] as String),
+      status:
+          $enumDecodeNullable(
+            _$RecurringOccurrenceStatusEnumMap,
+            json['status'],
+          ) ??
+          RecurringOccurrenceStatus.scheduled,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      updatedAt: json['updatedAt'] == null
+          ? null
+          : DateTime.parse(json['updatedAt'] as String),
+      postedTxId: json['postedTxId'] as String?,
+    );
+
+Map<String, dynamic> _$RecurringOccurrenceToJson(
+  _RecurringOccurrence instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'ruleId': instance.ruleId,
+  'dueAt': instance.dueAt.toIso8601String(),
+  'status': _$RecurringOccurrenceStatusEnumMap[instance.status]!,
+  'createdAt': instance.createdAt.toIso8601String(),
+  'updatedAt': instance.updatedAt?.toIso8601String(),
+  'postedTxId': instance.postedTxId,
+};
+
+const _$RecurringOccurrenceStatusEnumMap = {
+  RecurringOccurrenceStatus.scheduled: 'scheduled',
+  RecurringOccurrenceStatus.posted: 'posted',
+  RecurringOccurrenceStatus.skipped: 'skipped',
+  RecurringOccurrenceStatus.failed: 'failed',
+};

--- a/lib/features/recurring_transactions/domain/entities/recurring_rule.dart
+++ b/lib/features/recurring_transactions/domain/entities/recurring_rule.dart
@@ -1,0 +1,49 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'recurring_rule.freezed.dart';
+part 'recurring_rule.g.dart';
+
+enum RecurringRuleShortMonthPolicy {
+  clipToLastDay('clip_to_last_day'),
+  skipMonth('skip_month');
+
+  const RecurringRuleShortMonthPolicy(this.value);
+  final String value;
+
+  static RecurringRuleShortMonthPolicy fromValue(String value) {
+    return RecurringRuleShortMonthPolicy.values.firstWhere(
+      (RecurringRuleShortMonthPolicy policy) => policy.value == value,
+      orElse: () => RecurringRuleShortMonthPolicy.clipToLastDay,
+    );
+  }
+}
+
+@freezed
+abstract class RecurringRule with _$RecurringRule {
+  const factory RecurringRule({
+    required String id,
+    required String title,
+    required String accountId,
+    required double amount,
+    required String currency,
+    required DateTime startAt,
+    DateTime? endAt,
+    required String timezone,
+    required String rrule,
+    String? notes,
+    @Default(true) bool isActive,
+    @Default(false) bool autoPost,
+    int? reminderMinutesBefore,
+    @Default(RecurringRuleShortMonthPolicy.clipToLastDay)
+    RecurringRuleShortMonthPolicy shortMonthPolicy,
+    required DateTime createdAt,
+    required DateTime updatedAt,
+  }) = _RecurringRule;
+
+  const RecurringRule._();
+
+  factory RecurringRule.fromJson(Map<String, dynamic> json) =>
+      _$RecurringRuleFromJson(json);
+
+  bool get hasEndDate => endAt != null;
+}

--- a/lib/features/recurring_transactions/domain/entities/recurring_rule.freezed.dart
+++ b/lib/features/recurring_transactions/domain/entities/recurring_rule.freezed.dart
@@ -1,0 +1,322 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'recurring_rule.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$RecurringRule {
+
+ String get id; String get title; String get accountId; double get amount; String get currency; DateTime get startAt; DateTime? get endAt; String get timezone; String get rrule; String? get notes; bool get isActive; bool get autoPost; int? get reminderMinutesBefore; RecurringRuleShortMonthPolicy get shortMonthPolicy; DateTime get createdAt; DateTime get updatedAt;
+/// Create a copy of RecurringRule
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$RecurringRuleCopyWith<RecurringRule> get copyWith => _$RecurringRuleCopyWithImpl<RecurringRule>(this as RecurringRule, _$identity);
+
+  /// Serializes this RecurringRule to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RecurringRule&&(identical(other.id, id) || other.id == id)&&(identical(other.title, title) || other.title == title)&&(identical(other.accountId, accountId) || other.accountId == accountId)&&(identical(other.amount, amount) || other.amount == amount)&&(identical(other.currency, currency) || other.currency == currency)&&(identical(other.startAt, startAt) || other.startAt == startAt)&&(identical(other.endAt, endAt) || other.endAt == endAt)&&(identical(other.timezone, timezone) || other.timezone == timezone)&&(identical(other.rrule, rrule) || other.rrule == rrule)&&(identical(other.notes, notes) || other.notes == notes)&&(identical(other.isActive, isActive) || other.isActive == isActive)&&(identical(other.autoPost, autoPost) || other.autoPost == autoPost)&&(identical(other.reminderMinutesBefore, reminderMinutesBefore) || other.reminderMinutesBefore == reminderMinutesBefore)&&(identical(other.shortMonthPolicy, shortMonthPolicy) || other.shortMonthPolicy == shortMonthPolicy)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,title,accountId,amount,currency,startAt,endAt,timezone,rrule,notes,isActive,autoPost,reminderMinutesBefore,shortMonthPolicy,createdAt,updatedAt);
+
+@override
+String toString() {
+  return 'RecurringRule(id: $id, title: $title, accountId: $accountId, amount: $amount, currency: $currency, startAt: $startAt, endAt: $endAt, timezone: $timezone, rrule: $rrule, notes: $notes, isActive: $isActive, autoPost: $autoPost, reminderMinutesBefore: $reminderMinutesBefore, shortMonthPolicy: $shortMonthPolicy, createdAt: $createdAt, updatedAt: $updatedAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $RecurringRuleCopyWith<$Res>  {
+  factory $RecurringRuleCopyWith(RecurringRule value, $Res Function(RecurringRule) _then) = _$RecurringRuleCopyWithImpl;
+@useResult
+$Res call({
+ String id, String title, String accountId, double amount, String currency, DateTime startAt, DateTime? endAt, String timezone, String rrule, String? notes, bool isActive, bool autoPost, int? reminderMinutesBefore, RecurringRuleShortMonthPolicy shortMonthPolicy, DateTime createdAt, DateTime updatedAt
+});
+
+
+
+
+}
+/// @nodoc
+class _$RecurringRuleCopyWithImpl<$Res>
+    implements $RecurringRuleCopyWith<$Res> {
+  _$RecurringRuleCopyWithImpl(this._self, this._then);
+
+  final RecurringRule _self;
+  final $Res Function(RecurringRule) _then;
+
+/// Create a copy of RecurringRule
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? title = null,Object? accountId = null,Object? amount = null,Object? currency = null,Object? startAt = null,Object? endAt = freezed,Object? timezone = null,Object? rrule = null,Object? notes = freezed,Object? isActive = null,Object? autoPost = null,Object? reminderMinutesBefore = freezed,Object? shortMonthPolicy = null,Object? createdAt = null,Object? updatedAt = null,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,accountId: null == accountId ? _self.accountId : accountId // ignore: cast_nullable_to_non_nullable
+as String,amount: null == amount ? _self.amount : amount // ignore: cast_nullable_to_non_nullable
+as double,currency: null == currency ? _self.currency : currency // ignore: cast_nullable_to_non_nullable
+as String,startAt: null == startAt ? _self.startAt : startAt // ignore: cast_nullable_to_non_nullable
+as DateTime,endAt: freezed == endAt ? _self.endAt : endAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,timezone: null == timezone ? _self.timezone : timezone // ignore: cast_nullable_to_non_nullable
+as String,rrule: null == rrule ? _self.rrule : rrule // ignore: cast_nullable_to_non_nullable
+as String,notes: freezed == notes ? _self.notes : notes // ignore: cast_nullable_to_non_nullable
+as String?,isActive: null == isActive ? _self.isActive : isActive // ignore: cast_nullable_to_non_nullable
+as bool,autoPost: null == autoPost ? _self.autoPost : autoPost // ignore: cast_nullable_to_non_nullable
+as bool,reminderMinutesBefore: freezed == reminderMinutesBefore ? _self.reminderMinutesBefore : reminderMinutesBefore // ignore: cast_nullable_to_non_nullable
+as int?,shortMonthPolicy: null == shortMonthPolicy ? _self.shortMonthPolicy : shortMonthPolicy // ignore: cast_nullable_to_non_nullable
+as RecurringRuleShortMonthPolicy,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [RecurringRule].
+extension RecurringRulePatterns on RecurringRule {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _RecurringRule value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _RecurringRule() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _RecurringRule value)  $default,){
+final _that = this;
+switch (_that) {
+case _RecurringRule():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _RecurringRule value)?  $default,){
+final _that = this;
+switch (_that) {
+case _RecurringRule() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String title,  String accountId,  double amount,  String currency,  DateTime startAt,  DateTime? endAt,  String timezone,  String rrule,  String? notes,  bool isActive,  bool autoPost,  int? reminderMinutesBefore,  RecurringRuleShortMonthPolicy shortMonthPolicy,  DateTime createdAt,  DateTime updatedAt)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _RecurringRule() when $default != null:
+return $default(_that.id,_that.title,_that.accountId,_that.amount,_that.currency,_that.startAt,_that.endAt,_that.timezone,_that.rrule,_that.notes,_that.isActive,_that.autoPost,_that.reminderMinutesBefore,_that.shortMonthPolicy,_that.createdAt,_that.updatedAt);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String title,  String accountId,  double amount,  String currency,  DateTime startAt,  DateTime? endAt,  String timezone,  String rrule,  String? notes,  bool isActive,  bool autoPost,  int? reminderMinutesBefore,  RecurringRuleShortMonthPolicy shortMonthPolicy,  DateTime createdAt,  DateTime updatedAt)  $default,) {final _that = this;
+switch (_that) {
+case _RecurringRule():
+return $default(_that.id,_that.title,_that.accountId,_that.amount,_that.currency,_that.startAt,_that.endAt,_that.timezone,_that.rrule,_that.notes,_that.isActive,_that.autoPost,_that.reminderMinutesBefore,_that.shortMonthPolicy,_that.createdAt,_that.updatedAt);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String title,  String accountId,  double amount,  String currency,  DateTime startAt,  DateTime? endAt,  String timezone,  String rrule,  String? notes,  bool isActive,  bool autoPost,  int? reminderMinutesBefore,  RecurringRuleShortMonthPolicy shortMonthPolicy,  DateTime createdAt,  DateTime updatedAt)?  $default,) {final _that = this;
+switch (_that) {
+case _RecurringRule() when $default != null:
+return $default(_that.id,_that.title,_that.accountId,_that.amount,_that.currency,_that.startAt,_that.endAt,_that.timezone,_that.rrule,_that.notes,_that.isActive,_that.autoPost,_that.reminderMinutesBefore,_that.shortMonthPolicy,_that.createdAt,_that.updatedAt);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _RecurringRule extends RecurringRule {
+  const _RecurringRule({required this.id, required this.title, required this.accountId, required this.amount, required this.currency, required this.startAt, this.endAt, required this.timezone, required this.rrule, this.notes, this.isActive = true, this.autoPost = false, this.reminderMinutesBefore, this.shortMonthPolicy = RecurringRuleShortMonthPolicy.clipToLastDay, required this.createdAt, required this.updatedAt}): super._();
+  factory _RecurringRule.fromJson(Map<String, dynamic> json) => _$RecurringRuleFromJson(json);
+
+@override final  String id;
+@override final  String title;
+@override final  String accountId;
+@override final  double amount;
+@override final  String currency;
+@override final  DateTime startAt;
+@override final  DateTime? endAt;
+@override final  String timezone;
+@override final  String rrule;
+@override final  String? notes;
+@override@JsonKey() final  bool isActive;
+@override@JsonKey() final  bool autoPost;
+@override final  int? reminderMinutesBefore;
+@override@JsonKey() final  RecurringRuleShortMonthPolicy shortMonthPolicy;
+@override final  DateTime createdAt;
+@override final  DateTime updatedAt;
+
+/// Create a copy of RecurringRule
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$RecurringRuleCopyWith<_RecurringRule> get copyWith => __$RecurringRuleCopyWithImpl<_RecurringRule>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$RecurringRuleToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _RecurringRule&&(identical(other.id, id) || other.id == id)&&(identical(other.title, title) || other.title == title)&&(identical(other.accountId, accountId) || other.accountId == accountId)&&(identical(other.amount, amount) || other.amount == amount)&&(identical(other.currency, currency) || other.currency == currency)&&(identical(other.startAt, startAt) || other.startAt == startAt)&&(identical(other.endAt, endAt) || other.endAt == endAt)&&(identical(other.timezone, timezone) || other.timezone == timezone)&&(identical(other.rrule, rrule) || other.rrule == rrule)&&(identical(other.notes, notes) || other.notes == notes)&&(identical(other.isActive, isActive) || other.isActive == isActive)&&(identical(other.autoPost, autoPost) || other.autoPost == autoPost)&&(identical(other.reminderMinutesBefore, reminderMinutesBefore) || other.reminderMinutesBefore == reminderMinutesBefore)&&(identical(other.shortMonthPolicy, shortMonthPolicy) || other.shortMonthPolicy == shortMonthPolicy)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,title,accountId,amount,currency,startAt,endAt,timezone,rrule,notes,isActive,autoPost,reminderMinutesBefore,shortMonthPolicy,createdAt,updatedAt);
+
+@override
+String toString() {
+  return 'RecurringRule(id: $id, title: $title, accountId: $accountId, amount: $amount, currency: $currency, startAt: $startAt, endAt: $endAt, timezone: $timezone, rrule: $rrule, notes: $notes, isActive: $isActive, autoPost: $autoPost, reminderMinutesBefore: $reminderMinutesBefore, shortMonthPolicy: $shortMonthPolicy, createdAt: $createdAt, updatedAt: $updatedAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$RecurringRuleCopyWith<$Res> implements $RecurringRuleCopyWith<$Res> {
+  factory _$RecurringRuleCopyWith(_RecurringRule value, $Res Function(_RecurringRule) _then) = __$RecurringRuleCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, String title, String accountId, double amount, String currency, DateTime startAt, DateTime? endAt, String timezone, String rrule, String? notes, bool isActive, bool autoPost, int? reminderMinutesBefore, RecurringRuleShortMonthPolicy shortMonthPolicy, DateTime createdAt, DateTime updatedAt
+});
+
+
+
+
+}
+/// @nodoc
+class __$RecurringRuleCopyWithImpl<$Res>
+    implements _$RecurringRuleCopyWith<$Res> {
+  __$RecurringRuleCopyWithImpl(this._self, this._then);
+
+  final _RecurringRule _self;
+  final $Res Function(_RecurringRule) _then;
+
+/// Create a copy of RecurringRule
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? title = null,Object? accountId = null,Object? amount = null,Object? currency = null,Object? startAt = null,Object? endAt = freezed,Object? timezone = null,Object? rrule = null,Object? notes = freezed,Object? isActive = null,Object? autoPost = null,Object? reminderMinutesBefore = freezed,Object? shortMonthPolicy = null,Object? createdAt = null,Object? updatedAt = null,}) {
+  return _then(_RecurringRule(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,accountId: null == accountId ? _self.accountId : accountId // ignore: cast_nullable_to_non_nullable
+as String,amount: null == amount ? _self.amount : amount // ignore: cast_nullable_to_non_nullable
+as double,currency: null == currency ? _self.currency : currency // ignore: cast_nullable_to_non_nullable
+as String,startAt: null == startAt ? _self.startAt : startAt // ignore: cast_nullable_to_non_nullable
+as DateTime,endAt: freezed == endAt ? _self.endAt : endAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,timezone: null == timezone ? _self.timezone : timezone // ignore: cast_nullable_to_non_nullable
+as String,rrule: null == rrule ? _self.rrule : rrule // ignore: cast_nullable_to_non_nullable
+as String,notes: freezed == notes ? _self.notes : notes // ignore: cast_nullable_to_non_nullable
+as String?,isActive: null == isActive ? _self.isActive : isActive // ignore: cast_nullable_to_non_nullable
+as bool,autoPost: null == autoPost ? _self.autoPost : autoPost // ignore: cast_nullable_to_non_nullable
+as bool,reminderMinutesBefore: freezed == reminderMinutesBefore ? _self.reminderMinutesBefore : reminderMinutesBefore // ignore: cast_nullable_to_non_nullable
+as int?,shortMonthPolicy: null == shortMonthPolicy ? _self.shortMonthPolicy : shortMonthPolicy // ignore: cast_nullable_to_non_nullable
+as RecurringRuleShortMonthPolicy,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/features/recurring_transactions/domain/entities/recurring_rule.g.dart
+++ b/lib/features/recurring_transactions/domain/entities/recurring_rule.g.dart
@@ -1,0 +1,60 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'recurring_rule.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_RecurringRule _$RecurringRuleFromJson(Map<String, dynamic> json) =>
+    _RecurringRule(
+      id: json['id'] as String,
+      title: json['title'] as String,
+      accountId: json['accountId'] as String,
+      amount: (json['amount'] as num).toDouble(),
+      currency: json['currency'] as String,
+      startAt: DateTime.parse(json['startAt'] as String),
+      endAt: json['endAt'] == null
+          ? null
+          : DateTime.parse(json['endAt'] as String),
+      timezone: json['timezone'] as String,
+      rrule: json['rrule'] as String,
+      notes: json['notes'] as String?,
+      isActive: json['isActive'] as bool? ?? true,
+      autoPost: json['autoPost'] as bool? ?? false,
+      reminderMinutesBefore: (json['reminderMinutesBefore'] as num?)?.toInt(),
+      shortMonthPolicy:
+          $enumDecodeNullable(
+            _$RecurringRuleShortMonthPolicyEnumMap,
+            json['shortMonthPolicy'],
+          ) ??
+          RecurringRuleShortMonthPolicy.clipToLastDay,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      updatedAt: DateTime.parse(json['updatedAt'] as String),
+    );
+
+Map<String, dynamic> _$RecurringRuleToJson(_RecurringRule instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'title': instance.title,
+      'accountId': instance.accountId,
+      'amount': instance.amount,
+      'currency': instance.currency,
+      'startAt': instance.startAt.toIso8601String(),
+      'endAt': instance.endAt?.toIso8601String(),
+      'timezone': instance.timezone,
+      'rrule': instance.rrule,
+      'notes': instance.notes,
+      'isActive': instance.isActive,
+      'autoPost': instance.autoPost,
+      'reminderMinutesBefore': instance.reminderMinutesBefore,
+      'shortMonthPolicy':
+          _$RecurringRuleShortMonthPolicyEnumMap[instance.shortMonthPolicy]!,
+      'createdAt': instance.createdAt.toIso8601String(),
+      'updatedAt': instance.updatedAt.toIso8601String(),
+    };
+
+const _$RecurringRuleShortMonthPolicyEnumMap = {
+  RecurringRuleShortMonthPolicy.clipToLastDay: 'clipToLastDay',
+  RecurringRuleShortMonthPolicy.skipMonth: 'skipMonth',
+};

--- a/lib/features/recurring_transactions/domain/repositories/recurring_transactions_repository.dart
+++ b/lib/features/recurring_transactions/domain/repositories/recurring_transactions_repository.dart
@@ -1,0 +1,37 @@
+import 'package:kopim/features/recurring_transactions/domain/entities/recurring_job.dart';
+import 'package:kopim/features/recurring_transactions/domain/entities/recurring_occurrence.dart';
+import 'package:kopim/features/recurring_transactions/domain/entities/recurring_rule.dart';
+
+abstract class RecurringTransactionsRepository {
+  Stream<List<RecurringRule>> watchRules();
+  Stream<List<RecurringOccurrence>> watchUpcomingOccurrences({
+    required DateTime from,
+    required DateTime to,
+  });
+  Stream<List<RecurringOccurrence>> watchRuleOccurrences(String ruleId);
+
+  Future<RecurringRule?> getRuleById(String id);
+  Future<List<RecurringRule>> getAllRules({bool activeOnly = false});
+  Future<void> upsertRule(RecurringRule rule, {bool regenerateWindow = true});
+  Future<void> deleteRule(String id);
+  Future<void> toggleRule({required String id, required bool isActive});
+
+  Future<void> saveOccurrences(
+    Iterable<RecurringOccurrence> occurrences, {
+    bool replaceExisting = false,
+  });
+  Future<void> updateOccurrenceStatus(
+    String occurrenceId,
+    RecurringOccurrenceStatus status, {
+    String? postedTxId,
+  });
+  Future<List<RecurringOccurrence>> getDueOccurrences(DateTime forDate);
+
+  Future<void> enqueueJob({
+    required String type,
+    required String payload,
+    required DateTime runAt,
+  });
+  Future<void> markJobAttempt(int jobId, {String? error});
+  Stream<List<RecurringJob>> watchPendingJobs();
+}

--- a/lib/features/recurring_transactions/domain/services/recurring_rule_engine.dart
+++ b/lib/features/recurring_transactions/domain/services/recurring_rule_engine.dart
@@ -1,0 +1,220 @@
+import 'dart:isolate';
+
+import 'package:kopim/features/recurring_transactions/domain/entities/recurring_occurrence.dart';
+import 'package:kopim/features/recurring_transactions/domain/entities/recurring_rule.dart';
+import 'package:rrule/rrule.dart';
+import 'package:timezone/data/latest.dart' as tzdata;
+import 'package:timezone/timezone.dart' as tz;
+
+class RecurringRuleEngine {
+  RecurringRuleEngine({int? windowMonthsForward})
+    : _windowMonthsForward = windowMonthsForward ?? 6;
+
+  final int _windowMonthsForward;
+
+  Future<List<RecurringOccurrence>> generateOccurrences({
+    required RecurringRule rule,
+    required DateTime windowStart,
+    required DateTime windowEnd,
+  }) {
+    return Isolate.run(() {
+      _ensureTimeZonesInitialized();
+      return _generateOccurrences(
+        rule: rule,
+        windowStart: windowStart,
+        windowEnd: windowEnd,
+        windowMonthsForward: _windowMonthsForward,
+      );
+    });
+  }
+}
+
+bool _tzInitialized = false;
+
+void _ensureTimeZonesInitialized() {
+  if (!_tzInitialized) {
+    tzdata.initializeTimeZones();
+    _tzInitialized = true;
+  }
+}
+
+List<RecurringOccurrence> _generateOccurrences({
+  required RecurringRule rule,
+  required DateTime windowStart,
+  required DateTime windowEnd,
+  required int windowMonthsForward,
+}) {
+  final tz.Location location = tz.getLocation(rule.timezone);
+  final tz.TZDateTime start = tz.TZDateTime.from(rule.startAt, location);
+
+  final String rruleString = rule.rrule.trim().startsWith('RRULE:')
+      ? rule.rrule.trim()
+      : 'RRULE:${rule.rrule.trim()}';
+  final RecurrenceRule recurrenceRule = RecurrenceRule.fromString(rruleString);
+
+  final tz.TZDateTime localWindowStart = tz.TZDateTime.from(
+    windowStart,
+    location,
+  );
+  final tz.TZDateTime localWindowEnd = tz.TZDateTime.from(windowEnd, location);
+
+  final Set<String> seenIds = <String>{};
+  final List<RecurringOccurrence> occurrences = <RecurringOccurrence>[];
+  final DateTime startFloating = _toFloatingUtc(start);
+  final DateTime afterFloatingCandidate = _toFloatingUtc(
+    localWindowStart,
+  ).subtract(const Duration(seconds: 1));
+  final DateTime afterFloating = afterFloatingCandidate.isBefore(startFloating)
+      ? startFloating
+      : afterFloatingCandidate;
+  final DateTime beforeFloating = _toFloatingUtc(
+    localWindowEnd,
+  ).add(const Duration(seconds: 1));
+
+  final Iterable<DateTime> generated = recurrenceRule.getInstances(
+    start: startFloating,
+    after: afterFloating,
+    includeAfter: true,
+    before: beforeFloating,
+    includeBefore: true,
+  );
+
+  for (final DateTime occurrence in generated) {
+    final tz.TZDateTime instance = tz.TZDateTime(
+      location,
+      occurrence.year,
+      occurrence.month,
+      occurrence.day,
+      occurrence.hour,
+      occurrence.minute,
+      occurrence.second,
+      occurrence.millisecond,
+      occurrence.microsecond,
+    );
+    if (_isOutsideRule(instance, rule, localWindowStart, localWindowEnd)) {
+      continue;
+    }
+    final String occurrenceId = _occurrenceId(rule.id, instance);
+    if (seenIds.add(occurrenceId)) {
+      occurrences.add(
+        RecurringOccurrence(
+          id: occurrenceId,
+          ruleId: rule.id,
+          dueAt: _asUtcDateTime(instance),
+          createdAt: DateTime.now().toUtc(),
+        ),
+      );
+    }
+  }
+
+  if (rule.shortMonthPolicy == RecurringRuleShortMonthPolicy.clipToLastDay &&
+      recurrenceRule.frequency == Frequency.monthly) {
+    final Set<int> targetDays = recurrenceRule.byMonthDays.isNotEmpty
+        ? recurrenceRule.byMonthDays.toSet()
+        : <int>{start.day};
+    if (targetDays.isNotEmpty) {
+      tz.TZDateTime cursor = tz.TZDateTime(
+        location,
+        localWindowStart.year,
+        localWindowStart.month,
+      );
+      final tz.TZDateTime limit = tz.TZDateTime(
+        location,
+        localWindowEnd.year,
+        localWindowEnd.month,
+      );
+      while (!cursor.isAfter(limit)) {
+        for (final int day in targetDays) {
+          final int lastDayOfMonth = DateTime(
+            cursor.year,
+            cursor.month + 1,
+            0,
+          ).day;
+          final int resolvedDay = day > lastDayOfMonth ? lastDayOfMonth : day;
+          final tz.TZDateTime candidate = tz.TZDateTime(
+            location,
+            cursor.year,
+            cursor.month,
+            resolvedDay,
+            start.hour,
+            start.minute,
+            start.second,
+            start.millisecond,
+            start.microsecond,
+          );
+          if (_isOutsideRule(
+            candidate,
+            rule,
+            localWindowStart,
+            localWindowEnd,
+          )) {
+            continue;
+          }
+          final String occurrenceId = _occurrenceId(rule.id, candidate);
+          if (seenIds.add(occurrenceId)) {
+            occurrences.add(
+              RecurringOccurrence(
+                id: occurrenceId,
+                ruleId: rule.id,
+                dueAt: _asUtcDateTime(candidate),
+                createdAt: DateTime.now().toUtc(),
+              ),
+            );
+          }
+        }
+        cursor = tz.TZDateTime(location, cursor.year, cursor.month + 1);
+      }
+    }
+  }
+
+  occurrences.sort(
+    (RecurringOccurrence a, RecurringOccurrence b) =>
+        a.dueAt.compareTo(b.dueAt),
+  );
+  return occurrences;
+}
+
+bool _isOutsideRule(
+  tz.TZDateTime instance,
+  RecurringRule rule,
+  tz.TZDateTime windowStart,
+  tz.TZDateTime windowEnd,
+) {
+  if (instance.isBefore(windowStart)) {
+    return true;
+  }
+  if (instance.isAfter(windowEnd)) {
+    return true;
+  }
+  if (rule.endAt != null) {
+    final DateTime endAtUtc = rule.endAt!.toUtc();
+    if (instance.toUtc().isAfter(endAtUtc)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+String _occurrenceId(String ruleId, tz.TZDateTime dueAt) {
+  return '$ruleId-${dueAt.toUtc().toIso8601String()}';
+}
+
+DateTime _asUtcDateTime(tz.TZDateTime value) {
+  return DateTime.fromMillisecondsSinceEpoch(
+    value.millisecondsSinceEpoch,
+    isUtc: true,
+  );
+}
+
+DateTime _toFloatingUtc(tz.TZDateTime value) {
+  return DateTime.utc(
+    value.year,
+    value.month,
+    value.day,
+    value.hour,
+    value.minute,
+    value.second,
+    value.millisecond,
+    value.microsecond,
+  );
+}

--- a/lib/features/recurring_transactions/domain/use_cases/delete_recurring_rule_use_case.dart
+++ b/lib/features/recurring_transactions/domain/use_cases/delete_recurring_rule_use_case.dart
@@ -1,0 +1,11 @@
+import 'package:kopim/features/recurring_transactions/domain/repositories/recurring_transactions_repository.dart';
+
+class DeleteRecurringRuleUseCase {
+  const DeleteRecurringRuleUseCase(this._repository);
+
+  final RecurringTransactionsRepository _repository;
+
+  Future<void> call(String id) {
+    return _repository.deleteRule(id);
+  }
+}

--- a/lib/features/recurring_transactions/domain/use_cases/regenerate_rule_window_use_case.dart
+++ b/lib/features/recurring_transactions/domain/use_cases/regenerate_rule_window_use_case.dart
@@ -1,0 +1,29 @@
+import 'package:kopim/features/recurring_transactions/domain/entities/recurring_occurrence.dart';
+import 'package:kopim/features/recurring_transactions/domain/entities/recurring_rule.dart';
+import 'package:kopim/features/recurring_transactions/domain/repositories/recurring_transactions_repository.dart';
+import 'package:kopim/features/recurring_transactions/domain/services/recurring_rule_engine.dart';
+
+class RegenerateRuleWindowUseCase {
+  const RegenerateRuleWindowUseCase(this._repository, this._engine);
+
+  final RecurringTransactionsRepository _repository;
+  final RecurringRuleEngine _engine;
+
+  Future<void> call({
+    required String ruleId,
+    required DateTime windowStart,
+    required DateTime windowEnd,
+  }) async {
+    final RecurringRule? rule = await _repository.getRuleById(ruleId);
+    if (rule == null) {
+      return;
+    }
+    final List<RecurringOccurrence> occurrences = await _engine
+        .generateOccurrences(
+          rule: rule,
+          windowStart: windowStart,
+          windowEnd: windowEnd,
+        );
+    await _repository.saveOccurrences(occurrences, replaceExisting: true);
+  }
+}

--- a/lib/features/recurring_transactions/domain/use_cases/save_recurring_rule_use_case.dart
+++ b/lib/features/recurring_transactions/domain/use_cases/save_recurring_rule_use_case.dart
@@ -1,0 +1,12 @@
+import 'package:kopim/features/recurring_transactions/domain/entities/recurring_rule.dart';
+import 'package:kopim/features/recurring_transactions/domain/repositories/recurring_transactions_repository.dart';
+
+class SaveRecurringRuleUseCase {
+  const SaveRecurringRuleUseCase(this._repository);
+
+  final RecurringTransactionsRepository _repository;
+
+  Future<void> call(RecurringRule rule, {bool regenerateWindow = true}) {
+    return _repository.upsertRule(rule, regenerateWindow: regenerateWindow);
+  }
+}

--- a/lib/features/recurring_transactions/domain/use_cases/toggle_recurring_rule_use_case.dart
+++ b/lib/features/recurring_transactions/domain/use_cases/toggle_recurring_rule_use_case.dart
@@ -1,0 +1,11 @@
+import 'package:kopim/features/recurring_transactions/domain/repositories/recurring_transactions_repository.dart';
+
+class ToggleRecurringRuleUseCase {
+  const ToggleRecurringRuleUseCase(this._repository);
+
+  final RecurringTransactionsRepository _repository;
+
+  Future<void> call({required String id, required bool isActive}) {
+    return _repository.toggleRule(id: id, isActive: isActive);
+  }
+}

--- a/lib/features/recurring_transactions/domain/use_cases/watch_recurring_rules_use_case.dart
+++ b/lib/features/recurring_transactions/domain/use_cases/watch_recurring_rules_use_case.dart
@@ -1,0 +1,12 @@
+import 'package:kopim/features/recurring_transactions/domain/entities/recurring_rule.dart';
+import 'package:kopim/features/recurring_transactions/domain/repositories/recurring_transactions_repository.dart';
+
+class WatchRecurringRulesUseCase {
+  const WatchRecurringRulesUseCase(this._repository);
+
+  final RecurringTransactionsRepository _repository;
+
+  Stream<List<RecurringRule>> call() {
+    return _repository.watchRules();
+  }
+}

--- a/lib/features/recurring_transactions/domain/use_cases/watch_upcoming_occurrences_use_case.dart
+++ b/lib/features/recurring_transactions/domain/use_cases/watch_upcoming_occurrences_use_case.dart
@@ -1,0 +1,15 @@
+import 'package:kopim/features/recurring_transactions/domain/entities/recurring_occurrence.dart';
+import 'package:kopim/features/recurring_transactions/domain/repositories/recurring_transactions_repository.dart';
+
+class WatchUpcomingOccurrencesUseCase {
+  const WatchUpcomingOccurrencesUseCase(this._repository);
+
+  final RecurringTransactionsRepository _repository;
+
+  Stream<List<RecurringOccurrence>> call({
+    required DateTime from,
+    required DateTime to,
+  }) {
+    return _repository.watchUpcomingOccurrences(from: from, to: to);
+  }
+}

--- a/lib/features/recurring_transactions/presentation/controllers/recurring_transactions_providers.dart
+++ b/lib/features/recurring_transactions/presentation/controllers/recurring_transactions_providers.dart
@@ -1,0 +1,27 @@
+import 'package:kopim/core/di/injectors.dart';
+import 'package:kopim/features/recurring_transactions/domain/entities/recurring_occurrence.dart';
+import 'package:kopim/features/recurring_transactions/domain/entities/recurring_rule.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'recurring_transactions_providers.g.dart';
+
+const int kRecurringWindowMonths = 6;
+
+@riverpod
+Stream<List<RecurringRule>> recurringRules(Ref ref) {
+  return ref.watch(watchRecurringRulesUseCaseProvider).call();
+}
+
+@riverpod
+Stream<List<RecurringOccurrence>> upcomingRecurringOccurrences(
+  Ref ref, {
+  DateTime? from,
+  DateTime? to,
+}) {
+  final DateTime start = from ?? DateTime.now();
+  final DateTime end =
+      to ?? DateTime(start.year, start.month + kRecurringWindowMonths);
+  return ref
+      .watch(watchUpcomingOccurrencesUseCaseProvider)
+      .call(from: start, to: end);
+}

--- a/lib/features/recurring_transactions/presentation/controllers/recurring_transactions_providers.g.dart
+++ b/lib/features/recurring_transactions/presentation/controllers/recurring_transactions_providers.g.dart
@@ -1,0 +1,142 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'recurring_transactions_providers.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(recurringRules)
+const recurringRulesProvider = RecurringRulesProvider._();
+
+final class RecurringRulesProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<RecurringRule>>,
+          List<RecurringRule>,
+          Stream<List<RecurringRule>>
+        >
+    with
+        $FutureModifier<List<RecurringRule>>,
+        $StreamProvider<List<RecurringRule>> {
+  const RecurringRulesProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'recurringRulesProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$recurringRulesHash();
+
+  @$internal
+  @override
+  $StreamProviderElement<List<RecurringRule>> $createElement(
+    $ProviderPointer pointer,
+  ) => $StreamProviderElement(pointer);
+
+  @override
+  Stream<List<RecurringRule>> create(Ref ref) {
+    return recurringRules(ref);
+  }
+}
+
+String _$recurringRulesHash() => r'5fa30fa65c7e7c733773fdbf42242d31e71bb6a4';
+
+@ProviderFor(upcomingRecurringOccurrences)
+const upcomingRecurringOccurrencesProvider =
+    UpcomingRecurringOccurrencesFamily._();
+
+final class UpcomingRecurringOccurrencesProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<RecurringOccurrence>>,
+          List<RecurringOccurrence>,
+          Stream<List<RecurringOccurrence>>
+        >
+    with
+        $FutureModifier<List<RecurringOccurrence>>,
+        $StreamProvider<List<RecurringOccurrence>> {
+  const UpcomingRecurringOccurrencesProvider._({
+    required UpcomingRecurringOccurrencesFamily super.from,
+    required ({DateTime? from, DateTime? to}) super.argument,
+  }) : super(
+         retry: null,
+         name: r'upcomingRecurringOccurrencesProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$upcomingRecurringOccurrencesHash();
+
+  @override
+  String toString() {
+    return r'upcomingRecurringOccurrencesProvider'
+        ''
+        '$argument';
+  }
+
+  @$internal
+  @override
+  $StreamProviderElement<List<RecurringOccurrence>> $createElement(
+    $ProviderPointer pointer,
+  ) => $StreamProviderElement(pointer);
+
+  @override
+  Stream<List<RecurringOccurrence>> create(Ref ref) {
+    final argument = this.argument as ({DateTime? from, DateTime? to});
+    return upcomingRecurringOccurrences(
+      ref,
+      from: argument.from,
+      to: argument.to,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is UpcomingRecurringOccurrencesProvider &&
+        other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$upcomingRecurringOccurrencesHash() =>
+    r'564a4250158c7c3912ff10ecd00333d05cd12ecc';
+
+final class UpcomingRecurringOccurrencesFamily extends $Family
+    with
+        $FunctionalFamilyOverride<
+          Stream<List<RecurringOccurrence>>,
+          ({DateTime? from, DateTime? to})
+        > {
+  const UpcomingRecurringOccurrencesFamily._()
+    : super(
+        retry: null,
+        name: r'upcomingRecurringOccurrencesProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  UpcomingRecurringOccurrencesProvider call({DateTime? from, DateTime? to}) =>
+      UpcomingRecurringOccurrencesProvider._(
+        argument: (from: from, to: to),
+        from: this,
+      );
+
+  @override
+  String toString() => r'upcomingRecurringOccurrencesProvider';
+}

--- a/lib/features/recurring_transactions/presentation/screens/recurring_transactions_screen.dart
+++ b/lib/features/recurring_transactions/presentation/screens/recurring_transactions_screen.dart
@@ -1,6 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-
+import 'package:intl/intl.dart';
+import 'package:kopim/core/di/injectors.dart';
+import 'package:kopim/features/recurring_transactions/domain/entities/recurring_occurrence.dart';
+import 'package:kopim/features/recurring_transactions/domain/entities/recurring_rule.dart';
+import 'package:kopim/features/recurring_transactions/presentation/controllers/recurring_transactions_providers.dart';
 import 'package:kopim/l10n/app_localizations.dart';
 
 /// Entry point screen that will host recurring transaction management.
@@ -12,17 +16,145 @@ class RecurringTransactionsScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final AppLocalizations strings = AppLocalizations.of(context)!;
+    final AsyncValue<List<RecurringRule>> rulesAsync = ref.watch(
+      recurringRulesProvider,
+    );
+    final AsyncValue<List<RecurringOccurrence>> upcomingAsync = ref.watch(
+      upcomingRecurringOccurrencesProvider(),
+    );
 
     return Scaffold(
       appBar: AppBar(title: Text(strings.recurringTransactionsTitle)),
-      body: Center(
-        child: Padding(
-          padding: const EdgeInsets.all(24),
-          child: Text(
-            strings.recurringTransactionsEmpty,
-            style: Theme.of(context).textTheme.bodyLarge,
-            textAlign: TextAlign.center,
-          ),
+      body: rulesAsync.when(
+        data: (List<RecurringRule> rules) {
+          if (rules.isEmpty) {
+            return _EmptyState(message: strings.recurringTransactionsEmpty);
+          }
+          final Map<String, RecurringOccurrence?> nextByRule =
+              _mapNextOccurrence(rules: rules, occurrencesAsync: upcomingAsync);
+          return RefreshIndicator(
+            onRefresh: () async {
+              await ref.read(recurringWindowServiceProvider).rebuildWindow();
+            },
+            child: ListView.separated(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 24),
+              itemBuilder: (BuildContext context, int index) {
+                final RecurringRule rule = rules[index];
+                final RecurringOccurrence? nextOccurrence = nextByRule[rule.id];
+                return _RecurringRuleTile(
+                  rule: rule,
+                  nextOccurrence: nextOccurrence,
+                  onToggle: (bool value) async {
+                    await ref
+                        .read(toggleRecurringRuleUseCaseProvider)
+                        .call(id: rule.id, isActive: value);
+                  },
+                );
+              },
+              separatorBuilder: (BuildContext context, int _) =>
+                  const SizedBox(height: 12),
+              itemCount: rules.length,
+            ),
+          );
+        },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (Object error, StackTrace stackTrace) =>
+            Center(child: Text(strings.genericErrorMessage)),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => _showComingSoon(context),
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+
+  Map<String, RecurringOccurrence?> _mapNextOccurrence({
+    required List<RecurringRule> rules,
+    required AsyncValue<List<RecurringOccurrence>> occurrencesAsync,
+  }) {
+    final Map<String, RecurringOccurrence?> map =
+        <String, RecurringOccurrence?>{};
+    final List<RecurringOccurrence>? occurrences = occurrencesAsync.value;
+    if (occurrences == null) {
+      for (final RecurringRule rule in rules) {
+        map[rule.id] = null;
+      }
+      return map;
+    }
+    final Map<String, List<RecurringOccurrence>> grouped =
+        <String, List<RecurringOccurrence>>{};
+    for (final RecurringOccurrence occurrence in occurrences) {
+      final List<RecurringOccurrence> list = grouped.putIfAbsent(
+        occurrence.ruleId,
+        () => <RecurringOccurrence>[],
+      );
+      list.add(occurrence);
+    }
+    grouped.updateAll((String key, List<RecurringOccurrence> value) {
+      value.sort(
+        (RecurringOccurrence a, RecurringOccurrence b) =>
+            a.dueAt.compareTo(b.dueAt),
+      );
+      return value;
+    });
+    for (final RecurringRule rule in rules) {
+      final List<RecurringOccurrence>? list = grouped[rule.id];
+      map[rule.id] = list == null || list.isEmpty ? null : list.first;
+    }
+    return map;
+  }
+
+  void _showComingSoon(BuildContext context) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(AppLocalizations.of(context)!.commonComingSoon)),
+    );
+  }
+}
+
+class _RecurringRuleTile extends StatelessWidget {
+  const _RecurringRuleTile({
+    required this.rule,
+    required this.nextOccurrence,
+    required this.onToggle,
+  });
+
+  final RecurringRule rule;
+  final RecurringOccurrence? nextOccurrence;
+  final ValueChanged<bool> onToggle;
+
+  @override
+  Widget build(BuildContext context) {
+    final DateFormat dateFormat = DateFormat.yMMMMd();
+    final String subtitle = nextOccurrence == null
+        ? AppLocalizations.of(context)!.recurringTransactionsNoUpcoming
+        : '${AppLocalizations.of(context)!.recurringTransactionsNextDue}: '
+              '${dateFormat.format(nextOccurrence!.dueAt.toLocal())}';
+    return Material(
+      elevation: 1,
+      borderRadius: BorderRadius.circular(12),
+      child: ListTile(
+        title: Text(rule.title),
+        subtitle: Text(subtitle),
+        trailing: Switch(value: rule.isActive, onChanged: onToggle),
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Text(
+          message,
+          style: Theme.of(context).textTheme.bodyLarge,
+          textAlign: TextAlign.center,
         ),
       ),
     );

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -281,6 +281,22 @@
   "@recurringTransactionsEmpty": {
     "description": "Placeholder shown when there are no recurring transactions configured"
   },
+  "recurringTransactionsNextDue": "Next due",
+  "@recurringTransactionsNextDue": {
+    "description": "Label prefix for the next due date of a recurring rule"
+  },
+  "recurringTransactionsNoUpcoming": "No upcoming occurrences",
+  "@recurringTransactionsNoUpcoming": {
+    "description": "Shown when a recurring rule has no future occurrences"
+  },
+  "commonComingSoon": "Coming soon",
+  "@commonComingSoon": {
+    "description": "Generic copy when a feature is not yet available"
+  },
+  "genericErrorMessage": "Something went wrong. Please try again later.",
+  "@genericErrorMessage": {
+    "description": "Fallback error message for unexpected failures"
+  },
   "signInTitle": "Welcome to Kopim",
   "@signInTitle": {
     "description": "Main heading on the sign-in screen"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -482,6 +482,30 @@ abstract class AppLocalizations {
   /// **'No recurring transactions yet. Create one to automate your cash flow.'**
   String get recurringTransactionsEmpty;
 
+  /// Label prefix for the next due date of a recurring rule
+  ///
+  /// In en, this message translates to:
+  /// **'Next due'**
+  String get recurringTransactionsNextDue;
+
+  /// Shown when a recurring rule has no future occurrences
+  ///
+  /// In en, this message translates to:
+  /// **'No upcoming occurrences'**
+  String get recurringTransactionsNoUpcoming;
+
+  /// Generic copy when a feature is not yet available
+  ///
+  /// In en, this message translates to:
+  /// **'Coming soon'**
+  String get commonComingSoon;
+
+  /// Fallback error message for unexpected failures
+  ///
+  /// In en, this message translates to:
+  /// **'Something went wrong. Please try again later.'**
+  String get genericErrorMessage;
+
   /// Main heading on the sign-in screen
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -213,6 +213,19 @@ class AppLocalizationsEn extends AppLocalizations {
       'No recurring transactions yet. Create one to automate your cash flow.';
 
   @override
+  String get recurringTransactionsNextDue => 'Next due';
+
+  @override
+  String get recurringTransactionsNoUpcoming => 'No upcoming occurrences';
+
+  @override
+  String get commonComingSoon => 'Coming soon';
+
+  @override
+  String get genericErrorMessage =>
+      'Something went wrong. Please try again later.';
+
+  @override
   String get signInTitle => 'Welcome to Kopim';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -214,6 +214,18 @@ class AppLocalizationsRu extends AppLocalizations {
       'Пока нет повторяющихся операций. Создайте правило, чтобы автоматизировать движение средств.';
 
   @override
+  String get recurringTransactionsNextDue => 'Ближайшая дата';
+
+  @override
+  String get recurringTransactionsNoUpcoming => 'Нет предстоящих операций';
+
+  @override
+  String get commonComingSoon => 'Скоро появится';
+
+  @override
+  String get genericErrorMessage => 'Что-то пошло не так. Попробуйте позже.';
+
+  @override
   String get signInTitle => 'Добро пожаловать в Kopim';
 
   @override

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -281,6 +281,22 @@
   "@recurringTransactionsEmpty": {
     "description": "Сообщение-заглушка, когда нет настроенных повторяющихся операций"
   },
+  "recurringTransactionsNextDue": "Ближайшая дата",
+  "@recurringTransactionsNextDue": {
+    "description": "Label prefix for the next due date of a recurring rule"
+  },
+  "recurringTransactionsNoUpcoming": "Нет предстоящих операций",
+  "@recurringTransactionsNoUpcoming": {
+    "description": "Shown when a recurring rule has no future occurrences"
+  },
+  "commonComingSoon": "Скоро появится",
+  "@commonComingSoon": {
+    "description": "Generic copy when a feature is not yet available"
+  },
+  "genericErrorMessage": "Что-то пошло не так. Попробуйте позже.",
+  "@genericErrorMessage": {
+    "description": "Fallback error message for unexpected failures"
+  },
   "signInTitle": "Добро пожаловать в Kopim",
   "@signInTitle": {
     "description": "Заголовок экрана входа"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,6 +59,8 @@ dependencies:
   google_generative_ai: ^0.4.7
   uuid: ^4.5.1
   phosphor_flutter: ^2.1.0
+  rrule: ^0.2.17
+  timezone: ^0.10.0
 
 dev_dependencies:
   flutter_test:

--- a/test/features/home/presentation/screens/home_screen_test.dart
+++ b/test/features/home/presentation/screens/home_screen_test.dart
@@ -137,16 +137,17 @@ void main() {
         final Completer<List<TransactionEntity>> completer =
             Completer<List<TransactionEntity>>();
         final ProviderSubscription<AsyncValue<List<TransactionEntity>>>
-        subscription = scopedContainer.listen(homeRecentTransactionsProvider(), (
-          AsyncValue<List<TransactionEntity>>? previous,
-          AsyncValue<List<TransactionEntity>> next,
-        ) {
-          next.whenData((List<TransactionEntity> transactions) {
-            if (!completer.isCompleted) {
-              completer.complete(transactions);
-            }
-          });
-        }, fireImmediately: true);
+        subscription = scopedContainer
+            .listen(homeRecentTransactionsProvider(), (
+              AsyncValue<List<TransactionEntity>>? previous,
+              AsyncValue<List<TransactionEntity>> next,
+            ) {
+              next.whenData((List<TransactionEntity> transactions) {
+                if (!completer.isCompleted) {
+                  completer.complete(transactions);
+                }
+              });
+            }, fireImmediately: true);
         addTearDown(subscription.close);
 
         controller.add(<TransactionEntity>[_transaction('a')]);

--- a/test/features/profile/presentation/profile_screen_test.dart
+++ b/test/features/profile/presentation/profile_screen_test.dart
@@ -13,6 +13,10 @@ import 'package:kopim/features/profile/domain/usecases/update_profile_use_case.d
 import 'package:kopim/features/profile/presentation/controllers/auth_controller.dart';
 import 'package:kopim/features/profile/presentation/controllers/profile_controller.dart';
 import 'package:kopim/features/profile/presentation/screens/profile_screen.dart';
+import 'package:kopim/features/recurring_transactions/domain/entities/recurring_job.dart';
+import 'package:kopim/features/recurring_transactions/domain/entities/recurring_occurrence.dart';
+import 'package:kopim/features/recurring_transactions/domain/entities/recurring_rule.dart';
+import 'package:kopim/features/recurring_transactions/domain/repositories/recurring_transactions_repository.dart';
 import 'package:kopim/features/recurring_transactions/presentation/screens/recurring_transactions_screen.dart';
 import 'package:kopim/l10n/app_localizations.dart';
 
@@ -55,6 +59,76 @@ class _FakeProfileController extends ProfileController {
   FutureOr<Profile?> build(String uid) => _profile;
 }
 
+class _StubRecurringTransactionsRepository
+    implements RecurringTransactionsRepository {
+  const _StubRecurringTransactionsRepository();
+
+  @override
+  Future<void> deleteRule(String id) => throw UnimplementedError();
+
+  @override
+  Future<void> enqueueJob({
+    required String type,
+    required String payload,
+    required DateTime runAt,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<List<RecurringRule>> getAllRules({bool activeOnly = false}) =>
+      Future<List<RecurringRule>>.value(const <RecurringRule>[]);
+
+  @override
+  Future<List<RecurringOccurrence>> getDueOccurrences(DateTime forDate) =>
+      Future<List<RecurringOccurrence>>.value(const <RecurringOccurrence>[]);
+
+  @override
+  Future<RecurringRule?> getRuleById(String id) =>
+      Future<RecurringRule?>.value(null);
+
+  @override
+  Future<void> markJobAttempt(int jobId, {String? error}) =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> saveOccurrences(
+    Iterable<RecurringOccurrence> occurrences, {
+    bool replaceExisting = false,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<void> toggleRule({required String id, required bool isActive}) =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> upsertRule(RecurringRule rule, {bool regenerateWindow = true}) =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> updateOccurrenceStatus(
+    String occurrenceId,
+    RecurringOccurrenceStatus status, {
+    String? postedTxId,
+  }) => throw UnimplementedError();
+
+  @override
+  Stream<List<RecurringJob>> watchPendingJobs() =>
+      Stream<List<RecurringJob>>.value(const <RecurringJob>[]);
+
+  @override
+  Stream<List<RecurringOccurrence>> watchRuleOccurrences(String ruleId) =>
+      Stream<List<RecurringOccurrence>>.value(const <RecurringOccurrence>[]);
+
+  @override
+  Stream<List<RecurringRule>> watchRules() =>
+      Stream<List<RecurringRule>>.value(const <RecurringRule>[]);
+
+  @override
+  Stream<List<RecurringOccurrence>> watchUpcomingOccurrences({
+    required DateTime from,
+    required DateTime to,
+  }) => Stream<List<RecurringOccurrence>>.value(const <RecurringOccurrence>[]);
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -93,6 +167,9 @@ void main() {
             (Ref ref) => Stream<List<CategoryTreeNode>>.value(
               const <CategoryTreeNode>[],
             ),
+          ),
+          recurringTransactionsRepositoryProvider.overrideWithValue(
+            const _StubRecurringTransactionsRepository(),
           ),
         ],
         child: const MaterialApp(
@@ -138,6 +215,9 @@ void main() {
               const <CategoryTreeNode>[],
             ),
           ),
+          recurringTransactionsRepositoryProvider.overrideWithValue(
+            const _StubRecurringTransactionsRepository(),
+          ),
         ],
         child: const MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -177,6 +257,9 @@ void main() {
             (Ref ref) => Stream<List<CategoryTreeNode>>.value(
               const <CategoryTreeNode>[],
             ),
+          ),
+          recurringTransactionsRepositoryProvider.overrideWithValue(
+            const _StubRecurringTransactionsRepository(),
           ),
         ],
         child: MaterialApp(
@@ -234,6 +317,9 @@ void main() {
               (Ref ref) => Stream<List<CategoryTreeNode>>.value(
                 const <CategoryTreeNode>[],
               ),
+            ),
+            recurringTransactionsRepositoryProvider.overrideWithValue(
+              const _StubRecurringTransactionsRepository(),
             ),
           ],
           child: MaterialApp(
@@ -293,6 +379,9 @@ void main() {
             (Ref ref) => Stream<List<CategoryTreeNode>>.value(
               const <CategoryTreeNode>[],
             ),
+          ),
+          recurringTransactionsRepositoryProvider.overrideWithValue(
+            const _StubRecurringTransactionsRepository(),
           ),
         ],
         child: const MaterialApp(

--- a/test/features/recurring_transactions/domain/services/recurring_rule_engine_test.dart
+++ b/test/features/recurring_transactions/domain/services/recurring_rule_engine_test.dart
@@ -1,0 +1,140 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kopim/features/recurring_transactions/domain/entities/recurring_occurrence.dart';
+import 'package:kopim/features/recurring_transactions/domain/entities/recurring_rule.dart';
+import 'package:kopim/features/recurring_transactions/domain/services/recurring_rule_engine.dart';
+import 'package:timezone/data/latest.dart' as tzdata;
+import 'package:timezone/timezone.dart' as tz;
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  tzdata.initializeTimeZones();
+  final RecurringRuleEngine engine = RecurringRuleEngine();
+
+  RecurringRule buildRule({
+    required String id,
+    required String rrule,
+    required DateTime startAt,
+    RecurringRuleShortMonthPolicy shortMonthPolicy =
+        RecurringRuleShortMonthPolicy.clipToLastDay,
+    DateTime? endAt,
+    String timezone = 'UTC',
+    bool autoPost = false,
+  }) {
+    final DateTime now = DateTime.now().toUtc();
+    return RecurringRule(
+      id: id,
+      title: 'Rule $id',
+      accountId: 'acc',
+      amount: 100,
+      currency: 'USD',
+      startAt: startAt,
+      timezone: timezone,
+      rrule: rrule,
+      endAt: endAt,
+      notes: null,
+      isActive: true,
+      autoPost: autoPost,
+      reminderMinutesBefore: 0,
+      shortMonthPolicy: shortMonthPolicy,
+      createdAt: now,
+      updatedAt: now,
+    );
+  }
+
+  group('RecurringRuleEngine', () {
+    test('clips short months when policy is clipToLastDay', () async {
+      final RecurringRule rule = buildRule(
+        id: 'clip',
+        rrule: 'FREQ=MONTHLY;BYMONTHDAY=31',
+        startAt: DateTime.utc(2024, 1, 31, 10),
+      );
+      final List<RecurringOccurrence> occurrences = await engine
+          .generateOccurrences(
+            rule: rule,
+            windowStart: DateTime.utc(2024, 1, 1),
+            windowEnd: DateTime.utc(2024, 4, 30, 23, 59),
+          );
+      final List<DateTime> dates = occurrences
+          .map((RecurringOccurrence e) => e.dueAt)
+          .toList();
+      expect(
+        dates,
+        containsAll(<DateTime>[
+          DateTime.utc(2024, 1, 31, 10),
+          DateTime.utc(2024, 2, 29, 10),
+          DateTime.utc(2024, 3, 31, 10),
+          DateTime.utc(2024, 4, 30, 10),
+        ]),
+      );
+    });
+
+    test('skips short months when policy is skipMonth', () async {
+      final RecurringRule rule = buildRule(
+        id: 'skip',
+        rrule: 'FREQ=MONTHLY;BYMONTHDAY=31',
+        startAt: DateTime.utc(2024, 1, 31, 8),
+        shortMonthPolicy: RecurringRuleShortMonthPolicy.skipMonth,
+      );
+      final List<RecurringOccurrence> occurrences = await engine
+          .generateOccurrences(
+            rule: rule,
+            windowStart: DateTime.utc(2024, 1, 1),
+            windowEnd: DateTime.utc(2024, 4, 30, 23, 59),
+          );
+      final List<DateTime> dates = occurrences
+          .map((RecurringOccurrence e) => e.dueAt)
+          .toList();
+      expect(dates, contains(DateTime.utc(2024, 1, 31, 8)));
+      expect(dates, isNot(contains(DateTime.utc(2024, 2, 29, 8))));
+      expect(dates, contains(DateTime.utc(2024, 3, 31, 8)));
+      expect(dates, isNot(contains(DateTime.utc(2024, 4, 30, 8))));
+    });
+
+    test('preserves local time across DST transitions', () async {
+      final RecurringRule rule = buildRule(
+        id: 'dst',
+        rrule: 'FREQ=WEEKLY',
+        startAt: DateTime.utc(2024, 3, 1, 12),
+        timezone: 'America/New_York',
+      );
+      final List<RecurringOccurrence> occurrences = await engine
+          .generateOccurrences(
+            rule: rule,
+            windowStart: DateTime.utc(2024, 3, 1),
+            windowEnd: DateTime.utc(2024, 3, 31),
+          );
+      expect(occurrences, isNotEmpty);
+      final tz.Location location = tz.getLocation('America/New_York');
+      for (final RecurringOccurrence occurrence in occurrences.take(3)) {
+        final tz.TZDateTime local = tz.TZDateTime.from(
+          occurrence.dueAt,
+          location,
+        );
+        expect(local.hour, 7); // 12:00 UTC == 7 AM EST/EDT
+      }
+    });
+
+    test('stops generating after endAt', () async {
+      final RecurringRule rule = buildRule(
+        id: 'end',
+        rrule: 'FREQ=MONTHLY;BYMONTHDAY=15',
+        startAt: DateTime.utc(2024, 1, 15, 9),
+        endAt: DateTime.utc(2024, 2, 16),
+      );
+      final List<RecurringOccurrence> occurrences = await engine
+          .generateOccurrences(
+            rule: rule,
+            windowStart: DateTime.utc(2024, 1, 1),
+            windowEnd: DateTime.utc(2024, 4, 1),
+          );
+      expect(occurrences.length, 2);
+      expect(
+        occurrences.map((RecurringOccurrence e) => e.dueAt).toList(),
+        containsAll(<DateTime>[
+          DateTime.utc(2024, 1, 15, 9),
+          DateTime.utc(2024, 2, 15, 9),
+        ]),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add recurring transactions domain models, repository implementation, and scheduling services wired into DI
- expose Riverpod providers and UI for recurring transactions while updating localization and navigation
- introduce a timezone-aware recurring rule engine with dedicated tests and adjust profile tests with repository stubs

## Testing
- `dart format --set-exit-if-changed .`
- `flutter analyze`
- `dart run build_runner build --delete-conflicting-outputs`
- `flutter test --reporter expanded`
- `flutter pub outdated`


------
https://chatgpt.com/codex/tasks/task_e_68dedc9e1ff0832e92cad7e1db5a047f