### PR TITLE
feat: enhance analytics filters and visualization

### DIFF
--- a/lib/features/analytics/domain/models/analytics_filter.dart
+++ b/lib/features/analytics/domain/models/analytics_filter.dart
@@ -1,0 +1,32 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'analytics_filter.freezed.dart';
+part 'analytics_filter.g.dart';
+
+@freezed
+abstract class AnalyticsFilter with _$AnalyticsFilter {
+  const AnalyticsFilter._();
+
+  const factory AnalyticsFilter({
+    required DateTime start,
+    required DateTime end,
+    String? accountId,
+    String? categoryId,
+  }) = _AnalyticsFilter;
+
+  factory AnalyticsFilter.fromJson(Map<String, Object?> json) =>
+      _$AnalyticsFilterFromJson(json);
+
+  factory AnalyticsFilter.monthly({DateTime? reference}) {
+    final DateTime now = reference ?? DateTime.now();
+    final DateTime monthStart = DateTime(now.year, now.month);
+    final DateTime monthEnd = DateTime(now.year, now.month + 1);
+    return AnalyticsFilter(start: monthStart, end: monthEnd);
+  }
+}
+
+extension AnalyticsFilterX on AnalyticsFilter {
+  bool includesDate(DateTime date) {
+    return !date.isBefore(start) && date.isBefore(end);
+  }
+}

--- a/lib/features/analytics/domain/models/analytics_filter.freezed.dart
+++ b/lib/features/analytics/domain/models/analytics_filter.freezed.dart
@@ -1,0 +1,286 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'analytics_filter.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$AnalyticsFilter {
+
+ DateTime get start; DateTime get end; String? get accountId; String? get categoryId;
+/// Create a copy of AnalyticsFilter
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$AnalyticsFilterCopyWith<AnalyticsFilter> get copyWith => _$AnalyticsFilterCopyWithImpl<AnalyticsFilter>(this as AnalyticsFilter, _$identity);
+
+  /// Serializes this AnalyticsFilter to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AnalyticsFilter&&(identical(other.start, start) || other.start == start)&&(identical(other.end, end) || other.end == end)&&(identical(other.accountId, accountId) || other.accountId == accountId)&&(identical(other.categoryId, categoryId) || other.categoryId == categoryId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,start,end,accountId,categoryId);
+
+@override
+String toString() {
+  return 'AnalyticsFilter(start: $start, end: $end, accountId: $accountId, categoryId: $categoryId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $AnalyticsFilterCopyWith<$Res>  {
+  factory $AnalyticsFilterCopyWith(AnalyticsFilter value, $Res Function(AnalyticsFilter) _then) = _$AnalyticsFilterCopyWithImpl;
+@useResult
+$Res call({
+ DateTime start, DateTime end, String? accountId, String? categoryId
+});
+
+
+
+
+}
+/// @nodoc
+class _$AnalyticsFilterCopyWithImpl<$Res>
+    implements $AnalyticsFilterCopyWith<$Res> {
+  _$AnalyticsFilterCopyWithImpl(this._self, this._then);
+
+  final AnalyticsFilter _self;
+  final $Res Function(AnalyticsFilter) _then;
+
+/// Create a copy of AnalyticsFilter
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? start = null,Object? end = null,Object? accountId = freezed,Object? categoryId = freezed,}) {
+  return _then(_self.copyWith(
+start: null == start ? _self.start : start // ignore: cast_nullable_to_non_nullable
+as DateTime,end: null == end ? _self.end : end // ignore: cast_nullable_to_non_nullable
+as DateTime,accountId: freezed == accountId ? _self.accountId : accountId // ignore: cast_nullable_to_non_nullable
+as String?,categoryId: freezed == categoryId ? _self.categoryId : categoryId // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [AnalyticsFilter].
+extension AnalyticsFilterPatterns on AnalyticsFilter {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _AnalyticsFilter value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _AnalyticsFilter() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _AnalyticsFilter value)  $default,){
+final _that = this;
+switch (_that) {
+case _AnalyticsFilter():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _AnalyticsFilter value)?  $default,){
+final _that = this;
+switch (_that) {
+case _AnalyticsFilter() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( DateTime start,  DateTime end,  String? accountId,  String? categoryId)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _AnalyticsFilter() when $default != null:
+return $default(_that.start,_that.end,_that.accountId,_that.categoryId);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( DateTime start,  DateTime end,  String? accountId,  String? categoryId)  $default,) {final _that = this;
+switch (_that) {
+case _AnalyticsFilter():
+return $default(_that.start,_that.end,_that.accountId,_that.categoryId);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( DateTime start,  DateTime end,  String? accountId,  String? categoryId)?  $default,) {final _that = this;
+switch (_that) {
+case _AnalyticsFilter() when $default != null:
+return $default(_that.start,_that.end,_that.accountId,_that.categoryId);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _AnalyticsFilter extends AnalyticsFilter {
+  const _AnalyticsFilter({required this.start, required this.end, this.accountId, this.categoryId}): super._();
+  factory _AnalyticsFilter.fromJson(Map<String, dynamic> json) => _$AnalyticsFilterFromJson(json);
+
+@override final  DateTime start;
+@override final  DateTime end;
+@override final  String? accountId;
+@override final  String? categoryId;
+
+/// Create a copy of AnalyticsFilter
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$AnalyticsFilterCopyWith<_AnalyticsFilter> get copyWith => __$AnalyticsFilterCopyWithImpl<_AnalyticsFilter>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$AnalyticsFilterToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AnalyticsFilter&&(identical(other.start, start) || other.start == start)&&(identical(other.end, end) || other.end == end)&&(identical(other.accountId, accountId) || other.accountId == accountId)&&(identical(other.categoryId, categoryId) || other.categoryId == categoryId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,start,end,accountId,categoryId);
+
+@override
+String toString() {
+  return 'AnalyticsFilter(start: $start, end: $end, accountId: $accountId, categoryId: $categoryId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$AnalyticsFilterCopyWith<$Res> implements $AnalyticsFilterCopyWith<$Res> {
+  factory _$AnalyticsFilterCopyWith(_AnalyticsFilter value, $Res Function(_AnalyticsFilter) _then) = __$AnalyticsFilterCopyWithImpl;
+@override @useResult
+$Res call({
+ DateTime start, DateTime end, String? accountId, String? categoryId
+});
+
+
+
+
+}
+/// @nodoc
+class __$AnalyticsFilterCopyWithImpl<$Res>
+    implements _$AnalyticsFilterCopyWith<$Res> {
+  __$AnalyticsFilterCopyWithImpl(this._self, this._then);
+
+  final _AnalyticsFilter _self;
+  final $Res Function(_AnalyticsFilter) _then;
+
+/// Create a copy of AnalyticsFilter
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? start = null,Object? end = null,Object? accountId = freezed,Object? categoryId = freezed,}) {
+  return _then(_AnalyticsFilter(
+start: null == start ? _self.start : start // ignore: cast_nullable_to_non_nullable
+as DateTime,end: null == end ? _self.end : end // ignore: cast_nullable_to_non_nullable
+as DateTime,accountId: freezed == accountId ? _self.accountId : accountId // ignore: cast_nullable_to_non_nullable
+as String?,categoryId: freezed == categoryId ? _self.categoryId : categoryId // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/features/analytics/domain/models/analytics_filter.g.dart
+++ b/lib/features/analytics/domain/models/analytics_filter.g.dart
@@ -1,0 +1,23 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'analytics_filter.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_AnalyticsFilter _$AnalyticsFilterFromJson(Map<String, dynamic> json) =>
+    _AnalyticsFilter(
+      start: DateTime.parse(json['start'] as String),
+      end: DateTime.parse(json['end'] as String),
+      accountId: json['accountId'] as String?,
+      categoryId: json['categoryId'] as String?,
+    );
+
+Map<String, dynamic> _$AnalyticsFilterToJson(_AnalyticsFilter instance) =>
+    <String, dynamic>{
+      'start': instance.start.toIso8601String(),
+      'end': instance.end.toIso8601String(),
+      'accountId': instance.accountId,
+      'categoryId': instance.categoryId,
+    };

--- a/lib/features/analytics/presentation/analytics_screen.dart
+++ b/lib/features/analytics/presentation/analytics_screen.dart
@@ -1,9 +1,13 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:kopim/core/utils/helpers.dart';
+import 'package:kopim/features/accounts/domain/entities/account_entity.dart';
 import 'package:kopim/features/analytics/domain/models/analytics_category_breakdown.dart';
 import 'package:kopim/features/analytics/domain/models/analytics_overview.dart';
+import 'package:kopim/features/analytics/presentation/controllers/analytics_filter_controller.dart';
 import 'package:kopim/features/analytics/presentation/controllers/analytics_providers.dart';
 import 'package:kopim/features/app_shell/presentation/models/navigation_tab_content.dart';
 import 'package:kopim/features/categories/domain/entities/category.dart';
@@ -43,21 +47,34 @@ NavigationTabContent buildAnalyticsTabContent(
       final AsyncValue<List<Category>> categoriesAsync = ref.watch(
         analyticsCategoriesProvider,
       );
+      final AsyncValue<List<AccountEntity>> accountsAsync = ref.watch(
+        analyticsAccountsProvider,
+      );
+      final AnalyticsFilterState filterState = ref.watch(
+        analyticsFilterControllerProvider,
+      );
 
-      if (overviewAsync.isLoading || categoriesAsync.isLoading) {
+      if (overviewAsync.isLoading ||
+          categoriesAsync.isLoading ||
+          accountsAsync.isLoading) {
         return const Center(child: CircularProgressIndicator());
       }
 
       final Object? overviewError = overviewAsync.error;
       final Object? categoriesError = categoriesAsync.error;
-      if (overviewError != null || categoriesError != null) {
-        final Object? error = overviewError ?? categoriesError;
+      final Object? accountsError = accountsAsync.error;
+      if (overviewError != null ||
+          categoriesError != null ||
+          accountsError != null) {
+        final Object? error = overviewError ?? categoriesError ?? accountsError;
         return _AnalyticsError(message: error.toString(), strings: strings);
       }
 
       final AnalyticsOverview? overview = overviewAsync.value;
       final List<Category> categories =
           categoriesAsync.value ?? const <Category>[];
+      final List<AccountEntity> accounts =
+          accountsAsync.value ?? const <AccountEntity>[];
 
       if (overview == null ||
           (overview.totalIncome == 0 && overview.totalExpense == 0)) {
@@ -67,25 +84,31 @@ NavigationTabContent buildAnalyticsTabContent(
       return _AnalyticsContent(
         overview: overview,
         categories: categories,
+        accounts: accounts,
+        filterState: filterState,
         strings: strings,
       );
     },
   );
 }
 
-class _AnalyticsContent extends StatelessWidget {
+class _AnalyticsContent extends ConsumerWidget {
   const _AnalyticsContent({
     required this.overview,
     required this.categories,
+    required this.accounts,
+    required this.filterState,
     required this.strings,
   });
 
   final AnalyticsOverview overview;
   final List<Category> categories;
+  final List<AccountEntity> accounts;
+  final AnalyticsFilterState filterState;
   final AppLocalizations strings;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final ThemeData theme = Theme.of(context);
     final NumberFormat currencyFormat = NumberFormat.simpleCurrency(
       locale: strings.localeName,
@@ -94,6 +117,14 @@ class _AnalyticsContent extends StatelessWidget {
       for (final Category category in categories) category.id: category,
     };
     final double totalExpense = overview.totalExpense;
+    final DateFormat dateRangeFormat = DateFormat.yMMMMd(strings.localeName);
+    final String startLabel = dateRangeFormat.format(
+      filterState.dateRange.start,
+    );
+    final String endLabel = dateRangeFormat.format(filterState.dateRange.end);
+    final String rangeLabel = startLabel == endLabel
+        ? startLabel
+        : strings.analyticsFilterDateValue(startLabel, endLabel);
 
     return SingleChildScrollView(
       padding: const EdgeInsets.all(24),
@@ -101,35 +132,21 @@ class _AnalyticsContent extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
           Text(
-            strings.analyticsCurrentMonthTitle,
+            strings.analyticsOverviewRangeTitle(rangeLabel),
             style: theme.textTheme.titleLarge,
           ),
           const SizedBox(height: 16),
-          Wrap(
-            spacing: 12,
-            runSpacing: 12,
-            children: <Widget>[
-              _AnalyticsSummaryCard(
-                label: strings.analyticsSummaryIncomeLabel,
-                value: overview.totalIncome,
-                currencyFormat: currencyFormat,
-                valueColor: theme.colorScheme.primary,
-              ),
-              _AnalyticsSummaryCard(
-                label: strings.analyticsSummaryExpenseLabel,
-                value: overview.totalExpense,
-                currencyFormat: currencyFormat,
-                valueColor: theme.colorScheme.error,
-              ),
-              _AnalyticsSummaryCard(
-                label: strings.analyticsSummaryNetLabel,
-                value: overview.netBalance,
-                currencyFormat: currencyFormat,
-                valueColor: overview.netBalance >= 0
-                    ? theme.colorScheme.primary
-                    : theme.colorScheme.error,
-              ),
-            ],
+          _AnalyticsFilterBar(
+            filterState: filterState,
+            accounts: accounts,
+            categories: categories,
+            strings: strings,
+          ),
+          const SizedBox(height: 24),
+          _AnalyticsSummaryFrame(
+            overview: overview,
+            currencyFormat: currencyFormat,
+            strings: strings,
           ),
           const SizedBox(height: 24),
           Text(
@@ -143,30 +160,12 @@ class _AnalyticsContent extends StatelessWidget {
               style: theme.textTheme.bodyMedium,
             )
           else
-            Column(
-              children: overview.topExpenseCategories
-                  .map((AnalyticsCategoryBreakdown breakdown) {
-                    final Category? category = breakdown.categoryId == null
-                        ? null
-                        : categoriesById[breakdown.categoryId!];
-                    final Color? categoryColor = parseHexColor(category?.color);
-                    final double percentage =
-                        (breakdown.amount / totalExpense) * 100;
-                    final String title =
-                        category?.name ??
-                        strings.analyticsCategoryUncategorized;
-                    return Padding(
-                      padding: const EdgeInsets.only(bottom: 12),
-                      child: _CategoryBreakdownTile(
-                        title: title,
-                        amount: breakdown.amount,
-                        percentage: percentage,
-                        currencyFormat: currencyFormat,
-                        color: categoryColor,
-                      ),
-                    );
-                  })
-                  .toList(growable: false),
+            _TopCategoriesSection(
+              breakdowns: overview.topExpenseCategories,
+              categoriesById: categoriesById,
+              totalExpense: totalExpense,
+              currencyFormat: currencyFormat,
+              strings: strings,
             ),
         ],
       ),
@@ -174,69 +173,314 @@ class _AnalyticsContent extends StatelessWidget {
   }
 }
 
-class _AnalyticsSummaryCard extends StatelessWidget {
-  const _AnalyticsSummaryCard({
-    required this.label,
-    required this.value,
+class _AnalyticsSummaryFrame extends StatelessWidget {
+  const _AnalyticsSummaryFrame({
+    required this.overview,
     required this.currencyFormat,
-    required this.valueColor,
+    required this.strings,
   });
 
-  final String label;
-  final double value;
+  final AnalyticsOverview overview;
   final NumberFormat currencyFormat;
-  final Color valueColor;
+  final AppLocalizations strings;
 
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
-    return ConstrainedBox(
-      constraints: const BoxConstraints(minWidth: 200, maxWidth: 320),
-      child: Card(
-        elevation: 0,
-        surfaceTintColor: Colors.transparent,
-        child: Padding(
-          padding: const EdgeInsets.all(16),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              Text(label, style: theme.textTheme.bodyMedium),
-              const SizedBox(height: 8),
-              Text(
-                currencyFormat.format(value),
-                style: theme.textTheme.headlineSmall?.copyWith(
-                  color: valueColor,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-            ],
-          ),
+    final List<_SummaryEntry> entries = <_SummaryEntry>[
+      _SummaryEntry(
+        label: strings.analyticsSummaryIncomeLabel,
+        value: overview.totalIncome,
+        color: theme.colorScheme.primary,
+      ),
+      _SummaryEntry(
+        label: strings.analyticsSummaryExpenseLabel,
+        value: overview.totalExpense,
+        color: theme.colorScheme.error,
+      ),
+      _SummaryEntry(
+        label: strings.analyticsSummaryNetLabel,
+        value: overview.netBalance,
+        color: overview.netBalance >= 0
+            ? theme.colorScheme.primary
+            : theme.colorScheme.error,
+      ),
+    ];
+
+    return Card(
+      elevation: 0,
+      surfaceTintColor: Colors.transparent,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 20),
+        child: LayoutBuilder(
+          builder: (BuildContext context, BoxConstraints constraints) {
+            final bool isCompact = constraints.maxWidth < 520;
+            if (isCompact) {
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: <Widget>[
+                  for (
+                    int index = 0;
+                    index < entries.length;
+                    index++
+                  ) ...<Widget>[
+                    _SummaryValue(
+                      entry: entries[index],
+                      currencyFormat: currencyFormat,
+                      textAlign: TextAlign.start,
+                    ),
+                    if (index < entries.length - 1)
+                      const Padding(
+                        padding: EdgeInsets.symmetric(vertical: 12),
+                        child: Divider(height: 1),
+                      ),
+                  ],
+                ],
+              );
+            }
+
+            return Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                for (
+                  int index = 0;
+                  index < entries.length;
+                  index++
+                ) ...<Widget>[
+                  Expanded(
+                    child: _SummaryValue(
+                      entry: entries[index],
+                      currencyFormat: currencyFormat,
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                  if (index < entries.length - 1)
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 16),
+                      child: SizedBox(
+                        height: 64,
+                        child: VerticalDivider(
+                          width: 1,
+                          color: theme.colorScheme.outlineVariant,
+                        ),
+                      ),
+                    ),
+                ],
+              ],
+            );
+          },
         ),
       ),
     );
   }
 }
 
-class _CategoryBreakdownTile extends StatelessWidget {
-  const _CategoryBreakdownTile({
-    required this.title,
-    required this.amount,
-    required this.percentage,
-    required this.currencyFormat,
-    this.color,
+class _SummaryEntry {
+  const _SummaryEntry({
+    required this.label,
+    required this.value,
+    required this.color,
   });
 
-  final String title;
-  final double amount;
-  final double percentage;
+  final String label;
+  final double value;
+  final Color color;
+}
+
+class _SummaryValue extends StatelessWidget {
+  const _SummaryValue({
+    required this.entry,
+    required this.currencyFormat,
+    required this.textAlign,
+  });
+
+  final _SummaryEntry entry;
   final NumberFormat currencyFormat;
-  final Color? color;
+  final TextAlign textAlign;
 
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
-    final Color resolvedColor = color ?? theme.colorScheme.primary;
-    final double normalizedValue = (percentage / 100).clamp(0, 1);
+    return Column(
+      crossAxisAlignment: textAlign == TextAlign.center
+          ? CrossAxisAlignment.center
+          : CrossAxisAlignment.start,
+      children: <Widget>[
+        Text(entry.label, style: theme.textTheme.bodyMedium),
+        const SizedBox(height: 8),
+        Text(
+          currencyFormat.format(entry.value),
+          textAlign: textAlign,
+          style: theme.textTheme.headlineSmall?.copyWith(
+            color: entry.color,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _AnalyticsFilterBar extends ConsumerWidget {
+  const _AnalyticsFilterBar({
+    required this.filterState,
+    required this.accounts,
+    required this.categories,
+    required this.strings,
+  });
+
+  final AnalyticsFilterState filterState;
+  final List<AccountEntity> accounts;
+  final List<Category> categories;
+  final AppLocalizations strings;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final DateFormat dateFormat = DateFormat.yMMMd(strings.localeName);
+    final String startText = dateFormat.format(filterState.dateRange.start);
+    final String endText = dateFormat.format(filterState.dateRange.end);
+    final String dateValue = startText == endText
+        ? startText
+        : strings.analyticsFilterDateValue(startText, endText);
+
+    return Card(
+      elevation: 0,
+      surfaceTintColor: Colors.transparent,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Wrap(
+          spacing: 16,
+          runSpacing: 16,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          children: <Widget>[
+            FilledButton.tonal(
+              onPressed: () async {
+                final DateTimeRange? result = await showDateRangePicker(
+                  context: context,
+                  initialDateRange: filterState.dateRange,
+                  firstDate: DateTime(2000),
+                  lastDate: DateTime(DateTime.now().year + 10, 12, 31),
+                  locale: Locale(strings.localeName),
+                );
+                if (result == null) {
+                  return;
+                }
+                ref
+                    .read(analyticsFilterControllerProvider.notifier)
+                    .updateDateRange(result);
+              },
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  const Icon(Icons.calendar_today_outlined, size: 18),
+                  const SizedBox(width: 8),
+                  Text('${strings.analyticsFilterDateLabel}: $dateValue'),
+                ],
+              ),
+            ),
+            SizedBox(
+              width: 240,
+              child: DropdownMenu<String?>(
+                initialSelection: filterState.accountId,
+                label: Text(strings.analyticsFilterAccountLabel),
+                inputDecorationTheme: const InputDecorationTheme(
+                  border: OutlineInputBorder(),
+                  isDense: true,
+                ),
+                dropdownMenuEntries: <DropdownMenuEntry<String?>>[
+                  DropdownMenuEntry<String?>(
+                    value: null,
+                    label: strings.analyticsFilterAccountAll,
+                  ),
+                  ...accounts.map((AccountEntity account) {
+                    return DropdownMenuEntry<String?>(
+                      value: account.id,
+                      label: account.name,
+                    );
+                  }),
+                ],
+                onSelected: (String? value) {
+                  ref
+                      .read(analyticsFilterControllerProvider.notifier)
+                      .updateAccount(value);
+                },
+              ),
+            ),
+            SizedBox(
+              width: 240,
+              child: DropdownMenu<String?>(
+                initialSelection: filterState.categoryId,
+                label: Text(strings.analyticsFilterCategoryLabel),
+                inputDecorationTheme: const InputDecorationTheme(
+                  border: OutlineInputBorder(),
+                  isDense: true,
+                ),
+                dropdownMenuEntries: <DropdownMenuEntry<String?>>[
+                  DropdownMenuEntry<String?>(
+                    value: null,
+                    label: strings.analyticsFilterCategoryAll,
+                  ),
+                  ...categories.map((Category category) {
+                    return DropdownMenuEntry<String?>(
+                      value: category.id,
+                      label: category.name,
+                    );
+                  }),
+                ],
+                onSelected: (String? value) {
+                  ref
+                      .read(analyticsFilterControllerProvider.notifier)
+                      .updateCategory(value);
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _TopCategoriesSection extends StatelessWidget {
+  const _TopCategoriesSection({
+    required this.breakdowns,
+    required this.categoriesById,
+    required this.totalExpense,
+    required this.currencyFormat,
+    required this.strings,
+  });
+
+  final List<AnalyticsCategoryBreakdown> breakdowns;
+  final Map<String, Category> categoriesById;
+  final double totalExpense;
+  final NumberFormat currencyFormat;
+  final AppLocalizations strings;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final List<_CategoryChartItem> items = breakdowns
+        .map((AnalyticsCategoryBreakdown breakdown) {
+          final Category? category = breakdown.categoryId == null
+              ? null
+              : categoriesById[breakdown.categoryId!];
+          final Color color =
+              parseHexColor(category?.color) ?? theme.colorScheme.primary;
+          final String title =
+              category?.name ?? strings.analyticsCategoryUncategorized;
+          return _CategoryChartItem(
+            title: title,
+            amount: breakdown.amount,
+            color: color,
+          );
+        })
+        .toList(growable: false);
+
+    final double maxAmount = items.fold<double>(
+      0,
+      (double previousValue, _CategoryChartItem item) =>
+          math.max(previousValue, item.amount.abs()),
+    );
 
     return Card(
       elevation: 0,
@@ -246,42 +490,143 @@ class _CategoryBreakdownTile extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
-            Row(
-              children: <Widget>[
-                CircleAvatar(
-                  radius: 18,
-                  backgroundColor:
-                      color ?? theme.colorScheme.surfaceContainerHighest,
-                  child: color == null
-                      ? Icon(
-                          Icons.category_outlined,
-                          color: theme.colorScheme.onSurface,
-                        )
-                      : null,
-                ),
-                const SizedBox(width: 12),
-                Expanded(child: Text(title, style: theme.textTheme.bodyMedium)),
-                Text(
-                  '${percentage.toStringAsFixed(1)}%',
-                  style: theme.textTheme.bodySmall,
-                ),
-              ],
-            ),
-            const SizedBox(height: 12),
-            LinearProgressIndicator(
-              value: normalizedValue,
-              backgroundColor: theme.colorScheme.surfaceContainerHighest,
-              valueColor: AlwaysStoppedAnimation<Color>(resolvedColor),
-            ),
-            const SizedBox(height: 12),
-            Text(
-              currencyFormat.format(amount),
-              style: theme.textTheme.titleMedium?.copyWith(
-                color: resolvedColor,
-                fontWeight: FontWeight.w600,
+            SizedBox(
+              height: 220,
+              child: LayoutBuilder(
+                builder: (BuildContext context, BoxConstraints constraints) {
+                  final double chartHeight = math.max(
+                    constraints.maxHeight - 48,
+                    80,
+                  );
+                  return Row(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: <Widget>[
+                      for (final _CategoryChartItem item in items)
+                        Expanded(
+                          child: _BarColumn(
+                            item: item,
+                            maxAmount: maxAmount,
+                            totalExpense: totalExpense,
+                            currencyFormat: currencyFormat,
+                            chartHeight: chartHeight,
+                          ),
+                        ),
+                    ],
+                  );
+                },
               ),
             ),
+            const SizedBox(height: 16),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: items
+                  .map(
+                    (_CategoryChartItem item) => _CategoryLegendChip(
+                      label: item.title,
+                      color: item.color,
+                    ),
+                  )
+                  .toList(growable: false),
+            ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+class _BarColumn extends StatelessWidget {
+  const _BarColumn({
+    required this.item,
+    required this.maxAmount,
+    required this.totalExpense,
+    required this.currencyFormat,
+    required this.chartHeight,
+  });
+
+  final _CategoryChartItem item;
+  final double maxAmount;
+  final double totalExpense;
+  final NumberFormat currencyFormat;
+  final double chartHeight;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final double normalized = maxAmount == 0
+        ? 0
+        : (item.amount.abs() / maxAmount).clamp(0, 1);
+    final double barHeight = chartHeight * normalized;
+    final double percentage = totalExpense == 0
+        ? 0
+        : (item.amount / totalExpense * 100).clamp(0, 100);
+
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.end,
+      children: <Widget>[
+        Text(
+          '${percentage.toStringAsFixed(0)}%',
+          style: theme.textTheme.bodySmall,
+        ),
+        const SizedBox(height: 8),
+        Container(
+          height: barHeight,
+          decoration: BoxDecoration(
+            color: item.color,
+            borderRadius: BorderRadius.circular(12),
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          currencyFormat.format(item.amount),
+          style: theme.textTheme.bodySmall?.copyWith(
+            fontWeight: FontWeight.w600,
+          ),
+          textAlign: TextAlign.center,
+        ),
+      ],
+    );
+  }
+}
+
+class _CategoryChartItem {
+  const _CategoryChartItem({
+    required this.title,
+    required this.amount,
+    required this.color,
+  });
+
+  final String title;
+  final double amount;
+  final Color color;
+}
+
+class _CategoryLegendChip extends StatelessWidget {
+  const _CategoryLegendChip({required this.label, required this.color});
+
+  final String label;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Brightness brightness = ThemeData.estimateBrightnessForColor(color);
+    final Color textColor = brightness == Brightness.dark
+        ? Colors.white
+        : Colors.black.withValues(alpha: 0.87);
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: color,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Text(
+        label,
+        style: theme.textTheme.labelMedium?.copyWith(
+          color: textColor,
+          fontWeight: FontWeight.w600,
         ),
       ),
     );

--- a/lib/features/analytics/presentation/controllers/analytics_filter_controller.dart
+++ b/lib/features/analytics/presentation/controllers/analytics_filter_controller.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:kopim/features/analytics/domain/models/analytics_filter.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'analytics_filter_controller.freezed.dart';
+part 'analytics_filter_controller.g.dart';
+
+@freezed
+abstract class AnalyticsFilterState with _$AnalyticsFilterState {
+  const AnalyticsFilterState._();
+
+  const factory AnalyticsFilterState({
+    required DateTimeRange dateRange,
+    String? accountId,
+    String? categoryId,
+  }) = _AnalyticsFilterState;
+
+  factory AnalyticsFilterState.initial() {
+    final DateTime now = DateTime.now();
+    final DateTime start = DateTime(now.year, now.month);
+    final DateTime endInclusive = DateTime(
+      now.year,
+      now.month + 1,
+    ).subtract(const Duration(days: 1));
+    return AnalyticsFilterState(
+      dateRange: DateTimeRange(start: start, end: endInclusive),
+    );
+  }
+}
+
+extension AnalyticsFilterStateX on AnalyticsFilterState {
+  AnalyticsFilter toDomain() {
+    final DateTime normalizedStart = DateUtils.dateOnly(dateRange.start);
+    final DateTime normalizedEndInclusive = DateUtils.dateOnly(dateRange.end);
+    final DateTime endExclusive = normalizedEndInclusive.add(
+      const Duration(days: 1),
+    );
+
+    return AnalyticsFilter(
+      start: normalizedStart,
+      end: endExclusive,
+      accountId: accountId,
+      categoryId: categoryId,
+    );
+  }
+}
+
+@riverpod
+class AnalyticsFilterController extends _$AnalyticsFilterController {
+  @override
+  AnalyticsFilterState build() {
+    return AnalyticsFilterState.initial();
+  }
+
+  void updateDateRange(DateTimeRange range) {
+    final DateTimeRange normalized = DateTimeRange(
+      start: DateUtils.dateOnly(range.start),
+      end: DateUtils.dateOnly(range.end),
+    );
+    if (normalized == state.dateRange) {
+      return;
+    }
+    state = state.copyWith(dateRange: normalized);
+  }
+
+  void updateAccount(String? accountId) {
+    if (state.accountId == accountId) {
+      return;
+    }
+    state = state.copyWith(accountId: accountId);
+  }
+
+  void updateCategory(String? categoryId) {
+    if (state.categoryId == categoryId) {
+      return;
+    }
+    state = state.copyWith(categoryId: categoryId);
+  }
+}

--- a/lib/features/analytics/presentation/controllers/analytics_filter_controller.freezed.dart
+++ b/lib/features/analytics/presentation/controllers/analytics_filter_controller.freezed.dart
@@ -1,0 +1,277 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'analytics_filter_controller.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$AnalyticsFilterState {
+
+ DateTimeRange get dateRange; String? get accountId; String? get categoryId;
+/// Create a copy of AnalyticsFilterState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$AnalyticsFilterStateCopyWith<AnalyticsFilterState> get copyWith => _$AnalyticsFilterStateCopyWithImpl<AnalyticsFilterState>(this as AnalyticsFilterState, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AnalyticsFilterState&&(identical(other.dateRange, dateRange) || other.dateRange == dateRange)&&(identical(other.accountId, accountId) || other.accountId == accountId)&&(identical(other.categoryId, categoryId) || other.categoryId == categoryId));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,dateRange,accountId,categoryId);
+
+@override
+String toString() {
+  return 'AnalyticsFilterState(dateRange: $dateRange, accountId: $accountId, categoryId: $categoryId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $AnalyticsFilterStateCopyWith<$Res>  {
+  factory $AnalyticsFilterStateCopyWith(AnalyticsFilterState value, $Res Function(AnalyticsFilterState) _then) = _$AnalyticsFilterStateCopyWithImpl;
+@useResult
+$Res call({
+ DateTimeRange dateRange, String? accountId, String? categoryId
+});
+
+
+
+
+}
+/// @nodoc
+class _$AnalyticsFilterStateCopyWithImpl<$Res>
+    implements $AnalyticsFilterStateCopyWith<$Res> {
+  _$AnalyticsFilterStateCopyWithImpl(this._self, this._then);
+
+  final AnalyticsFilterState _self;
+  final $Res Function(AnalyticsFilterState) _then;
+
+/// Create a copy of AnalyticsFilterState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? dateRange = null,Object? accountId = freezed,Object? categoryId = freezed,}) {
+  return _then(_self.copyWith(
+dateRange: null == dateRange ? _self.dateRange : dateRange // ignore: cast_nullable_to_non_nullable
+as DateTimeRange,accountId: freezed == accountId ? _self.accountId : accountId // ignore: cast_nullable_to_non_nullable
+as String?,categoryId: freezed == categoryId ? _self.categoryId : categoryId // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [AnalyticsFilterState].
+extension AnalyticsFilterStatePatterns on AnalyticsFilterState {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _AnalyticsFilterState value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _AnalyticsFilterState() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _AnalyticsFilterState value)  $default,){
+final _that = this;
+switch (_that) {
+case _AnalyticsFilterState():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _AnalyticsFilterState value)?  $default,){
+final _that = this;
+switch (_that) {
+case _AnalyticsFilterState() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( DateTimeRange dateRange,  String? accountId,  String? categoryId)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _AnalyticsFilterState() when $default != null:
+return $default(_that.dateRange,_that.accountId,_that.categoryId);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( DateTimeRange dateRange,  String? accountId,  String? categoryId)  $default,) {final _that = this;
+switch (_that) {
+case _AnalyticsFilterState():
+return $default(_that.dateRange,_that.accountId,_that.categoryId);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( DateTimeRange dateRange,  String? accountId,  String? categoryId)?  $default,) {final _that = this;
+switch (_that) {
+case _AnalyticsFilterState() when $default != null:
+return $default(_that.dateRange,_that.accountId,_that.categoryId);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _AnalyticsFilterState extends AnalyticsFilterState {
+  const _AnalyticsFilterState({required this.dateRange, this.accountId, this.categoryId}): super._();
+  
+
+@override final  DateTimeRange dateRange;
+@override final  String? accountId;
+@override final  String? categoryId;
+
+/// Create a copy of AnalyticsFilterState
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$AnalyticsFilterStateCopyWith<_AnalyticsFilterState> get copyWith => __$AnalyticsFilterStateCopyWithImpl<_AnalyticsFilterState>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AnalyticsFilterState&&(identical(other.dateRange, dateRange) || other.dateRange == dateRange)&&(identical(other.accountId, accountId) || other.accountId == accountId)&&(identical(other.categoryId, categoryId) || other.categoryId == categoryId));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,dateRange,accountId,categoryId);
+
+@override
+String toString() {
+  return 'AnalyticsFilterState(dateRange: $dateRange, accountId: $accountId, categoryId: $categoryId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$AnalyticsFilterStateCopyWith<$Res> implements $AnalyticsFilterStateCopyWith<$Res> {
+  factory _$AnalyticsFilterStateCopyWith(_AnalyticsFilterState value, $Res Function(_AnalyticsFilterState) _then) = __$AnalyticsFilterStateCopyWithImpl;
+@override @useResult
+$Res call({
+ DateTimeRange dateRange, String? accountId, String? categoryId
+});
+
+
+
+
+}
+/// @nodoc
+class __$AnalyticsFilterStateCopyWithImpl<$Res>
+    implements _$AnalyticsFilterStateCopyWith<$Res> {
+  __$AnalyticsFilterStateCopyWithImpl(this._self, this._then);
+
+  final _AnalyticsFilterState _self;
+  final $Res Function(_AnalyticsFilterState) _then;
+
+/// Create a copy of AnalyticsFilterState
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? dateRange = null,Object? accountId = freezed,Object? categoryId = freezed,}) {
+  return _then(_AnalyticsFilterState(
+dateRange: null == dateRange ? _self.dateRange : dateRange // ignore: cast_nullable_to_non_nullable
+as DateTimeRange,accountId: freezed == accountId ? _self.accountId : accountId // ignore: cast_nullable_to_non_nullable
+as String?,categoryId: freezed == categoryId ? _self.categoryId : categoryId // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/features/analytics/presentation/controllers/analytics_filter_controller.g.dart
+++ b/lib/features/analytics/presentation/controllers/analytics_filter_controller.g.dart
@@ -1,0 +1,65 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'analytics_filter_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(AnalyticsFilterController)
+const analyticsFilterControllerProvider = AnalyticsFilterControllerProvider._();
+
+final class AnalyticsFilterControllerProvider
+    extends $NotifierProvider<AnalyticsFilterController, AnalyticsFilterState> {
+  const AnalyticsFilterControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'analyticsFilterControllerProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$analyticsFilterControllerHash();
+
+  @$internal
+  @override
+  AnalyticsFilterController create() => AnalyticsFilterController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AnalyticsFilterState value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AnalyticsFilterState>(value),
+    );
+  }
+}
+
+String _$analyticsFilterControllerHash() =>
+    r'd6bd42488cb918e8768a43cf75ce4819192f846a';
+
+abstract class _$AnalyticsFilterController
+    extends $Notifier<AnalyticsFilterState> {
+  AnalyticsFilterState build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build();
+    final ref = this.ref as $Ref<AnalyticsFilterState, AnalyticsFilterState>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AnalyticsFilterState, AnalyticsFilterState>,
+              AnalyticsFilterState,
+              Object?,
+              Object?
+            >;
+    element.handleValue(ref, created);
+  }
+}

--- a/lib/features/analytics/presentation/controllers/analytics_providers.dart
+++ b/lib/features/analytics/presentation/controllers/analytics_providers.dart
@@ -1,5 +1,7 @@
 import 'package:kopim/core/di/injectors.dart';
+import 'package:kopim/features/accounts/domain/entities/account_entity.dart';
 import 'package:kopim/features/analytics/domain/models/analytics_overview.dart';
+import 'package:kopim/features/analytics/presentation/controllers/analytics_filter_controller.dart';
 import 'package:kopim/features/categories/domain/entities/category.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -10,12 +12,20 @@ Stream<AnalyticsOverview> analyticsOverview(
   Ref ref, {
   int topCategoriesLimit = 5,
 }) {
+  final AnalyticsFilterState filters = ref.watch(
+    analyticsFilterControllerProvider,
+  );
   return ref
       .watch(watchMonthlyAnalyticsUseCaseProvider)
-      .call(topCategoriesLimit: topCategoriesLimit);
+      .call(topCategoriesLimit: topCategoriesLimit, filter: filters.toDomain());
 }
 
 @riverpod
 Stream<List<Category>> analyticsCategories(Ref ref) {
   return ref.watch(watchCategoriesUseCaseProvider).call();
+}
+
+@riverpod
+Stream<List<AccountEntity>> analyticsAccounts(Ref ref) {
+  return ref.watch(watchAccountsUseCaseProvider).call();
 }

--- a/lib/features/analytics/presentation/controllers/analytics_providers.g.dart
+++ b/lib/features/analytics/presentation/controllers/analytics_providers.g.dart
@@ -66,7 +66,7 @@ final class AnalyticsOverviewProvider
   }
 }
 
-String _$analyticsOverviewHash() => r'f445da9ec62abe6be2b31a26a7cb5814454f40d6';
+String _$analyticsOverviewHash() => r'f12f5f64d9b276c96d20180901258f80940cfa37';
 
 final class AnalyticsOverviewFamily extends $Family
     with $FunctionalFamilyOverride<Stream<AnalyticsOverview>, int> {
@@ -125,3 +125,44 @@ final class AnalyticsCategoriesProvider
 
 String _$analyticsCategoriesHash() =>
     r'a0481679265a41e2ab35b1ae879ce50cf957fce3';
+
+@ProviderFor(analyticsAccounts)
+const analyticsAccountsProvider = AnalyticsAccountsProvider._();
+
+final class AnalyticsAccountsProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<AccountEntity>>,
+          List<AccountEntity>,
+          Stream<List<AccountEntity>>
+        >
+    with
+        $FutureModifier<List<AccountEntity>>,
+        $StreamProvider<List<AccountEntity>> {
+  const AnalyticsAccountsProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'analyticsAccountsProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$analyticsAccountsHash();
+
+  @$internal
+  @override
+  $StreamProviderElement<List<AccountEntity>> $createElement(
+    $ProviderPointer pointer,
+  ) => $StreamProviderElement(pointer);
+
+  @override
+  Stream<List<AccountEntity>> create(Ref ref) {
+    return analyticsAccounts(ref);
+  }
+}
+
+String _$analyticsAccountsHash() => r'd78d4d75ea71704dc5d8fd42a64919cb59824340';

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -478,9 +478,50 @@
   "@analyticsCategoryUncategorized": {
     "description": "Label for expenses without a category"
   },
-  "analyticsEmptyState": "No analytics available for the current month yet.",
+  "analyticsOverviewRangeTitle": "Overview for {range}",
+  "@analyticsOverviewRangeTitle": {
+    "description": "Heading for analytics overview showing selected range",
+    "placeholders": {
+      "range": {
+        "type": "String"
+      }
+    }
+  },
+  "analyticsFilterDateLabel": "Date",
+  "@analyticsFilterDateLabel": {
+    "description": "Label for the analytics date filter button"
+  },
+  "analyticsFilterDateValue": "{start} – {end}",
+  "@analyticsFilterDateValue": {
+    "description": "Formatted range used for analytics date filter",
+    "placeholders": {
+      "start": {
+        "type": "String"
+      },
+      "end": {
+        "type": "String"
+      }
+    }
+  },
+  "analyticsFilterAccountLabel": "Account",
+  "@analyticsFilterAccountLabel": {
+    "description": "Label for the analytics account filter"
+  },
+  "analyticsFilterAccountAll": "All accounts",
+  "@analyticsFilterAccountAll": {
+    "description": "Option for selecting all accounts in analytics filters"
+  },
+  "analyticsFilterCategoryLabel": "Category",
+  "@analyticsFilterCategoryLabel": {
+    "description": "Label for the analytics category filter"
+  },
+  "analyticsFilterCategoryAll": "All categories",
+  "@analyticsFilterCategoryAll": {
+    "description": "Option for selecting all categories in analytics filters"
+  },
+  "analyticsEmptyState": "No analytics available for the selected filters yet.",
   "@analyticsEmptyState": {
-    "description": "Message shown when there are no transactions to analyse"
+    "description": "Message shown when there are no transactions matching selected filters"
   },
   "analyticsLoadError": "Unable to load analytics: {error}",
   "@analyticsLoadError": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -740,10 +740,52 @@ abstract class AppLocalizations {
   /// **'Uncategorized'**
   String get analyticsCategoryUncategorized;
 
-  /// Message shown when there are no transactions to analyse
+  /// Heading for analytics overview showing selected range
   ///
   /// In en, this message translates to:
-  /// **'No analytics available for the current month yet.'**
+  /// **'Overview for {range}'**
+  String analyticsOverviewRangeTitle(String range);
+
+  /// Label for the analytics date filter button
+  ///
+  /// In en, this message translates to:
+  /// **'Date'**
+  String get analyticsFilterDateLabel;
+
+  /// Formatted range used for analytics date filter
+  ///
+  /// In en, this message translates to:
+  /// **'{start} – {end}'**
+  String analyticsFilterDateValue(String start, String end);
+
+  /// Label for the analytics account filter
+  ///
+  /// In en, this message translates to:
+  /// **'Account'**
+  String get analyticsFilterAccountLabel;
+
+  /// Option for selecting all accounts in analytics filters
+  ///
+  /// In en, this message translates to:
+  /// **'All accounts'**
+  String get analyticsFilterAccountAll;
+
+  /// Label for the analytics category filter
+  ///
+  /// In en, this message translates to:
+  /// **'Category'**
+  String get analyticsFilterCategoryLabel;
+
+  /// Option for selecting all categories in analytics filters
+  ///
+  /// In en, this message translates to:
+  /// **'All categories'**
+  String get analyticsFilterCategoryAll;
+
+  /// Message shown when there are no transactions matching selected filters
+  ///
+  /// In en, this message translates to:
+  /// **'No analytics available for the selected filters yet.'**
   String get analyticsEmptyState;
 
   /// Error shown when analytics stream fails

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -356,8 +356,33 @@ class AppLocalizationsEn extends AppLocalizations {
   String get analyticsCategoryUncategorized => 'Uncategorized';
 
   @override
+  String analyticsOverviewRangeTitle(String range) {
+    return 'Overview for $range';
+  }
+
+  @override
+  String get analyticsFilterDateLabel => 'Date';
+
+  @override
+  String analyticsFilterDateValue(String start, String end) {
+    return '$start – $end';
+  }
+
+  @override
+  String get analyticsFilterAccountLabel => 'Account';
+
+  @override
+  String get analyticsFilterAccountAll => 'All accounts';
+
+  @override
+  String get analyticsFilterCategoryLabel => 'Category';
+
+  @override
+  String get analyticsFilterCategoryAll => 'All categories';
+
+  @override
   String get analyticsEmptyState =>
-      'No analytics available for the current month yet.';
+      'No analytics available for the selected filters yet.';
 
   @override
   String analyticsLoadError(String error) {

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -357,8 +357,32 @@ class AppLocalizationsRu extends AppLocalizations {
   String get analyticsCategoryUncategorized => 'Без категории';
 
   @override
-  String get analyticsEmptyState =>
-      'За текущий месяц пока нет данных для аналитики.';
+  String analyticsOverviewRangeTitle(String range) {
+    return 'Обзор за $range';
+  }
+
+  @override
+  String get analyticsFilterDateLabel => 'Дата';
+
+  @override
+  String analyticsFilterDateValue(String start, String end) {
+    return '$start – $end';
+  }
+
+  @override
+  String get analyticsFilterAccountLabel => 'Счёт';
+
+  @override
+  String get analyticsFilterAccountAll => 'Все счета';
+
+  @override
+  String get analyticsFilterCategoryLabel => 'Категория';
+
+  @override
+  String get analyticsFilterCategoryAll => 'Все категории';
+
+  @override
+  String get analyticsEmptyState => 'Для выбранных фильтров пока нет данных.';
 
   @override
   String analyticsLoadError(String error) {

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -478,9 +478,50 @@
   "@analyticsCategoryUncategorized": {
     "description": "Подпись для неразмеченных расходов"
   },
-  "analyticsEmptyState": "За текущий месяц пока нет данных для аналитики.",
+  "analyticsOverviewRangeTitle": "Обзор за {range}",
+  "@analyticsOverviewRangeTitle": {
+    "description": "Заголовок аналитики с учётом выбранного периода",
+    "placeholders": {
+      "range": {
+        "type": "String"
+      }
+    }
+  },
+  "analyticsFilterDateLabel": "Дата",
+  "@analyticsFilterDateLabel": {
+    "description": "Подпись кнопки выбора периода"
+  },
+  "analyticsFilterDateValue": "{start} – {end}",
+  "@analyticsFilterDateValue": {
+    "description": "Формат отображения выбранного периода",
+    "placeholders": {
+      "start": {
+        "type": "String"
+      },
+      "end": {
+        "type": "String"
+      }
+    }
+  },
+  "analyticsFilterAccountLabel": "Счёт",
+  "@analyticsFilterAccountLabel": {
+    "description": "Подпись фильтра по счёту"
+  },
+  "analyticsFilterAccountAll": "Все счета",
+  "@analyticsFilterAccountAll": {
+    "description": "Опция выбора всех счетов"
+  },
+  "analyticsFilterCategoryLabel": "Категория",
+  "@analyticsFilterCategoryLabel": {
+    "description": "Подпись фильтра по категории"
+  },
+  "analyticsFilterCategoryAll": "Все категории",
+  "@analyticsFilterCategoryAll": {
+    "description": "Опция выбора всех категорий"
+  },
+  "analyticsEmptyState": "Для выбранных фильтров пока нет данных.",
   "@analyticsEmptyState": {
-    "description": "Сообщение при отсутствии транзакций"
+    "description": "Сообщение при отсутствии транзакций под выбранные фильтры"
   },
   "analyticsLoadError": "Не удалось загрузить аналитику: {error}",
   "@analyticsLoadError": {

--- a/test/features/analytics/domain/use_cases/watch_monthly_analytics_use_case_test.dart
+++ b/test/features/analytics/domain/use_cases/watch_monthly_analytics_use_case_test.dart
@@ -1,0 +1,197 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kopim/features/analytics/domain/models/analytics_filter.dart';
+import 'package:kopim/features/analytics/domain/models/analytics_overview.dart';
+import 'package:kopim/features/analytics/domain/use_cases/watch_monthly_analytics_use_case.dart';
+import 'package:kopim/features/transactions/domain/entities/transaction.dart';
+import 'package:kopim/features/transactions/domain/entities/transaction_type.dart';
+import 'package:kopim/features/transactions/domain/repositories/transaction_repository.dart';
+
+void main() {
+  group('WatchMonthlyAnalyticsUseCase', () {
+    late FakeTransactionRepository repository;
+    late WatchMonthlyAnalyticsUseCase useCase;
+
+    setUp(() {
+      repository = FakeTransactionRepository();
+      useCase = WatchMonthlyAnalyticsUseCase(transactionRepository: repository);
+    });
+
+    tearDown(() async {
+      await repository.dispose();
+    });
+
+    test('returns zero overview when there are no transactions', () async {
+      final Future<AnalyticsOverview> future = useCase.call().first;
+
+      await repository.emit(<TransactionEntity>[]);
+
+      final AnalyticsOverview overview = await future;
+      expect(overview.totalIncome, 0);
+      expect(overview.totalExpense, 0);
+      expect(overview.netBalance, 0);
+      expect(overview.topExpenseCategories, isEmpty);
+    });
+
+    test('applies date range filter', () async {
+      final AnalyticsFilter filter = AnalyticsFilter(
+        start: DateTime(2024, 6, 1),
+        end: DateTime(2024, 7, 1),
+      );
+      final Future<AnalyticsOverview> future = useCase
+          .call(filter: filter)
+          .first;
+
+      await repository.emit(<TransactionEntity>[
+        buildTransaction(
+          id: 't1',
+          accountId: 'acc-1',
+          amount: 120,
+          date: DateTime(2024, 6, 12),
+          categoryId: 'cat-ent',
+          type: TransactionType.income,
+        ),
+        buildTransaction(
+          id: 't2',
+          accountId: 'acc-1',
+          amount: -40,
+          date: DateTime(2024, 6, 15),
+          categoryId: 'cat-food',
+          type: TransactionType.expense,
+        ),
+        buildTransaction(
+          id: 't3',
+          accountId: 'acc-1',
+          amount: -20,
+          date: DateTime(2024, 7, 4),
+          categoryId: 'cat-travel',
+          type: TransactionType.expense,
+        ),
+      ]);
+
+      final AnalyticsOverview overview = await future;
+      expect(overview.totalIncome, 120);
+      expect(overview.totalExpense, 40);
+      expect(overview.netBalance, 80);
+      expect(overview.topExpenseCategories, hasLength(1));
+      expect(overview.topExpenseCategories.first.categoryId, 'cat-food');
+      expect(overview.topExpenseCategories.first.amount, 40);
+    });
+
+    test('filters by account and category', () async {
+      final AnalyticsFilter filter = AnalyticsFilter(
+        start: DateTime(2024, 6, 1),
+        end: DateTime(2024, 7, 1),
+        accountId: 'acc-2',
+        categoryId: 'cat-ent',
+      );
+      final Future<AnalyticsOverview> future = useCase
+          .call(filter: filter)
+          .first;
+
+      await repository.emit(<TransactionEntity>[
+        buildTransaction(
+          id: 't1',
+          accountId: 'acc-1',
+          amount: 200,
+          date: DateTime(2024, 6, 5),
+          categoryId: 'cat-ent',
+          type: TransactionType.income,
+        ),
+        buildTransaction(
+          id: 't2',
+          accountId: 'acc-2',
+          amount: 150,
+          date: DateTime(2024, 6, 6),
+          categoryId: 'cat-ent',
+          type: TransactionType.income,
+        ),
+        buildTransaction(
+          id: 't3',
+          accountId: 'acc-2',
+          amount: -30,
+          date: DateTime(2024, 6, 7),
+          categoryId: 'cat-ent',
+          type: TransactionType.expense,
+        ),
+        buildTransaction(
+          id: 't4',
+          accountId: 'acc-2',
+          amount: -15,
+          date: DateTime(2024, 6, 8),
+          categoryId: 'cat-food',
+          type: TransactionType.expense,
+        ),
+      ]);
+
+      final AnalyticsOverview overview = await future;
+      expect(overview.totalIncome, 150);
+      expect(overview.totalExpense, 30);
+      expect(overview.netBalance, 120);
+      expect(overview.topExpenseCategories, hasLength(1));
+      expect(overview.topExpenseCategories.first.categoryId, 'cat-ent');
+      expect(overview.topExpenseCategories.first.amount, 30);
+    });
+  });
+}
+
+TransactionEntity buildTransaction({
+  required String id,
+  required String accountId,
+  required double amount,
+  required DateTime date,
+  required TransactionType type,
+  String? categoryId,
+}) {
+  return TransactionEntity(
+    id: id,
+    accountId: accountId,
+    categoryId: categoryId,
+    amount: amount,
+    date: date,
+    note: null,
+    type: type.storageValue,
+    createdAt: date,
+    updatedAt: date,
+  );
+}
+
+class FakeTransactionRepository implements TransactionRepository {
+  FakeTransactionRepository()
+    : _controller = StreamController<List<TransactionEntity>>.broadcast();
+
+  final StreamController<List<TransactionEntity>> _controller;
+
+  @override
+  Stream<List<TransactionEntity>> watchTransactions() => _controller.stream;
+
+  Future<void> emit(List<TransactionEntity> transactions) async {
+    _controller.add(transactions);
+    await Future<void>.delayed(Duration.zero);
+  }
+
+  Future<void> dispose() async {
+    await _controller.close();
+  }
+
+  @override
+  Future<List<TransactionEntity>> loadTransactions() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<TransactionEntity?> findById(String id) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> upsert(TransactionEntity transaction) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> softDelete(String id) {
+    throw UnimplementedError();
+  }
+}


### PR DESCRIPTION
## Summary
- add user-selectable date, account, and category filters on the analytics screen and surface the selection in the overview
- consolidate the income, expense, and balance metrics into a responsive summary frame and render top categories as a compact bar chart with color-coded legend
- introduce immutable analytics filter model with Riverpod controller, update providers/use case to respect the filter, localize new strings, and cover logic with unit tests

## Testing
- `dart format --set-exit-if-changed .`
- `flutter analyze`
- `dart run build_runner build --delete-conflicting-outputs`
- `flutter test --reporter expanded`
- `flutter pub outdated`


------
https://chatgpt.com/codex/tasks/task_e_68dfc00ae7c8832e8f2894854c1b22a2