### PR TITLE
Добавить форму создания повторяющихся операций

### DIFF
--- a/lib/features/recurring_transactions/presentation/controllers/recurring_rule_form_controller.freezed.dart
+++ b/lib/features/recurring_transactions/presentation/controllers/recurring_rule_form_controller.freezed.dart
@@ -1,0 +1,334 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'recurring_rule_form_controller.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$RecurringRuleFormState {
+
+ String get title; String get amountInput; AccountEntity? get account; TransactionType get type; DateTime get startDate; int get applyHour; int get applyMinute; bool get autoPost; bool get isSubmitting; bool get submissionSuccess; RecurringRuleTitleError? get titleError; RecurringRuleAmountError? get amountError; RecurringRuleAccountError? get accountError; String? get generalErrorMessage;
+/// Create a copy of RecurringRuleFormState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$RecurringRuleFormStateCopyWith<RecurringRuleFormState> get copyWith => _$RecurringRuleFormStateCopyWithImpl<RecurringRuleFormState>(this as RecurringRuleFormState, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RecurringRuleFormState&&(identical(other.title, title) || other.title == title)&&(identical(other.amountInput, amountInput) || other.amountInput == amountInput)&&(identical(other.account, account) || other.account == account)&&(identical(other.type, type) || other.type == type)&&(identical(other.startDate, startDate) || other.startDate == startDate)&&(identical(other.applyHour, applyHour) || other.applyHour == applyHour)&&(identical(other.applyMinute, applyMinute) || other.applyMinute == applyMinute)&&(identical(other.autoPost, autoPost) || other.autoPost == autoPost)&&(identical(other.isSubmitting, isSubmitting) || other.isSubmitting == isSubmitting)&&(identical(other.submissionSuccess, submissionSuccess) || other.submissionSuccess == submissionSuccess)&&(identical(other.titleError, titleError) || other.titleError == titleError)&&(identical(other.amountError, amountError) || other.amountError == amountError)&&(identical(other.accountError, accountError) || other.accountError == accountError)&&(identical(other.generalErrorMessage, generalErrorMessage) || other.generalErrorMessage == generalErrorMessage));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,title,amountInput,account,type,startDate,applyHour,applyMinute,autoPost,isSubmitting,submissionSuccess,titleError,amountError,accountError,generalErrorMessage);
+
+@override
+String toString() {
+  return 'RecurringRuleFormState(title: $title, amountInput: $amountInput, account: $account, type: $type, startDate: $startDate, applyHour: $applyHour, applyMinute: $applyMinute, autoPost: $autoPost, isSubmitting: $isSubmitting, submissionSuccess: $submissionSuccess, titleError: $titleError, amountError: $amountError, accountError: $accountError, generalErrorMessage: $generalErrorMessage)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $RecurringRuleFormStateCopyWith<$Res>  {
+  factory $RecurringRuleFormStateCopyWith(RecurringRuleFormState value, $Res Function(RecurringRuleFormState) _then) = _$RecurringRuleFormStateCopyWithImpl;
+@useResult
+$Res call({
+ String title, String amountInput, AccountEntity? account, TransactionType type, DateTime startDate, int applyHour, int applyMinute, bool autoPost, bool isSubmitting, bool submissionSuccess, RecurringRuleTitleError? titleError, RecurringRuleAmountError? amountError, RecurringRuleAccountError? accountError, String? generalErrorMessage
+});
+
+
+$AccountEntityCopyWith<$Res>? get account;
+
+}
+/// @nodoc
+class _$RecurringRuleFormStateCopyWithImpl<$Res>
+    implements $RecurringRuleFormStateCopyWith<$Res> {
+  _$RecurringRuleFormStateCopyWithImpl(this._self, this._then);
+
+  final RecurringRuleFormState _self;
+  final $Res Function(RecurringRuleFormState) _then;
+
+/// Create a copy of RecurringRuleFormState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? title = null,Object? amountInput = null,Object? account = freezed,Object? type = null,Object? startDate = null,Object? applyHour = null,Object? applyMinute = null,Object? autoPost = null,Object? isSubmitting = null,Object? submissionSuccess = null,Object? titleError = freezed,Object? amountError = freezed,Object? accountError = freezed,Object? generalErrorMessage = freezed,}) {
+  return _then(_self.copyWith(
+title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,amountInput: null == amountInput ? _self.amountInput : amountInput // ignore: cast_nullable_to_non_nullable
+as String,account: freezed == account ? _self.account : account // ignore: cast_nullable_to_non_nullable
+as AccountEntity?,type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as TransactionType,startDate: null == startDate ? _self.startDate : startDate // ignore: cast_nullable_to_non_nullable
+as DateTime,applyHour: null == applyHour ? _self.applyHour : applyHour // ignore: cast_nullable_to_non_nullable
+as int,applyMinute: null == applyMinute ? _self.applyMinute : applyMinute // ignore: cast_nullable_to_non_nullable
+as int,autoPost: null == autoPost ? _self.autoPost : autoPost // ignore: cast_nullable_to_non_nullable
+as bool,isSubmitting: null == isSubmitting ? _self.isSubmitting : isSubmitting // ignore: cast_nullable_to_non_nullable
+as bool,submissionSuccess: null == submissionSuccess ? _self.submissionSuccess : submissionSuccess // ignore: cast_nullable_to_non_nullable
+as bool,titleError: freezed == titleError ? _self.titleError : titleError // ignore: cast_nullable_to_non_nullable
+as RecurringRuleTitleError?,amountError: freezed == amountError ? _self.amountError : amountError // ignore: cast_nullable_to_non_nullable
+as RecurringRuleAmountError?,accountError: freezed == accountError ? _self.accountError : accountError // ignore: cast_nullable_to_non_nullable
+as RecurringRuleAccountError?,generalErrorMessage: freezed == generalErrorMessage ? _self.generalErrorMessage : generalErrorMessage // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+/// Create a copy of RecurringRuleFormState
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$AccountEntityCopyWith<$Res>? get account {
+    if (_self.account == null) {
+    return null;
+  }
+
+  return $AccountEntityCopyWith<$Res>(_self.account!, (value) {
+    return _then(_self.copyWith(account: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [RecurringRuleFormState].
+extension RecurringRuleFormStatePatterns on RecurringRuleFormState {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _RecurringRuleFormState value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _RecurringRuleFormState() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _RecurringRuleFormState value)  $default,){
+final _that = this;
+switch (_that) {
+case _RecurringRuleFormState():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _RecurringRuleFormState value)?  $default,){
+final _that = this;
+switch (_that) {
+case _RecurringRuleFormState() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String title,  String amountInput,  AccountEntity? account,  TransactionType type,  DateTime startDate,  int applyHour,  int applyMinute,  bool autoPost,  bool isSubmitting,  bool submissionSuccess,  RecurringRuleTitleError? titleError,  RecurringRuleAmountError? amountError,  RecurringRuleAccountError? accountError,  String? generalErrorMessage)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _RecurringRuleFormState() when $default != null:
+return $default(_that.title,_that.amountInput,_that.account,_that.type,_that.startDate,_that.applyHour,_that.applyMinute,_that.autoPost,_that.isSubmitting,_that.submissionSuccess,_that.titleError,_that.amountError,_that.accountError,_that.generalErrorMessage);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String title,  String amountInput,  AccountEntity? account,  TransactionType type,  DateTime startDate,  int applyHour,  int applyMinute,  bool autoPost,  bool isSubmitting,  bool submissionSuccess,  RecurringRuleTitleError? titleError,  RecurringRuleAmountError? amountError,  RecurringRuleAccountError? accountError,  String? generalErrorMessage)  $default,) {final _that = this;
+switch (_that) {
+case _RecurringRuleFormState():
+return $default(_that.title,_that.amountInput,_that.account,_that.type,_that.startDate,_that.applyHour,_that.applyMinute,_that.autoPost,_that.isSubmitting,_that.submissionSuccess,_that.titleError,_that.amountError,_that.accountError,_that.generalErrorMessage);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String title,  String amountInput,  AccountEntity? account,  TransactionType type,  DateTime startDate,  int applyHour,  int applyMinute,  bool autoPost,  bool isSubmitting,  bool submissionSuccess,  RecurringRuleTitleError? titleError,  RecurringRuleAmountError? amountError,  RecurringRuleAccountError? accountError,  String? generalErrorMessage)?  $default,) {final _that = this;
+switch (_that) {
+case _RecurringRuleFormState() when $default != null:
+return $default(_that.title,_that.amountInput,_that.account,_that.type,_that.startDate,_that.applyHour,_that.applyMinute,_that.autoPost,_that.isSubmitting,_that.submissionSuccess,_that.titleError,_that.amountError,_that.accountError,_that.generalErrorMessage);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _RecurringRuleFormState extends RecurringRuleFormState {
+  const _RecurringRuleFormState({this.title = '', this.amountInput = '', this.account, this.type = TransactionType.expense, required this.startDate, this.applyHour = 0, this.applyMinute = 0, this.autoPost = false, this.isSubmitting = false, this.submissionSuccess = false, this.titleError, this.amountError, this.accountError, this.generalErrorMessage}): super._();
+  
+
+@override@JsonKey() final  String title;
+@override@JsonKey() final  String amountInput;
+@override final  AccountEntity? account;
+@override@JsonKey() final  TransactionType type;
+@override final  DateTime startDate;
+@override@JsonKey() final  int applyHour;
+@override@JsonKey() final  int applyMinute;
+@override@JsonKey() final  bool autoPost;
+@override@JsonKey() final  bool isSubmitting;
+@override@JsonKey() final  bool submissionSuccess;
+@override final  RecurringRuleTitleError? titleError;
+@override final  RecurringRuleAmountError? amountError;
+@override final  RecurringRuleAccountError? accountError;
+@override final  String? generalErrorMessage;
+
+/// Create a copy of RecurringRuleFormState
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$RecurringRuleFormStateCopyWith<_RecurringRuleFormState> get copyWith => __$RecurringRuleFormStateCopyWithImpl<_RecurringRuleFormState>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _RecurringRuleFormState&&(identical(other.title, title) || other.title == title)&&(identical(other.amountInput, amountInput) || other.amountInput == amountInput)&&(identical(other.account, account) || other.account == account)&&(identical(other.type, type) || other.type == type)&&(identical(other.startDate, startDate) || other.startDate == startDate)&&(identical(other.applyHour, applyHour) || other.applyHour == applyHour)&&(identical(other.applyMinute, applyMinute) || other.applyMinute == applyMinute)&&(identical(other.autoPost, autoPost) || other.autoPost == autoPost)&&(identical(other.isSubmitting, isSubmitting) || other.isSubmitting == isSubmitting)&&(identical(other.submissionSuccess, submissionSuccess) || other.submissionSuccess == submissionSuccess)&&(identical(other.titleError, titleError) || other.titleError == titleError)&&(identical(other.amountError, amountError) || other.amountError == amountError)&&(identical(other.accountError, accountError) || other.accountError == accountError)&&(identical(other.generalErrorMessage, generalErrorMessage) || other.generalErrorMessage == generalErrorMessage));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,title,amountInput,account,type,startDate,applyHour,applyMinute,autoPost,isSubmitting,submissionSuccess,titleError,amountError,accountError,generalErrorMessage);
+
+@override
+String toString() {
+  return 'RecurringRuleFormState(title: $title, amountInput: $amountInput, account: $account, type: $type, startDate: $startDate, applyHour: $applyHour, applyMinute: $applyMinute, autoPost: $autoPost, isSubmitting: $isSubmitting, submissionSuccess: $submissionSuccess, titleError: $titleError, amountError: $amountError, accountError: $accountError, generalErrorMessage: $generalErrorMessage)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$RecurringRuleFormStateCopyWith<$Res> implements $RecurringRuleFormStateCopyWith<$Res> {
+  factory _$RecurringRuleFormStateCopyWith(_RecurringRuleFormState value, $Res Function(_RecurringRuleFormState) _then) = __$RecurringRuleFormStateCopyWithImpl;
+@override @useResult
+$Res call({
+ String title, String amountInput, AccountEntity? account, TransactionType type, DateTime startDate, int applyHour, int applyMinute, bool autoPost, bool isSubmitting, bool submissionSuccess, RecurringRuleTitleError? titleError, RecurringRuleAmountError? amountError, RecurringRuleAccountError? accountError, String? generalErrorMessage
+});
+
+
+@override $AccountEntityCopyWith<$Res>? get account;
+
+}
+/// @nodoc
+class __$RecurringRuleFormStateCopyWithImpl<$Res>
+    implements _$RecurringRuleFormStateCopyWith<$Res> {
+  __$RecurringRuleFormStateCopyWithImpl(this._self, this._then);
+
+  final _RecurringRuleFormState _self;
+  final $Res Function(_RecurringRuleFormState) _then;
+
+/// Create a copy of RecurringRuleFormState
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? title = null,Object? amountInput = null,Object? account = freezed,Object? type = null,Object? startDate = null,Object? applyHour = null,Object? applyMinute = null,Object? autoPost = null,Object? isSubmitting = null,Object? submissionSuccess = null,Object? titleError = freezed,Object? amountError = freezed,Object? accountError = freezed,Object? generalErrorMessage = freezed,}) {
+  return _then(_RecurringRuleFormState(
+title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,amountInput: null == amountInput ? _self.amountInput : amountInput // ignore: cast_nullable_to_non_nullable
+as String,account: freezed == account ? _self.account : account // ignore: cast_nullable_to_non_nullable
+as AccountEntity?,type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as TransactionType,startDate: null == startDate ? _self.startDate : startDate // ignore: cast_nullable_to_non_nullable
+as DateTime,applyHour: null == applyHour ? _self.applyHour : applyHour // ignore: cast_nullable_to_non_nullable
+as int,applyMinute: null == applyMinute ? _self.applyMinute : applyMinute // ignore: cast_nullable_to_non_nullable
+as int,autoPost: null == autoPost ? _self.autoPost : autoPost // ignore: cast_nullable_to_non_nullable
+as bool,isSubmitting: null == isSubmitting ? _self.isSubmitting : isSubmitting // ignore: cast_nullable_to_non_nullable
+as bool,submissionSuccess: null == submissionSuccess ? _self.submissionSuccess : submissionSuccess // ignore: cast_nullable_to_non_nullable
+as bool,titleError: freezed == titleError ? _self.titleError : titleError // ignore: cast_nullable_to_non_nullable
+as RecurringRuleTitleError?,amountError: freezed == amountError ? _self.amountError : amountError // ignore: cast_nullable_to_non_nullable
+as RecurringRuleAmountError?,accountError: freezed == accountError ? _self.accountError : accountError // ignore: cast_nullable_to_non_nullable
+as RecurringRuleAccountError?,generalErrorMessage: freezed == generalErrorMessage ? _self.generalErrorMessage : generalErrorMessage // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+/// Create a copy of RecurringRuleFormState
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$AccountEntityCopyWith<$Res>? get account {
+    if (_self.account == null) {
+    return null;
+  }
+
+  return $AccountEntityCopyWith<$Res>(_self.account!, (value) {
+    return _then(_self.copyWith(account: value));
+  });
+}
+}
+
+// dart format on

--- a/lib/features/recurring_transactions/presentation/controllers/recurring_rule_form_controller.g.dart
+++ b/lib/features/recurring_transactions/presentation/controllers/recurring_rule_form_controller.g.dart
@@ -1,0 +1,68 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'recurring_rule_form_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(RecurringRuleFormController)
+const recurringRuleFormControllerProvider =
+    RecurringRuleFormControllerProvider._();
+
+final class RecurringRuleFormControllerProvider
+    extends
+        $NotifierProvider<RecurringRuleFormController, RecurringRuleFormState> {
+  const RecurringRuleFormControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'recurringRuleFormControllerProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$recurringRuleFormControllerHash();
+
+  @$internal
+  @override
+  RecurringRuleFormController create() => RecurringRuleFormController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(RecurringRuleFormState value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<RecurringRuleFormState>(value),
+    );
+  }
+}
+
+String _$recurringRuleFormControllerHash() =>
+    r'921d9cbc31c55689e68333dc0e6b550d368d35c5';
+
+abstract class _$RecurringRuleFormController
+    extends $Notifier<RecurringRuleFormState> {
+  RecurringRuleFormState build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build();
+    final ref =
+        this.ref as $Ref<RecurringRuleFormState, RecurringRuleFormState>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<RecurringRuleFormState, RecurringRuleFormState>,
+              RecurringRuleFormState,
+              Object?,
+              Object?
+            >;
+    element.handleValue(ref, created);
+  }
+}

--- a/lib/features/recurring_transactions/presentation/screens/add_recurring_rule_screen.dart
+++ b/lib/features/recurring_transactions/presentation/screens/add_recurring_rule_screen.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:kopim/features/recurring_transactions/presentation/widgets/recurring_rule_form_view.dart';
+import 'package:kopim/l10n/app_localizations.dart';
+
+class AddRecurringRuleScreen extends ConsumerStatefulWidget {
+  const AddRecurringRuleScreen({super.key});
+
+  static const String routeName = '/recurring-transactions/add';
+
+  @override
+  ConsumerState<AddRecurringRuleScreen> createState() =>
+      _AddRecurringRuleScreenState();
+}
+
+class _AddRecurringRuleScreenState
+    extends ConsumerState<AddRecurringRuleScreen> {
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations strings = AppLocalizations.of(context)!;
+    return Scaffold(
+      appBar: AppBar(title: Text(strings.addRecurringRuleTitle)),
+      body: SafeArea(
+        child: RecurringRuleFormView(
+          formKey: _formKey,
+          onSuccess: () {
+            if (!context.mounted) return;
+            Navigator.of(context).pop(true);
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/recurring_transactions/presentation/screens/recurring_transactions_screen.dart
+++ b/lib/features/recurring_transactions/presentation/screens/recurring_transactions_screen.dart
@@ -5,6 +5,7 @@ import 'package:kopim/core/di/injectors.dart';
 import 'package:kopim/features/recurring_transactions/domain/entities/recurring_occurrence.dart';
 import 'package:kopim/features/recurring_transactions/domain/entities/recurring_rule.dart';
 import 'package:kopim/features/recurring_transactions/presentation/controllers/recurring_transactions_providers.dart';
+import 'package:kopim/features/recurring_transactions/presentation/screens/add_recurring_rule_screen.dart';
 import 'package:kopim/l10n/app_localizations.dart';
 
 /// Entry point screen that will host recurring transaction management.
@@ -62,7 +63,7 @@ class RecurringTransactionsScreen extends ConsumerWidget {
             Center(child: Text(strings.genericErrorMessage)),
       ),
       floatingActionButton: FloatingActionButton(
-        onPressed: () => _showComingSoon(context),
+        onPressed: () => _onAddRulePressed(context),
         child: const Icon(Icons.add),
       ),
     );
@@ -104,10 +105,21 @@ class RecurringTransactionsScreen extends ConsumerWidget {
     return map;
   }
 
-  void _showComingSoon(BuildContext context) {
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text(AppLocalizations.of(context)!.commonComingSoon)),
-    );
+  Future<void> _onAddRulePressed(BuildContext context) async {
+    final bool? created = await Navigator.of(
+      context,
+    ).pushNamed<bool>(AddRecurringRuleScreen.routeName);
+    if (created == true && context.mounted) {
+      ScaffoldMessenger.of(context)
+        ..hideCurrentSnackBar()
+        ..showSnackBar(
+          SnackBar(
+            content: Text(
+              AppLocalizations.of(context)!.addRecurringRuleSuccess,
+            ),
+          ),
+        );
+    }
   }
 }
 

--- a/lib/features/recurring_transactions/presentation/widgets/recurring_rule_form_view.dart
+++ b/lib/features/recurring_transactions/presentation/widgets/recurring_rule_form_view.dart
@@ -1,0 +1,290 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+import 'package:kopim/features/accounts/domain/entities/account_entity.dart';
+import 'package:kopim/features/recurring_transactions/presentation/controllers/recurring_rule_form_controller.dart';
+import 'package:kopim/features/transactions/domain/entities/transaction_type.dart';
+import 'package:kopim/l10n/app_localizations.dart';
+
+class RecurringRuleFormView extends ConsumerWidget {
+  const RecurringRuleFormView({
+    super.key,
+    required this.formKey,
+    required this.onSuccess,
+  });
+
+  final GlobalKey<FormState> formKey;
+  final VoidCallback onSuccess;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final AppLocalizations strings = AppLocalizations.of(context)!;
+    final RecurringRuleFormState state = ref.watch(
+      recurringRuleFormControllerProvider,
+    );
+    final AsyncValue<List<AccountEntity>> accountsAsync = ref.watch(
+      recurringRuleAccountsProvider,
+    );
+
+    ref.listen<RecurringRuleFormState>(recurringRuleFormControllerProvider, (
+      RecurringRuleFormState? previous,
+      RecurringRuleFormState next,
+    ) {
+      if (next.submissionSuccess && previous?.submissionSuccess != true) {
+        ref
+            .read(recurringRuleFormControllerProvider.notifier)
+            .acknowledgeSuccess();
+        if (context.mounted) {
+          onSuccess();
+        }
+      } else if (next.generalErrorMessage != null &&
+          next.generalErrorMessage != previous?.generalErrorMessage &&
+          context.mounted) {
+        ScaffoldMessenger.of(context)
+          ..hideCurrentSnackBar()
+          ..showSnackBar(SnackBar(content: Text(next.generalErrorMessage!)));
+      }
+    });
+
+    return accountsAsync.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (Object error, _) => _ErrorMessage(message: error.toString()),
+      data: (List<AccountEntity> accounts) {
+        if (accounts.isEmpty) {
+          return _ErrorMessage(message: strings.addRecurringRuleNoAccounts);
+        }
+        if (state.account == null) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            ref
+                .read(recurringRuleFormControllerProvider.notifier)
+                .updateAccount(accounts.first);
+          });
+        }
+        return _RecurringRuleForm(
+          formKey: formKey,
+          state: state,
+          accounts: accounts,
+        );
+      },
+    );
+  }
+}
+
+class _RecurringRuleForm extends ConsumerWidget {
+  const _RecurringRuleForm({
+    required this.formKey,
+    required this.state,
+    required this.accounts,
+  });
+
+  final GlobalKey<FormState> formKey;
+  final RecurringRuleFormState state;
+  final List<AccountEntity> accounts;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final AppLocalizations strings = AppLocalizations.of(context)!;
+    final DateFormat dateFormat = DateFormat.yMMMMd(strings.localeName);
+    final MaterialLocalizations materialLocalizations =
+        MaterialLocalizations.of(context);
+
+    return Form(
+      key: formKey,
+      child: ListView(
+        padding: const EdgeInsets.all(24),
+        children: <Widget>[
+          TextFormField(
+            initialValue: state.title,
+            decoration: InputDecoration(
+              labelText: strings.addRecurringRuleNameLabel,
+              errorText: state.titleError == null
+                  ? null
+                  : strings.addRecurringRuleTitleRequired,
+            ),
+            onChanged: ref
+                .read(recurringRuleFormControllerProvider.notifier)
+                .updateTitle,
+            textInputAction: TextInputAction.next,
+          ),
+          const SizedBox(height: 16),
+          TextFormField(
+            initialValue: state.amountInput,
+            keyboardType: const TextInputType.numberWithOptions(
+              decimal: true,
+              signed: false,
+            ),
+            decoration: InputDecoration(
+              labelText: strings.addRecurringRuleAmountLabel,
+              hintText: strings.addRecurringRuleAmountHint,
+              errorText: state.amountError == null
+                  ? null
+                  : strings.addRecurringRuleAmountInvalid,
+            ),
+            onChanged: ref
+                .read(recurringRuleFormControllerProvider.notifier)
+                .updateAmount,
+          ),
+          const SizedBox(height: 16),
+          InputDecorator(
+            decoration: InputDecoration(
+              labelText: strings.addRecurringRuleAccountLabel,
+              errorText: state.accountError == null
+                  ? null
+                  : strings.addRecurringRuleAccountRequired,
+            ),
+            child: DropdownButtonHideUnderline(
+              child: DropdownButton<String>(
+                value: state.account?.id,
+                hint: Text(strings.addRecurringRuleAccountLabel),
+                isExpanded: true,
+                items: accounts
+                    .map(
+                      (AccountEntity account) => DropdownMenuItem<String>(
+                        value: account.id,
+                        child: Text('${account.name} · ${account.currency}'),
+                      ),
+                    )
+                    .toList(growable: false),
+                onChanged: state.isSubmitting
+                    ? null
+                    : (String? value) {
+                        final AccountEntity? account = value == null
+                            ? null
+                            : accounts.firstWhere(
+                                (AccountEntity item) => item.id == value,
+                              );
+                        ref
+                            .read(recurringRuleFormControllerProvider.notifier)
+                            .updateAccount(account);
+                      },
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          InputDecorator(
+            decoration: InputDecoration(
+              labelText: strings.addRecurringRuleTypeLabel,
+            ),
+            child: SegmentedButton<TransactionType>(
+              segments: <ButtonSegment<TransactionType>>[
+                ButtonSegment<TransactionType>(
+                  value: TransactionType.expense,
+                  label: Text(strings.addRecurringRuleTypeExpense),
+                ),
+                ButtonSegment<TransactionType>(
+                  value: TransactionType.income,
+                  label: Text(strings.addRecurringRuleTypeIncome),
+                ),
+              ],
+              selected: <TransactionType>{state.type},
+              onSelectionChanged: (Set<TransactionType> values) {
+                if (values.isEmpty) return;
+                ref
+                    .read(recurringRuleFormControllerProvider.notifier)
+                    .updateType(values.first);
+              },
+            ),
+          ),
+          const SizedBox(height: 16),
+          ListTile(
+            contentPadding: EdgeInsets.zero,
+            title: Text(strings.addRecurringRuleStartDateLabel),
+            subtitle: Text(dateFormat.format(state.startDate)),
+            trailing: const Icon(Icons.calendar_today),
+            onTap: () async {
+              final DateTime? selected = await showDatePicker(
+                context: context,
+                initialDate: state.startDate,
+                firstDate: DateTime(2000),
+                lastDate: DateTime(2100),
+              );
+              if (selected != null && context.mounted) {
+                ref
+                    .read(recurringRuleFormControllerProvider.notifier)
+                    .updateStartDate(selected);
+              }
+            },
+          ),
+          const SizedBox(height: 16),
+          ListTile(
+            contentPadding: EdgeInsets.zero,
+            title: Text(strings.addRecurringRuleStartTimeLabel),
+            subtitle: Text(
+              materialLocalizations.formatTimeOfDay(
+                TimeOfDay(hour: state.applyHour, minute: state.applyMinute),
+                alwaysUse24HourFormat: MediaQuery.of(
+                  context,
+                ).alwaysUse24HourFormat,
+              ),
+            ),
+            trailing: const Icon(Icons.schedule),
+            onTap: () async {
+              final TimeOfDay initialTime = TimeOfDay(
+                hour: state.applyHour,
+                minute: state.applyMinute,
+              );
+              final TimeOfDay? picked = await showTimePicker(
+                context: context,
+                initialTime: initialTime,
+              );
+              if (picked != null && context.mounted) {
+                ref
+                    .read(recurringRuleFormControllerProvider.notifier)
+                    .updateTime(hour: picked.hour, minute: picked.minute);
+              }
+            },
+          ),
+          const SizedBox(height: 16),
+          SwitchListTile.adaptive(
+            contentPadding: EdgeInsets.zero,
+            title: Text(strings.addRecurringRuleAutoPostLabel),
+            value: state.autoPost,
+            onChanged: state.isSubmitting
+                ? null
+                : ref
+                      .read(recurringRuleFormControllerProvider.notifier)
+                      .updateAutoPost,
+          ),
+          const SizedBox(height: 24),
+          FilledButton(
+            onPressed: state.isSubmitting
+                ? null
+                : () {
+                    FocusScope.of(context).unfocus();
+                    ref
+                        .read(recurringRuleFormControllerProvider.notifier)
+                        .submit();
+                  },
+            child: state.isSubmitting
+                ? const SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : Text(strings.addRecurringRuleSubmit),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ErrorMessage extends StatelessWidget {
+  const _ErrorMessage({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Text(
+          message,
+          style: Theme.of(context).textTheme.bodyLarge,
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -289,6 +289,74 @@
   "@recurringTransactionsNoUpcoming": {
     "description": "Shown when a recurring rule has no future occurrences"
   },
+  "addRecurringRuleTitle": "New recurring transaction",
+  "@addRecurringRuleTitle": {
+    "description": "Title for the add recurring rule screen"
+  },
+  "addRecurringRuleNameLabel": "Title",
+  "@addRecurringRuleNameLabel": {
+    "description": "Label for the recurring rule title field"
+  },
+  "addRecurringRuleTitleRequired": "Enter a title",
+  "@addRecurringRuleTitleRequired": {
+    "description": "Validation error when title is empty"
+  },
+  "addRecurringRuleAmountLabel": "Amount",
+  "@addRecurringRuleAmountLabel": {
+    "description": "Label for the recurring rule amount field"
+  },
+  "addRecurringRuleAmountHint": "0.00",
+  "@addRecurringRuleAmountHint": {
+    "description": "Hint for the recurring rule amount field"
+  },
+  "addRecurringRuleAmountInvalid": "Enter a valid positive amount",
+  "@addRecurringRuleAmountInvalid": {
+    "description": "Validation error when amount is invalid"
+  },
+  "addRecurringRuleAccountLabel": "Account",
+  "@addRecurringRuleAccountLabel": {
+    "description": "Label for the account dropdown"
+  },
+  "addRecurringRuleAccountRequired": "Select an account",
+  "@addRecurringRuleAccountRequired": {
+    "description": "Validation error when no account selected"
+  },
+  "addRecurringRuleTypeLabel": "Type",
+  "@addRecurringRuleTypeLabel": {
+    "description": "Label for the transaction type selector"
+  },
+  "addRecurringRuleTypeExpense": "Expense",
+  "@addRecurringRuleTypeExpense": {
+    "description": "Label for expense option"
+  },
+  "addRecurringRuleTypeIncome": "Income",
+  "@addRecurringRuleTypeIncome": {
+    "description": "Label for income option"
+  },
+  "addRecurringRuleStartDateLabel": "Start date",
+  "@addRecurringRuleStartDateLabel": {
+    "description": "Label for the start date picker"
+  },
+  "addRecurringRuleStartTimeLabel": "Execution time",
+  "@addRecurringRuleStartTimeLabel": {
+    "description": "Label for the time picker"
+  },
+  "addRecurringRuleAutoPostLabel": "Post automatically",
+  "@addRecurringRuleAutoPostLabel": {
+    "description": "Label for the auto-post toggle"
+  },
+  "addRecurringRuleSubmit": "Save rule",
+  "@addRecurringRuleSubmit": {
+    "description": "Label for the submit button"
+  },
+  "addRecurringRuleNoAccounts": "Add an account before creating a recurring rule.",
+  "@addRecurringRuleNoAccounts": {
+    "description": "Message shown when there are no accounts"
+  },
+  "addRecurringRuleSuccess": "Recurring transaction saved",
+  "@addRecurringRuleSuccess": {
+    "description": "Snackbar message when recurring rule saved"
+  },
   "commonComingSoon": "Coming soon",
   "@commonComingSoon": {
     "description": "Generic copy when a feature is not yet available"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -494,6 +494,108 @@ abstract class AppLocalizations {
   /// **'No upcoming occurrences'**
   String get recurringTransactionsNoUpcoming;
 
+  /// Title for the add recurring rule screen
+  ///
+  /// In en, this message translates to:
+  /// **'New recurring transaction'**
+  String get addRecurringRuleTitle;
+
+  /// Label for the recurring rule title field
+  ///
+  /// In en, this message translates to:
+  /// **'Title'**
+  String get addRecurringRuleNameLabel;
+
+  /// Validation error when title is empty
+  ///
+  /// In en, this message translates to:
+  /// **'Enter a title'**
+  String get addRecurringRuleTitleRequired;
+
+  /// Label for the recurring rule amount field
+  ///
+  /// In en, this message translates to:
+  /// **'Amount'**
+  String get addRecurringRuleAmountLabel;
+
+  /// Hint for the recurring rule amount field
+  ///
+  /// In en, this message translates to:
+  /// **'0.00'**
+  String get addRecurringRuleAmountHint;
+
+  /// Validation error when amount is invalid
+  ///
+  /// In en, this message translates to:
+  /// **'Enter a valid positive amount'**
+  String get addRecurringRuleAmountInvalid;
+
+  /// Label for the account dropdown
+  ///
+  /// In en, this message translates to:
+  /// **'Account'**
+  String get addRecurringRuleAccountLabel;
+
+  /// Validation error when no account selected
+  ///
+  /// In en, this message translates to:
+  /// **'Select an account'**
+  String get addRecurringRuleAccountRequired;
+
+  /// Label for the transaction type selector
+  ///
+  /// In en, this message translates to:
+  /// **'Type'**
+  String get addRecurringRuleTypeLabel;
+
+  /// Label for expense option
+  ///
+  /// In en, this message translates to:
+  /// **'Expense'**
+  String get addRecurringRuleTypeExpense;
+
+  /// Label for income option
+  ///
+  /// In en, this message translates to:
+  /// **'Income'**
+  String get addRecurringRuleTypeIncome;
+
+  /// Label for the start date picker
+  ///
+  /// In en, this message translates to:
+  /// **'Start date'**
+  String get addRecurringRuleStartDateLabel;
+
+  /// Label for the time picker
+  ///
+  /// In en, this message translates to:
+  /// **'Execution time'**
+  String get addRecurringRuleStartTimeLabel;
+
+  /// Label for the auto-post toggle
+  ///
+  /// In en, this message translates to:
+  /// **'Post automatically'**
+  String get addRecurringRuleAutoPostLabel;
+
+  /// Label for the submit button
+  ///
+  /// In en, this message translates to:
+  /// **'Save rule'**
+  String get addRecurringRuleSubmit;
+
+  /// Message shown when there are no accounts
+  ///
+  /// In en, this message translates to:
+  /// **'Add an account before creating a recurring rule.'**
+  String get addRecurringRuleNoAccounts;
+
+  /// Snackbar message when recurring rule saved
+  ///
+  /// In en, this message translates to:
+  /// **'Recurring transaction saved'**
+  String get addRecurringRuleSuccess;
+
   /// Generic copy when a feature is not yet available
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -219,6 +219,58 @@ class AppLocalizationsEn extends AppLocalizations {
   String get recurringTransactionsNoUpcoming => 'No upcoming occurrences';
 
   @override
+  String get addRecurringRuleTitle => 'New recurring transaction';
+
+  @override
+  String get addRecurringRuleNameLabel => 'Title';
+
+  @override
+  String get addRecurringRuleTitleRequired => 'Enter a title';
+
+  @override
+  String get addRecurringRuleAmountLabel => 'Amount';
+
+  @override
+  String get addRecurringRuleAmountHint => '0.00';
+
+  @override
+  String get addRecurringRuleAmountInvalid => 'Enter a valid positive amount';
+
+  @override
+  String get addRecurringRuleAccountLabel => 'Account';
+
+  @override
+  String get addRecurringRuleAccountRequired => 'Select an account';
+
+  @override
+  String get addRecurringRuleTypeLabel => 'Type';
+
+  @override
+  String get addRecurringRuleTypeExpense => 'Expense';
+
+  @override
+  String get addRecurringRuleTypeIncome => 'Income';
+
+  @override
+  String get addRecurringRuleStartDateLabel => 'Start date';
+
+  @override
+  String get addRecurringRuleStartTimeLabel => 'Execution time';
+
+  @override
+  String get addRecurringRuleAutoPostLabel => 'Post automatically';
+
+  @override
+  String get addRecurringRuleSubmit => 'Save rule';
+
+  @override
+  String get addRecurringRuleNoAccounts =>
+      'Add an account before creating a recurring rule.';
+
+  @override
+  String get addRecurringRuleSuccess => 'Recurring transaction saved';
+
+  @override
   String get commonComingSoon => 'Coming soon';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -220,6 +220,58 @@ class AppLocalizationsRu extends AppLocalizations {
   String get recurringTransactionsNoUpcoming => 'Нет предстоящих операций';
 
   @override
+  String get addRecurringRuleTitle => 'Новая повторяющаяся операция';
+
+  @override
+  String get addRecurringRuleNameLabel => 'Название';
+
+  @override
+  String get addRecurringRuleTitleRequired => 'Введите название';
+
+  @override
+  String get addRecurringRuleAmountLabel => 'Сумма';
+
+  @override
+  String get addRecurringRuleAmountHint => '0,00';
+
+  @override
+  String get addRecurringRuleAmountInvalid => 'Введите положительную сумму';
+
+  @override
+  String get addRecurringRuleAccountLabel => 'Счёт';
+
+  @override
+  String get addRecurringRuleAccountRequired => 'Выберите счёт';
+
+  @override
+  String get addRecurringRuleTypeLabel => 'Тип';
+
+  @override
+  String get addRecurringRuleTypeExpense => 'Расход';
+
+  @override
+  String get addRecurringRuleTypeIncome => 'Доход';
+
+  @override
+  String get addRecurringRuleStartDateLabel => 'Дата начала';
+
+  @override
+  String get addRecurringRuleStartTimeLabel => 'Время выполнения';
+
+  @override
+  String get addRecurringRuleAutoPostLabel => 'Проводить автоматически';
+
+  @override
+  String get addRecurringRuleSubmit => 'Сохранить правило';
+
+  @override
+  String get addRecurringRuleNoAccounts =>
+      'Сначала добавьте счёт, чтобы создать повторяющееся правило.';
+
+  @override
+  String get addRecurringRuleSuccess => 'Повторяющаяся операция сохранена';
+
+  @override
   String get commonComingSoon => 'Скоро появится';
 
   @override

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -289,6 +289,74 @@
   "@recurringTransactionsNoUpcoming": {
     "description": "Shown when a recurring rule has no future occurrences"
   },
+  "addRecurringRuleTitle": "Новая повторяющаяся операция",
+  "@addRecurringRuleTitle": {
+    "description": "Заголовок экрана создания повторяющейся операции"
+  },
+  "addRecurringRuleNameLabel": "Название",
+  "@addRecurringRuleNameLabel": {
+    "description": "Подпись поля ввода названия повторяющегося правила"
+  },
+  "addRecurringRuleTitleRequired": "Введите название",
+  "@addRecurringRuleTitleRequired": {
+    "description": "Сообщение об ошибке, если название не заполнено"
+  },
+  "addRecurringRuleAmountLabel": "Сумма",
+  "@addRecurringRuleAmountLabel": {
+    "description": "Подпись поля ввода суммы"
+  },
+  "addRecurringRuleAmountHint": "0,00",
+  "@addRecurringRuleAmountHint": {
+    "description": "Подсказка для поля суммы"
+  },
+  "addRecurringRuleAmountInvalid": "Введите положительную сумму",
+  "@addRecurringRuleAmountInvalid": {
+    "description": "Сообщение об ошибке, если сумма некорректна"
+  },
+  "addRecurringRuleAccountLabel": "Счёт",
+  "@addRecurringRuleAccountLabel": {
+    "description": "Подпись выпадающего списка со счетами"
+  },
+  "addRecurringRuleAccountRequired": "Выберите счёт",
+  "@addRecurringRuleAccountRequired": {
+    "description": "Сообщение об ошибке, если счёт не выбран"
+  },
+  "addRecurringRuleTypeLabel": "Тип",
+  "@addRecurringRuleTypeLabel": {
+    "description": "Подпись выбора типа операции"
+  },
+  "addRecurringRuleTypeExpense": "Расход",
+  "@addRecurringRuleTypeExpense": {
+    "description": "Подпись варианта расхода"
+  },
+  "addRecurringRuleTypeIncome": "Доход",
+  "@addRecurringRuleTypeIncome": {
+    "description": "Подпись варианта дохода"
+  },
+  "addRecurringRuleStartDateLabel": "Дата начала",
+  "@addRecurringRuleStartDateLabel": {
+    "description": "Подпись выбора даты"
+  },
+  "addRecurringRuleStartTimeLabel": "Время выполнения",
+  "@addRecurringRuleStartTimeLabel": {
+    "description": "Подпись выбора времени"
+  },
+  "addRecurringRuleAutoPostLabel": "Проводить автоматически",
+  "@addRecurringRuleAutoPostLabel": {
+    "description": "Подпись переключателя автопроведения"
+  },
+  "addRecurringRuleSubmit": "Сохранить правило",
+  "@addRecurringRuleSubmit": {
+    "description": "Подпись кнопки сохранения повторяющегося правила"
+  },
+  "addRecurringRuleNoAccounts": "Сначала добавьте счёт, чтобы создать повторяющееся правило.",
+  "@addRecurringRuleNoAccounts": {
+    "description": "Сообщение, когда нет доступных счетов"
+  },
+  "addRecurringRuleSuccess": "Повторяющаяся операция сохранена",
+  "@addRecurringRuleSuccess": {
+    "description": "Сообщение об успешном создании повторяющейся операции"
+  },
   "commonComingSoon": "Скоро появится",
   "@commonComingSoon": {
     "description": "Generic copy when a feature is not yet available"

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,6 +15,7 @@ import 'features/categories/presentation/screens/manage_categories_screen.dart';
 import 'features/profile/presentation/screens/profile_screen.dart';
 import 'features/profile/presentation/screens/sign_in_screen.dart';
 import 'features/transactions/presentation/add_transaction_screen.dart';
+import 'features/recurring_transactions/presentation/screens/add_recurring_rule_screen.dart';
 import 'features/recurring_transactions/presentation/screens/recurring_transactions_screen.dart';
 
 Future<void> main() async {
@@ -74,6 +75,7 @@ class _MyAppState extends ConsumerState<MyApp> {
         ManageCategoriesScreen.routeName: (_) => const ManageCategoriesScreen(),
         RecurringTransactionsScreen.routeName: (_) =>
             const RecurringTransactionsScreen(),
+        AddRecurringRuleScreen.routeName: (_) => const AddRecurringRuleScreen(),
       },
       home: startupState.when(
         data: (_) => _AppHome(authState: ref.watch(authControllerProvider)),

--- a/test/features/recurring_transactions/presentation/controllers/recurring_rule_form_controller_test.dart
+++ b/test/features/recurring_transactions/presentation/controllers/recurring_rule_form_controller_test.dart
@@ -1,0 +1,163 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kopim/core/di/injectors.dart';
+import 'package:kopim/features/accounts/domain/entities/account_entity.dart';
+import 'package:kopim/features/recurring_transactions/domain/entities/recurring_rule.dart';
+import 'package:kopim/features/recurring_transactions/domain/use_cases/save_recurring_rule_use_case.dart';
+import 'package:kopim/features/recurring_transactions/presentation/controllers/recurring_rule_form_controller.dart';
+import 'package:kopim/features/transactions/domain/entities/transaction_type.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:riverpod/src/framework.dart';
+import 'package:uuid/uuid.dart';
+
+class _MockSaveRecurringRuleUseCase extends Mock
+    implements SaveRecurringRuleUseCase {}
+
+class _MockUuid extends Mock implements Uuid {}
+
+RecurringRule _fallbackRule() {
+  final DateTime now = DateTime.fromMillisecondsSinceEpoch(0, isUtc: true);
+  return RecurringRule(
+    id: 'id',
+    title: 'title',
+    accountId: 'account',
+    amount: 10,
+    currency: 'USD',
+    startAt: now,
+    timezone: 'UTC',
+    rrule: 'FREQ=MONTHLY;BYMONTHDAY=1',
+    notes: null,
+    dayOfMonth: 1,
+    applyAtLocalHour: 10,
+    applyAtLocalMinute: 0,
+    lastRunAt: null,
+    nextDueLocalDate: now,
+    isActive: true,
+    autoPost: false,
+    reminderMinutesBefore: null,
+    shortMonthPolicy: RecurringRuleShortMonthPolicy.clipToLastDay,
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+AccountEntity _buildAccount() {
+  final DateTime now = DateTime.fromMillisecondsSinceEpoch(0, isUtc: true);
+  return AccountEntity(
+    id: 'account-1',
+    name: 'Main',
+    balance: 1000,
+    currency: 'EUR',
+    type: 'bank',
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(_fallbackRule());
+  });
+
+  late _MockSaveRecurringRuleUseCase mockUseCase;
+  late _MockUuid mockUuid;
+  late ProviderContainer container;
+
+  setUp(() {
+    mockUseCase = _MockSaveRecurringRuleUseCase();
+    mockUuid = _MockUuid();
+    when(() => mockUuid.v4()).thenReturn('uuid-1');
+    container = ProviderContainer(
+      overrides: <Override>[
+        saveRecurringRuleUseCaseProvider.overrideWithValue(mockUseCase),
+        uuidGeneratorProvider.overrideWithValue(mockUuid),
+      ],
+    );
+    addTearDown(container.dispose);
+  });
+
+  test('submit sends recurring rule to use case and marks success', () async {
+    when(() => mockUseCase.call(any())).thenAnswer((_) async {});
+
+    final RecurringRuleFormController controller = container.read(
+      recurringRuleFormControllerProvider.notifier,
+    );
+    final AccountEntity account = _buildAccount();
+    controller.updateAccount(account);
+    controller.updateTitle('  Зарплата ');
+    controller.updateAmount('150');
+    controller.updateType(TransactionType.income);
+    controller.updateStartDate(DateTime(2024, 1, 15));
+    controller.updateTime(hour: 10, minute: 30);
+    controller.updateAutoPost(true);
+
+    await controller.submit();
+
+    final RecurringRule captured =
+        verify(() => mockUseCase.call(captureAny())).captured.single
+            as RecurringRule;
+
+    expect(captured.id, 'uuid-1');
+    expect(captured.title, 'Зарплата');
+    expect(captured.accountId, account.id);
+    expect(captured.currency, account.currency);
+    expect(captured.amount, -150);
+    expect(captured.autoPost, isTrue);
+    expect(captured.dayOfMonth, 15);
+    expect(captured.applyAtLocalHour, 10);
+    expect(captured.applyAtLocalMinute, 30);
+    expect(captured.rrule, 'FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=15');
+    expect(captured.startAt, DateTime.utc(2024, 1, 15, 10, 30));
+    expect(captured.nextDueLocalDate, DateTime(2024, 1, 15, 10, 30));
+    expect(captured.createdAt.isUtc, isTrue);
+    expect(captured.updatedAt.isUtc, isTrue);
+
+    final RecurringRuleFormState state = container.read(
+      recurringRuleFormControllerProvider,
+    );
+    expect(state.submissionSuccess, isTrue);
+    expect(state.isSubmitting, isFalse);
+    expect(state.generalErrorMessage, isNull);
+  });
+
+  test('submit validates fields before calling use case', () async {
+    final RecurringRuleFormController controller = container.read(
+      recurringRuleFormControllerProvider.notifier,
+    );
+    controller.updateTitle('  ');
+    controller.updateAmount('abc');
+    controller.updateAccount(null);
+
+    await controller.submit();
+
+    final RecurringRuleFormState state = container.read(
+      recurringRuleFormControllerProvider,
+    );
+    expect(state.titleError, RecurringRuleTitleError.empty);
+    expect(state.amountError, RecurringRuleAmountError.invalid);
+    expect(state.accountError, RecurringRuleAccountError.missing);
+    verifyNever(() => mockUseCase.call(any()));
+  });
+
+  test('submit surfaces error when use case throws', () async {
+    when(() => mockUseCase.call(any())).thenAnswer((_) async {
+      throw Exception('failed');
+    });
+
+    final RecurringRuleFormController controller = container.read(
+      recurringRuleFormControllerProvider.notifier,
+    );
+    controller.updateAccount(_buildAccount());
+    controller.updateTitle('Аренда');
+    controller.updateAmount('500');
+
+    await controller.submit();
+
+    final RecurringRuleFormState state = container.read(
+      recurringRuleFormControllerProvider,
+    );
+    expect(state.submissionSuccess, isFalse);
+    expect(state.isSubmitting, isFalse);
+    expect(state.generalErrorMessage, contains('failed'));
+    verify(() => mockUseCase.call(any())).called(1);
+  });
+}


### PR DESCRIPTION
## Обзор
- добавлен экран создания повторяющегося правила с формой ввода и валидацией
- реализован контроллер формы на Riverpod и юнит-тесты на создание и обработку ошибок
- расширены локализации и маршруты приложения для новой функции

## Тесты
- dart format --set-exit-if-changed .
- flutter analyze
- dart run build_runner build --delete-conflicting-outputs
- flutter test --reporter expanded
- flutter pub outdated

------
https://chatgpt.com/codex/tasks/task_e_68e038379f40832eba9b85a923d8a243