### PR TITLE
Обработка результата Navigator.pushNamed без обобщения

### DIFF
--- a/lib/features/recurring_transactions/presentation/screens/recurring_transactions_screen.dart
+++ b/lib/features/recurring_transactions/presentation/screens/recurring_transactions_screen.dart
@@ -106,9 +106,10 @@ class RecurringTransactionsScreen extends ConsumerWidget {
   }
 
   Future<void> _onAddRulePressed(BuildContext context) async {
-    final bool? created = await Navigator.of(
+    final Object? result = await Navigator.of(
       context,
-    ).pushNamed<bool>(AddRecurringRuleScreen.routeName);
+    ).pushNamed(AddRecurringRuleScreen.routeName);
+    final bool? created = result as bool?;
     if (created == true && context.mounted) {
       ScaffoldMessenger.of(context)
         ..hideCurrentSnackBar()


### PR DESCRIPTION
## Summary
- приводим результат Navigator.pushNamed на экране повторяющихся транзакций к bool? после получения Object?

## Testing
- `dart format --set-exit-if-changed .`
- `flutter analyze`
- `dart run build_runner build --delete-conflicting-outputs`
- `flutter test --reporter expanded`
- `flutter pub outdated`


------
https://chatgpt.com/codex/tasks/task_e_68e0449e8124832eaf203c089c81db4b