### PR TITLE
Исправить открытие экрана создания повторяющейся операции

### DIFF
--- a/lib/features/recurring_transactions/presentation/screens/recurring_transactions_screen.dart
+++ b/lib/features/recurring_transactions/presentation/screens/recurring_transactions_screen.dart
@@ -109,9 +109,12 @@ class RecurringTransactionsScreen extends ConsumerWidget {
   }
 
   Future<void> _onAddRulePressed(BuildContext context) async {
-    final RecurringRuleFormResult? result = await Navigator.of(
-      context,
-    ).pushNamed<RecurringRuleFormResult>(AddRecurringRuleScreen.routeName);
+    final RecurringRuleFormResult? result = await Navigator.of(context).push(
+      MaterialPageRoute<RecurringRuleFormResult>(
+        builder: (_) => const AddRecurringRuleScreen(),
+        settings: const RouteSettings(name: AddRecurringRuleScreen.routeName),
+      ),
+    );
     if (result == RecurringRuleFormResult.created && context.mounted) {
       ScaffoldMessenger.of(context)
         ..hideCurrentSnackBar()
@@ -132,6 +135,7 @@ class RecurringTransactionsScreen extends ConsumerWidget {
     final RecurringRuleFormResult? result = await Navigator.of(context).push(
       MaterialPageRoute<RecurringRuleFormResult>(
         builder: (_) => AddRecurringRuleScreen(initialRule: rule),
+        settings: const RouteSettings(name: AddRecurringRuleScreen.routeName),
       ),
     );
     if (result == RecurringRuleFormResult.updated && context.mounted) {

--- a/test/features/recurring_transactions/presentation/screens/recurring_transactions_screen_test.dart
+++ b/test/features/recurring_transactions/presentation/screens/recurring_transactions_screen_test.dart
@@ -1,0 +1,97 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kopim/features/accounts/domain/entities/account_entity.dart';
+import 'package:kopim/features/recurring_transactions/domain/entities/recurring_occurrence.dart';
+import 'package:kopim/features/recurring_transactions/domain/entities/recurring_rule.dart';
+import 'package:kopim/features/recurring_transactions/presentation/controllers/recurring_rule_form_controller.dart';
+import 'package:kopim/features/recurring_transactions/presentation/controllers/recurring_transactions_providers.dart';
+import 'package:kopim/features/recurring_transactions/presentation/screens/add_recurring_rule_screen.dart';
+import 'package:kopim/features/recurring_transactions/presentation/screens/recurring_transactions_screen.dart';
+import 'package:kopim/l10n/app_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class _RecordingNavigatorObserver extends NavigatorObserver {
+  _RecordingNavigatorObserver(this.pushedRoutes);
+
+  final List<Route<dynamic>> pushedRoutes;
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPush(route, previousRoute);
+    pushedRoutes.add(route);
+  }
+}
+
+void main() {
+  testWidgets('нажатие на кнопку добавления открывает экран создания правила', (
+    WidgetTester tester,
+  ) async {
+    final List<Route<dynamic>> pushedRoutes = <Route<dynamic>>[];
+    final NavigatorObserver observer = _RecordingNavigatorObserver(
+      pushedRoutes,
+    );
+
+    final StreamController<List<RecurringRule>> rulesController =
+        StreamController<List<RecurringRule>>();
+    final StreamController<List<RecurringOccurrence>> occurrencesController =
+        StreamController<List<RecurringOccurrence>>();
+    addTearDown(() async {
+      await rulesController.close();
+      await occurrencesController.close();
+    });
+    rulesController.add(const <RecurringRule>[]);
+    occurrencesController.add(const <RecurringOccurrence>[]);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        // ignore: always_specify_types
+        overrides: [
+          recurringRulesProvider.overrideWith(
+            (Ref ref) => rulesController.stream,
+          ),
+          recurringRuleAccountsProvider.overrideWith(
+            (Ref ref) => Stream<List<AccountEntity>>.value(<AccountEntity>[
+              AccountEntity(
+                id: 'acc-1',
+                name: 'Main',
+                balance: 0,
+                currency: 'USD',
+                type: 'cash',
+                createdAt: DateTime(2024, 1, 1),
+                updatedAt: DateTime(2024, 1, 1),
+              ),
+            ]),
+          ),
+          upcomingRecurringOccurrencesProvider().overrideWith(
+            (Ref ref) => occurrencesController.stream,
+          ),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const RecurringTransactionsScreen(),
+          routes: <String, WidgetBuilder>{
+            AddRecurringRuleScreen.routeName: (_) =>
+                const AddRecurringRuleScreen(),
+          },
+          navigatorObservers: <NavigatorObserver>[observer],
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(FloatingActionButton));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(
+      pushedRoutes.map((Route<dynamic> route) => route.settings.name),
+      contains(AddRecurringRuleScreen.routeName),
+    );
+    expect(find.byType(AddRecurringRuleScreen), findsOneWidget);
+    await tester.pump();
+    await tester.pumpWidget(const SizedBox());
+    await tester.pump();
+  });
+}


### PR DESCRIPTION
## Summary
- заменить переход на экран добавления правила повторений на MaterialPageRoute с именованными настройками
- добавить виджет-тест, проверяющий, что FAB открывает экран создания правила

## Testing
- dart format --set-exit-if-changed .
- flutter analyze
- dart run build_runner build --delete-conflicting-outputs
- flutter test --reporter expanded
- flutter pub outdated

------
https://chatgpt.com/codex/tasks/task_e_68e0aec64b8c832e96e7c6d976715d05