### PR TITLE
Исправлены миграция recurring_rules и диспетчер Workmanager

### DIFF
--- a/lib/features/recurring_transactions/data/services/recurring_work_scheduler.dart
+++ b/lib/features/recurring_transactions/data/services/recurring_work_scheduler.dart
@@ -31,6 +31,7 @@ const String kRecurringTaskGenerateWindow = 'recurring_generate_window';
 const String kRecurringTaskMaintainWindow = 'recurring_window_maintenance';
 const String kRecurringTaskApplyRules = 'apply_recurring_rules';
 
+@pragma('vm:entry-point')
 void recurringWorkDispatcher() {
   Workmanager().executeTask((
     String task,


### PR DESCRIPTION
## Изменения
- перестроил миграцию `recurring_rules` через `alterTable`, чтобы заполнить `category_id` в транзакции и включить проверку внешних ключей;
- добавил аннотацию `@pragma('vm:entry-point')` для `recurringWorkDispatcher`, чтобы Workmanager корректно вызывал диспетчер в AOT-сборках.

## Тесты
- `dart format --set-exit-if-changed .`
- `flutter analyze`
- `dart run build_runner build --delete-conflicting-outputs`
- `flutter test --reporter expanded`
- `flutter pub outdated`


------
https://chatgpt.com/codex/tasks/task_e_68e100b83328832e92bb965856df22c2