### PR TITLE
Добавить карточку предстоящих платежей и обновить аналитику

### DIFF
--- a/lib/core/di/injectors.dart
+++ b/lib/core/di/injectors.dart
@@ -21,6 +21,7 @@ import 'package:kopim/features/accounts/domain/repositories/account_repository.d
 import 'package:kopim/features/accounts/domain/use_cases/add_account_use_case.dart';
 import 'package:kopim/features/accounts/domain/use_cases/watch_accounts_use_case.dart';
 import 'package:kopim/features/analytics/domain/use_cases/watch_monthly_analytics_use_case.dart';
+import 'package:kopim/features/home/domain/use_cases/watch_upcoming_payments_use_case.dart';
 import 'package:kopim/features/categories/data/repositories/category_repository_impl.dart';
 import 'package:kopim/features/categories/data/sources/local/category_dao.dart';
 import 'package:kopim/features/categories/data/sources/remote/category_remote_data_source.dart';
@@ -260,6 +261,12 @@ GroupTransactionsByDayUseCase groupTransactionsByDayUseCase(Ref ref) =>
 WatchRecurringRulesUseCase watchRecurringRulesUseCase(Ref ref) =>
     WatchRecurringRulesUseCase(
       ref.watch(recurringTransactionsRepositoryProvider),
+    );
+
+@riverpod
+WatchUpcomingPaymentsUseCase watchUpcomingPaymentsUseCase(Ref ref) =>
+    WatchUpcomingPaymentsUseCase(
+      recurringRepository: ref.watch(recurringTransactionsRepositoryProvider),
     );
 
 @riverpod

--- a/lib/core/di/injectors.g.dart
+++ b/lib/core/di/injectors.g.dart
@@ -1753,6 +1753,55 @@ final class WatchRecurringRulesUseCaseProvider
 String _$watchRecurringRulesUseCaseHash() =>
     r'9cb754ec24ae0c6d8f780d6ebee2f1541b3a42a6';
 
+@ProviderFor(watchUpcomingPaymentsUseCase)
+const watchUpcomingPaymentsUseCaseProvider =
+    WatchUpcomingPaymentsUseCaseProvider._();
+
+final class WatchUpcomingPaymentsUseCaseProvider
+    extends
+        $FunctionalProvider<
+          WatchUpcomingPaymentsUseCase,
+          WatchUpcomingPaymentsUseCase,
+          WatchUpcomingPaymentsUseCase
+        >
+    with $Provider<WatchUpcomingPaymentsUseCase> {
+  const WatchUpcomingPaymentsUseCaseProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'watchUpcomingPaymentsUseCaseProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$watchUpcomingPaymentsUseCaseHash();
+
+  @$internal
+  @override
+  $ProviderElement<WatchUpcomingPaymentsUseCase> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  WatchUpcomingPaymentsUseCase create(Ref ref) {
+    return watchUpcomingPaymentsUseCase(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(WatchUpcomingPaymentsUseCase value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<WatchUpcomingPaymentsUseCase>(value),
+    );
+  }
+}
+
+String _$watchUpcomingPaymentsUseCaseHash() =>
+    r'ad5834fc7c603e34c587e2c1ca8a56a454851bca';
+
 @ProviderFor(watchUpcomingOccurrencesUseCase)
 const watchUpcomingOccurrencesUseCaseProvider =
     WatchUpcomingOccurrencesUseCaseProvider._();

--- a/lib/core/widgets/phosphor_icon_picker.dart
+++ b/lib/core/widgets/phosphor_icon_picker.dart
@@ -291,7 +291,7 @@ class _PhosphorIconPickerSheetState extends State<_PhosphorIconPickerSheet>
             crossAxisCount: crossAxisCount,
             crossAxisSpacing: 12,
             mainAxisSpacing: 12,
-            childAspectRatio: 0.8,
+            childAspectRatio: 1,
           ),
           itemCount: icons.length,
           itemBuilder: (BuildContext context, int index) {
@@ -375,36 +375,32 @@ class _IconGridTile extends StatelessWidget {
     final Color background = isSelected
         ? theme.colorScheme.primary.withValues(alpha: 0.08)
         : theme.colorScheme.surface;
-    return InkWell(
-      borderRadius: BorderRadius.circular(12),
-      onTap: onTap,
-      child: Container(
-        padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 8),
-        decoration: BoxDecoration(
-          color: background,
+    final String label = formatPhosphorIconName(name);
+    return Tooltip(
+      message: label,
+      child: Semantics(
+        button: true,
+        label: label,
+        selected: isSelected,
+        child: InkWell(
           borderRadius: BorderRadius.circular(12),
-          border: Border.all(color: borderColor),
-        ),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            Expanded(
+          onTap: onTap,
+          child: Container(
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: background,
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(color: borderColor),
+            ),
+            child: Center(
               child: FittedBox(
                 fit: BoxFit.scaleDown,
                 child: iconData != null
-                    ? Icon(iconData, size: 32)
-                    : const Icon(Icons.category_outlined, size: 32),
+                    ? Icon(iconData, size: 36)
+                    : const Icon(Icons.category_outlined, size: 36),
               ),
             ),
-            const SizedBox(height: 8),
-            Text(
-              formatPhosphorIconName(name),
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
-              textAlign: TextAlign.center,
-              style: theme.textTheme.bodySmall,
-            ),
-          ],
+          ),
         ),
       ),
     );

--- a/lib/features/analytics/domain/models/analytics_overview.dart
+++ b/lib/features/analytics/domain/models/analytics_overview.dart
@@ -12,5 +12,6 @@ abstract class AnalyticsOverview with _$AnalyticsOverview {
     required double totalExpense,
     required double netBalance,
     required List<AnalyticsCategoryBreakdown> topExpenseCategories,
+    required List<AnalyticsCategoryBreakdown> topIncomeCategories,
   }) = _AnalyticsOverview;
 }

--- a/lib/features/analytics/domain/models/analytics_overview.freezed.dart
+++ b/lib/features/analytics/domain/models/analytics_overview.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$AnalyticsOverview {
 
- double get totalIncome; double get totalExpense; double get netBalance; List<AnalyticsCategoryBreakdown> get topExpenseCategories;
+ double get totalIncome; double get totalExpense; double get netBalance; List<AnalyticsCategoryBreakdown> get topExpenseCategories; List<AnalyticsCategoryBreakdown> get topIncomeCategories;
 /// Create a copy of AnalyticsOverview
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -25,16 +25,16 @@ $AnalyticsOverviewCopyWith<AnalyticsOverview> get copyWith => _$AnalyticsOvervie
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is AnalyticsOverview&&(identical(other.totalIncome, totalIncome) || other.totalIncome == totalIncome)&&(identical(other.totalExpense, totalExpense) || other.totalExpense == totalExpense)&&(identical(other.netBalance, netBalance) || other.netBalance == netBalance)&&const DeepCollectionEquality().equals(other.topExpenseCategories, topExpenseCategories));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AnalyticsOverview&&(identical(other.totalIncome, totalIncome) || other.totalIncome == totalIncome)&&(identical(other.totalExpense, totalExpense) || other.totalExpense == totalExpense)&&(identical(other.netBalance, netBalance) || other.netBalance == netBalance)&&const DeepCollectionEquality().equals(other.topExpenseCategories, topExpenseCategories)&&const DeepCollectionEquality().equals(other.topIncomeCategories, topIncomeCategories));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,totalIncome,totalExpense,netBalance,const DeepCollectionEquality().hash(topExpenseCategories));
+int get hashCode => Object.hash(runtimeType,totalIncome,totalExpense,netBalance,const DeepCollectionEquality().hash(topExpenseCategories),const DeepCollectionEquality().hash(topIncomeCategories));
 
 @override
 String toString() {
-  return 'AnalyticsOverview(totalIncome: $totalIncome, totalExpense: $totalExpense, netBalance: $netBalance, topExpenseCategories: $topExpenseCategories)';
+  return 'AnalyticsOverview(totalIncome: $totalIncome, totalExpense: $totalExpense, netBalance: $netBalance, topExpenseCategories: $topExpenseCategories, topIncomeCategories: $topIncomeCategories)';
 }
 
 
@@ -45,7 +45,7 @@ abstract mixin class $AnalyticsOverviewCopyWith<$Res>  {
   factory $AnalyticsOverviewCopyWith(AnalyticsOverview value, $Res Function(AnalyticsOverview) _then) = _$AnalyticsOverviewCopyWithImpl;
 @useResult
 $Res call({
- double totalIncome, double totalExpense, double netBalance, List<AnalyticsCategoryBreakdown> topExpenseCategories
+ double totalIncome, double totalExpense, double netBalance, List<AnalyticsCategoryBreakdown> topExpenseCategories, List<AnalyticsCategoryBreakdown> topIncomeCategories
 });
 
 
@@ -62,12 +62,13 @@ class _$AnalyticsOverviewCopyWithImpl<$Res>
 
 /// Create a copy of AnalyticsOverview
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? totalIncome = null,Object? totalExpense = null,Object? netBalance = null,Object? topExpenseCategories = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? totalIncome = null,Object? totalExpense = null,Object? netBalance = null,Object? topExpenseCategories = null,Object? topIncomeCategories = null,}) {
   return _then(_self.copyWith(
 totalIncome: null == totalIncome ? _self.totalIncome : totalIncome // ignore: cast_nullable_to_non_nullable
 as double,totalExpense: null == totalExpense ? _self.totalExpense : totalExpense // ignore: cast_nullable_to_non_nullable
 as double,netBalance: null == netBalance ? _self.netBalance : netBalance // ignore: cast_nullable_to_non_nullable
 as double,topExpenseCategories: null == topExpenseCategories ? _self.topExpenseCategories : topExpenseCategories // ignore: cast_nullable_to_non_nullable
+as List<AnalyticsCategoryBreakdown>,topIncomeCategories: null == topIncomeCategories ? _self.topIncomeCategories : topIncomeCategories // ignore: cast_nullable_to_non_nullable
 as List<AnalyticsCategoryBreakdown>,
   ));
 }
@@ -153,10 +154,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( double totalIncome,  double totalExpense,  double netBalance,  List<AnalyticsCategoryBreakdown> topExpenseCategories)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( double totalIncome,  double totalExpense,  double netBalance,  List<AnalyticsCategoryBreakdown> topExpenseCategories,  List<AnalyticsCategoryBreakdown> topIncomeCategories)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _AnalyticsOverview() when $default != null:
-return $default(_that.totalIncome,_that.totalExpense,_that.netBalance,_that.topExpenseCategories);case _:
+return $default(_that.totalIncome,_that.totalExpense,_that.netBalance,_that.topExpenseCategories,_that.topIncomeCategories);case _:
   return orElse();
 
 }
@@ -174,10 +175,10 @@ return $default(_that.totalIncome,_that.totalExpense,_that.netBalance,_that.topE
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( double totalIncome,  double totalExpense,  double netBalance,  List<AnalyticsCategoryBreakdown> topExpenseCategories)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( double totalIncome,  double totalExpense,  double netBalance,  List<AnalyticsCategoryBreakdown> topExpenseCategories,  List<AnalyticsCategoryBreakdown> topIncomeCategories)  $default,) {final _that = this;
 switch (_that) {
 case _AnalyticsOverview():
-return $default(_that.totalIncome,_that.totalExpense,_that.netBalance,_that.topExpenseCategories);case _:
+return $default(_that.totalIncome,_that.totalExpense,_that.netBalance,_that.topExpenseCategories,_that.topIncomeCategories);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -194,10 +195,10 @@ return $default(_that.totalIncome,_that.totalExpense,_that.netBalance,_that.topE
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( double totalIncome,  double totalExpense,  double netBalance,  List<AnalyticsCategoryBreakdown> topExpenseCategories)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( double totalIncome,  double totalExpense,  double netBalance,  List<AnalyticsCategoryBreakdown> topExpenseCategories,  List<AnalyticsCategoryBreakdown> topIncomeCategories)?  $default,) {final _that = this;
 switch (_that) {
 case _AnalyticsOverview() when $default != null:
-return $default(_that.totalIncome,_that.totalExpense,_that.netBalance,_that.topExpenseCategories);case _:
+return $default(_that.totalIncome,_that.totalExpense,_that.netBalance,_that.topExpenseCategories,_that.topIncomeCategories);case _:
   return null;
 
 }
@@ -209,7 +210,7 @@ return $default(_that.totalIncome,_that.totalExpense,_that.netBalance,_that.topE
 
 
 class _AnalyticsOverview extends AnalyticsOverview {
-  const _AnalyticsOverview({required this.totalIncome, required this.totalExpense, required this.netBalance, required final  List<AnalyticsCategoryBreakdown> topExpenseCategories}): _topExpenseCategories = topExpenseCategories,super._();
+  const _AnalyticsOverview({required this.totalIncome, required this.totalExpense, required this.netBalance, required final  List<AnalyticsCategoryBreakdown> topExpenseCategories, required final  List<AnalyticsCategoryBreakdown> topIncomeCategories}): _topExpenseCategories = topExpenseCategories,_topIncomeCategories = topIncomeCategories,super._();
   
 
 @override final  double totalIncome;
@@ -220,6 +221,13 @@ class _AnalyticsOverview extends AnalyticsOverview {
   if (_topExpenseCategories is EqualUnmodifiableListView) return _topExpenseCategories;
   // ignore: implicit_dynamic_type
   return EqualUnmodifiableListView(_topExpenseCategories);
+}
+
+ final  List<AnalyticsCategoryBreakdown> _topIncomeCategories;
+@override List<AnalyticsCategoryBreakdown> get topIncomeCategories {
+  if (_topIncomeCategories is EqualUnmodifiableListView) return _topIncomeCategories;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_topIncomeCategories);
 }
 
 
@@ -233,16 +241,16 @@ _$AnalyticsOverviewCopyWith<_AnalyticsOverview> get copyWith => __$AnalyticsOver
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AnalyticsOverview&&(identical(other.totalIncome, totalIncome) || other.totalIncome == totalIncome)&&(identical(other.totalExpense, totalExpense) || other.totalExpense == totalExpense)&&(identical(other.netBalance, netBalance) || other.netBalance == netBalance)&&const DeepCollectionEquality().equals(other._topExpenseCategories, _topExpenseCategories));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AnalyticsOverview&&(identical(other.totalIncome, totalIncome) || other.totalIncome == totalIncome)&&(identical(other.totalExpense, totalExpense) || other.totalExpense == totalExpense)&&(identical(other.netBalance, netBalance) || other.netBalance == netBalance)&&const DeepCollectionEquality().equals(other._topExpenseCategories, _topExpenseCategories)&&const DeepCollectionEquality().equals(other._topIncomeCategories, _topIncomeCategories));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,totalIncome,totalExpense,netBalance,const DeepCollectionEquality().hash(_topExpenseCategories));
+int get hashCode => Object.hash(runtimeType,totalIncome,totalExpense,netBalance,const DeepCollectionEquality().hash(_topExpenseCategories),const DeepCollectionEquality().hash(_topIncomeCategories));
 
 @override
 String toString() {
-  return 'AnalyticsOverview(totalIncome: $totalIncome, totalExpense: $totalExpense, netBalance: $netBalance, topExpenseCategories: $topExpenseCategories)';
+  return 'AnalyticsOverview(totalIncome: $totalIncome, totalExpense: $totalExpense, netBalance: $netBalance, topExpenseCategories: $topExpenseCategories, topIncomeCategories: $topIncomeCategories)';
 }
 
 
@@ -253,7 +261,7 @@ abstract mixin class _$AnalyticsOverviewCopyWith<$Res> implements $AnalyticsOver
   factory _$AnalyticsOverviewCopyWith(_AnalyticsOverview value, $Res Function(_AnalyticsOverview) _then) = __$AnalyticsOverviewCopyWithImpl;
 @override @useResult
 $Res call({
- double totalIncome, double totalExpense, double netBalance, List<AnalyticsCategoryBreakdown> topExpenseCategories
+ double totalIncome, double totalExpense, double netBalance, List<AnalyticsCategoryBreakdown> topExpenseCategories, List<AnalyticsCategoryBreakdown> topIncomeCategories
 });
 
 
@@ -270,12 +278,13 @@ class __$AnalyticsOverviewCopyWithImpl<$Res>
 
 /// Create a copy of AnalyticsOverview
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? totalIncome = null,Object? totalExpense = null,Object? netBalance = null,Object? topExpenseCategories = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? totalIncome = null,Object? totalExpense = null,Object? netBalance = null,Object? topExpenseCategories = null,Object? topIncomeCategories = null,}) {
   return _then(_AnalyticsOverview(
 totalIncome: null == totalIncome ? _self.totalIncome : totalIncome // ignore: cast_nullable_to_non_nullable
 as double,totalExpense: null == totalExpense ? _self.totalExpense : totalExpense // ignore: cast_nullable_to_non_nullable
 as double,netBalance: null == netBalance ? _self.netBalance : netBalance // ignore: cast_nullable_to_non_nullable
 as double,topExpenseCategories: null == topExpenseCategories ? _self._topExpenseCategories : topExpenseCategories // ignore: cast_nullable_to_non_nullable
+as List<AnalyticsCategoryBreakdown>,topIncomeCategories: null == topIncomeCategories ? _self._topIncomeCategories : topIncomeCategories // ignore: cast_nullable_to_non_nullable
 as List<AnalyticsCategoryBreakdown>,
   ));
 }

--- a/lib/features/app_shell/presentation/widgets/main_navigation_shell.dart
+++ b/lib/features/app_shell/presentation/widgets/main_navigation_shell.dart
@@ -22,6 +22,7 @@ class MainNavigationShell extends ConsumerWidget {
         config.contentBuilder(context, ref),
     ];
     final NavigationTabContent activeContent = contents[currentIndex];
+    final bool isCurrentRoute = ModalRoute.of(context)?.isCurrent ?? true;
     final PreferredSizeWidget? appBar = activeContent.appBarBuilder?.call(
       context,
       ref,
@@ -40,19 +41,22 @@ class MainNavigationShell extends ConsumerWidget {
         ],
       ),
       floatingActionButton: floatingActionButton,
-      bottomNavigationBar: BottomNavigationBar(
-        currentIndex: currentIndex,
-        onTap: (int index) =>
-            ref.read(mainNavigationControllerProvider.notifier).setIndex(index),
-        items: <BottomNavigationBarItem>[
-          for (final NavigationTabConfig config in tabs)
-            BottomNavigationBarItem(
-              icon: Icon(config.icon),
-              activeIcon: Icon(config.activeIcon),
-              label: config.labelBuilder(context),
-            ),
-        ],
-      ),
+      bottomNavigationBar: isCurrentRoute
+          ? BottomNavigationBar(
+              currentIndex: currentIndex,
+              onTap: (int index) => ref
+                  .read(mainNavigationControllerProvider.notifier)
+                  .setIndex(index),
+              items: <BottomNavigationBarItem>[
+                for (final NavigationTabConfig config in tabs)
+                  BottomNavigationBarItem(
+                    icon: Icon(config.icon),
+                    activeIcon: Icon(config.activeIcon),
+                    label: config.labelBuilder(context),
+                  ),
+              ],
+            )
+          : null,
     );
   }
 }

--- a/lib/features/home/domain/models/upcoming_payment.dart
+++ b/lib/features/home/domain/models/upcoming_payment.dart
@@ -1,0 +1,23 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'upcoming_payment.freezed.dart';
+
+@freezed
+abstract class UpcomingPayment with _$UpcomingPayment {
+  const factory UpcomingPayment({
+    required String occurrenceId,
+    required String ruleId,
+    required String title,
+    required double amount,
+    required String currency,
+    required DateTime dueDate,
+    required String accountId,
+    required String categoryId,
+  }) = _UpcomingPayment;
+
+  const UpcomingPayment._();
+
+  bool get isExpense => amount >= 0;
+
+  double get absoluteAmount => amount.abs();
+}

--- a/lib/features/home/domain/models/upcoming_payment.freezed.dart
+++ b/lib/features/home/domain/models/upcoming_payment.freezed.dart
@@ -1,0 +1,292 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'upcoming_payment.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$UpcomingPayment {
+
+ String get occurrenceId; String get ruleId; String get title; double get amount; String get currency; DateTime get dueDate; String get accountId; String get categoryId;
+/// Create a copy of UpcomingPayment
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$UpcomingPaymentCopyWith<UpcomingPayment> get copyWith => _$UpcomingPaymentCopyWithImpl<UpcomingPayment>(this as UpcomingPayment, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is UpcomingPayment&&(identical(other.occurrenceId, occurrenceId) || other.occurrenceId == occurrenceId)&&(identical(other.ruleId, ruleId) || other.ruleId == ruleId)&&(identical(other.title, title) || other.title == title)&&(identical(other.amount, amount) || other.amount == amount)&&(identical(other.currency, currency) || other.currency == currency)&&(identical(other.dueDate, dueDate) || other.dueDate == dueDate)&&(identical(other.accountId, accountId) || other.accountId == accountId)&&(identical(other.categoryId, categoryId) || other.categoryId == categoryId));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,occurrenceId,ruleId,title,amount,currency,dueDate,accountId,categoryId);
+
+@override
+String toString() {
+  return 'UpcomingPayment(occurrenceId: $occurrenceId, ruleId: $ruleId, title: $title, amount: $amount, currency: $currency, dueDate: $dueDate, accountId: $accountId, categoryId: $categoryId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $UpcomingPaymentCopyWith<$Res>  {
+  factory $UpcomingPaymentCopyWith(UpcomingPayment value, $Res Function(UpcomingPayment) _then) = _$UpcomingPaymentCopyWithImpl;
+@useResult
+$Res call({
+ String occurrenceId, String ruleId, String title, double amount, String currency, DateTime dueDate, String accountId, String categoryId
+});
+
+
+
+
+}
+/// @nodoc
+class _$UpcomingPaymentCopyWithImpl<$Res>
+    implements $UpcomingPaymentCopyWith<$Res> {
+  _$UpcomingPaymentCopyWithImpl(this._self, this._then);
+
+  final UpcomingPayment _self;
+  final $Res Function(UpcomingPayment) _then;
+
+/// Create a copy of UpcomingPayment
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? occurrenceId = null,Object? ruleId = null,Object? title = null,Object? amount = null,Object? currency = null,Object? dueDate = null,Object? accountId = null,Object? categoryId = null,}) {
+  return _then(_self.copyWith(
+occurrenceId: null == occurrenceId ? _self.occurrenceId : occurrenceId // ignore: cast_nullable_to_non_nullable
+as String,ruleId: null == ruleId ? _self.ruleId : ruleId // ignore: cast_nullable_to_non_nullable
+as String,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,amount: null == amount ? _self.amount : amount // ignore: cast_nullable_to_non_nullable
+as double,currency: null == currency ? _self.currency : currency // ignore: cast_nullable_to_non_nullable
+as String,dueDate: null == dueDate ? _self.dueDate : dueDate // ignore: cast_nullable_to_non_nullable
+as DateTime,accountId: null == accountId ? _self.accountId : accountId // ignore: cast_nullable_to_non_nullable
+as String,categoryId: null == categoryId ? _self.categoryId : categoryId // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [UpcomingPayment].
+extension UpcomingPaymentPatterns on UpcomingPayment {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _UpcomingPayment value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _UpcomingPayment() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _UpcomingPayment value)  $default,){
+final _that = this;
+switch (_that) {
+case _UpcomingPayment():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _UpcomingPayment value)?  $default,){
+final _that = this;
+switch (_that) {
+case _UpcomingPayment() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String occurrenceId,  String ruleId,  String title,  double amount,  String currency,  DateTime dueDate,  String accountId,  String categoryId)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _UpcomingPayment() when $default != null:
+return $default(_that.occurrenceId,_that.ruleId,_that.title,_that.amount,_that.currency,_that.dueDate,_that.accountId,_that.categoryId);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String occurrenceId,  String ruleId,  String title,  double amount,  String currency,  DateTime dueDate,  String accountId,  String categoryId)  $default,) {final _that = this;
+switch (_that) {
+case _UpcomingPayment():
+return $default(_that.occurrenceId,_that.ruleId,_that.title,_that.amount,_that.currency,_that.dueDate,_that.accountId,_that.categoryId);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String occurrenceId,  String ruleId,  String title,  double amount,  String currency,  DateTime dueDate,  String accountId,  String categoryId)?  $default,) {final _that = this;
+switch (_that) {
+case _UpcomingPayment() when $default != null:
+return $default(_that.occurrenceId,_that.ruleId,_that.title,_that.amount,_that.currency,_that.dueDate,_that.accountId,_that.categoryId);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _UpcomingPayment extends UpcomingPayment {
+  const _UpcomingPayment({required this.occurrenceId, required this.ruleId, required this.title, required this.amount, required this.currency, required this.dueDate, required this.accountId, required this.categoryId}): super._();
+  
+
+@override final  String occurrenceId;
+@override final  String ruleId;
+@override final  String title;
+@override final  double amount;
+@override final  String currency;
+@override final  DateTime dueDate;
+@override final  String accountId;
+@override final  String categoryId;
+
+/// Create a copy of UpcomingPayment
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$UpcomingPaymentCopyWith<_UpcomingPayment> get copyWith => __$UpcomingPaymentCopyWithImpl<_UpcomingPayment>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _UpcomingPayment&&(identical(other.occurrenceId, occurrenceId) || other.occurrenceId == occurrenceId)&&(identical(other.ruleId, ruleId) || other.ruleId == ruleId)&&(identical(other.title, title) || other.title == title)&&(identical(other.amount, amount) || other.amount == amount)&&(identical(other.currency, currency) || other.currency == currency)&&(identical(other.dueDate, dueDate) || other.dueDate == dueDate)&&(identical(other.accountId, accountId) || other.accountId == accountId)&&(identical(other.categoryId, categoryId) || other.categoryId == categoryId));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,occurrenceId,ruleId,title,amount,currency,dueDate,accountId,categoryId);
+
+@override
+String toString() {
+  return 'UpcomingPayment(occurrenceId: $occurrenceId, ruleId: $ruleId, title: $title, amount: $amount, currency: $currency, dueDate: $dueDate, accountId: $accountId, categoryId: $categoryId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$UpcomingPaymentCopyWith<$Res> implements $UpcomingPaymentCopyWith<$Res> {
+  factory _$UpcomingPaymentCopyWith(_UpcomingPayment value, $Res Function(_UpcomingPayment) _then) = __$UpcomingPaymentCopyWithImpl;
+@override @useResult
+$Res call({
+ String occurrenceId, String ruleId, String title, double amount, String currency, DateTime dueDate, String accountId, String categoryId
+});
+
+
+
+
+}
+/// @nodoc
+class __$UpcomingPaymentCopyWithImpl<$Res>
+    implements _$UpcomingPaymentCopyWith<$Res> {
+  __$UpcomingPaymentCopyWithImpl(this._self, this._then);
+
+  final _UpcomingPayment _self;
+  final $Res Function(_UpcomingPayment) _then;
+
+/// Create a copy of UpcomingPayment
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? occurrenceId = null,Object? ruleId = null,Object? title = null,Object? amount = null,Object? currency = null,Object? dueDate = null,Object? accountId = null,Object? categoryId = null,}) {
+  return _then(_UpcomingPayment(
+occurrenceId: null == occurrenceId ? _self.occurrenceId : occurrenceId // ignore: cast_nullable_to_non_nullable
+as String,ruleId: null == ruleId ? _self.ruleId : ruleId // ignore: cast_nullable_to_non_nullable
+as String,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,amount: null == amount ? _self.amount : amount // ignore: cast_nullable_to_non_nullable
+as double,currency: null == currency ? _self.currency : currency // ignore: cast_nullable_to_non_nullable
+as String,dueDate: null == dueDate ? _self.dueDate : dueDate // ignore: cast_nullable_to_non_nullable
+as DateTime,accountId: null == accountId ? _self.accountId : accountId // ignore: cast_nullable_to_non_nullable
+as String,categoryId: null == categoryId ? _self.categoryId : categoryId // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/features/home/domain/use_cases/watch_upcoming_payments_use_case.dart
+++ b/lib/features/home/domain/use_cases/watch_upcoming_payments_use_case.dart
@@ -1,0 +1,153 @@
+import 'dart:async';
+
+import 'package:collection/collection.dart';
+import 'package:kopim/features/home/domain/models/upcoming_payment.dart';
+import 'package:kopim/features/recurring_transactions/domain/entities/recurring_occurrence.dart';
+import 'package:kopim/features/recurring_transactions/domain/entities/recurring_rule.dart';
+import 'package:kopim/features/recurring_transactions/domain/repositories/recurring_transactions_repository.dart';
+import 'package:meta/meta.dart';
+
+class WatchUpcomingPaymentsUseCase {
+  WatchUpcomingPaymentsUseCase({
+    required RecurringTransactionsRepository recurringRepository,
+  }) : _recurringRepository = recurringRepository;
+
+  final RecurringTransactionsRepository _recurringRepository;
+
+  Stream<List<UpcomingPayment>> call({
+    required DateTime from,
+    required DateTime to,
+  }) {
+    final Stream<List<RecurringOccurrence>> occurrencesStream =
+        _recurringRepository.watchUpcomingOccurrences(from: from, to: to);
+    final Stream<List<RecurringRule>> rulesStream = _recurringRepository
+        .watchRules();
+
+    return Stream<List<UpcomingPayment>>.multi((
+      StreamController<List<UpcomingPayment>> controller,
+    ) {
+      List<RecurringOccurrence> latestOccurrences =
+          const <RecurringOccurrence>[];
+      List<RecurringRule> latestRules = const <RecurringRule>[];
+      bool hasOccurrences = false;
+      bool hasRules = false;
+      bool occurrencesDone = false;
+      bool rulesDone = false;
+
+      void emitIfReady() {
+        if (!hasOccurrences || !hasRules) {
+          return;
+        }
+        final List<UpcomingPayment> payments = mapToUpcomingPayments(
+          occurrences: latestOccurrences,
+          rules: latestRules,
+        );
+        controller.add(payments);
+      }
+
+      final StreamSubscription<List<RecurringOccurrence>> occurrencesSub =
+          occurrencesStream.listen(
+            (List<RecurringOccurrence> value) {
+              hasOccurrences = true;
+              latestOccurrences = value;
+              emitIfReady();
+            },
+            onError: controller.addError,
+            onDone: () {
+              occurrencesDone = true;
+              if (rulesDone && !controller.isClosed) {
+                controller.close();
+              }
+            },
+          );
+
+      final StreamSubscription<List<RecurringRule>> rulesSub = rulesStream
+          .listen(
+            (List<RecurringRule> value) {
+              hasRules = true;
+              latestRules = value;
+              emitIfReady();
+            },
+            onError: controller.addError,
+            onDone: () {
+              rulesDone = true;
+              if (occurrencesDone && !controller.isClosed) {
+                controller.close();
+              }
+            },
+          );
+
+      controller
+        ..onCancel = () async {
+          await Future.wait<void>(<Future<void>>[
+            occurrencesSub.cancel(),
+            rulesSub.cancel(),
+          ]);
+        }
+        ..onPause = () {
+          occurrencesSub.pause();
+          rulesSub.pause();
+        }
+        ..onResume = () {
+          occurrencesSub.resume();
+          rulesSub.resume();
+        };
+    });
+  }
+
+  @visibleForTesting
+  static List<UpcomingPayment> mapToUpcomingPayments({
+    required List<RecurringOccurrence> occurrences,
+    required List<RecurringRule> rules,
+  }) {
+    if (occurrences.isEmpty || rules.isEmpty) {
+      return const <UpcomingPayment>[];
+    }
+
+    final Map<String, RecurringRule> activeRules = <String, RecurringRule>{}
+      ..addEntries(
+        rules
+            .where((RecurringRule rule) => rule.isActive)
+            .map(
+              (RecurringRule rule) =>
+                  MapEntry<String, RecurringRule>(rule.id, rule),
+            ),
+      );
+
+    final Iterable<RecurringOccurrence> filtered = occurrences.where((
+      RecurringOccurrence occurrence,
+    ) {
+      if (occurrence.status != RecurringOccurrenceStatus.scheduled) {
+        return false;
+      }
+      return activeRules.containsKey(occurrence.ruleId);
+    });
+
+    final List<RecurringOccurrence> sorted = filtered.sorted((
+      RecurringOccurrence a,
+      RecurringOccurrence b,
+    ) {
+      return a.dueAt.compareTo(b.dueAt);
+    });
+
+    return sorted
+        .map((RecurringOccurrence occurrence) {
+          final RecurringRule? rule = activeRules[occurrence.ruleId];
+          if (rule == null) {
+            return null;
+          }
+          return UpcomingPayment(
+            occurrenceId: occurrence.id,
+            ruleId: rule.id,
+            title: rule.title,
+            amount: rule.amount,
+            currency: rule.currency,
+            dueDate: occurrence.dueAt.toLocal(),
+            accountId: rule.accountId,
+            categoryId: rule.categoryId,
+          );
+        })
+        .nonNulls
+        .toList(growable: false);
+  }
+}

--- a/lib/features/home/presentation/controllers/home_providers.dart
+++ b/lib/features/home/presentation/controllers/home_providers.dart
@@ -1,10 +1,14 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:kopim/core/di/injectors.dart';
 import 'package:kopim/features/accounts/domain/entities/account_entity.dart';
 import 'package:kopim/features/categories/domain/entities/category.dart';
 import 'package:kopim/features/home/domain/models/day_section.dart';
 import 'package:kopim/features/home/domain/models/home_account_monthly_summary.dart';
+import 'package:kopim/features/home/domain/models/upcoming_payment.dart';
 import 'package:kopim/features/home/domain/use_cases/group_transactions_by_day_use_case.dart';
+import 'package:kopim/features/home/domain/use_cases/watch_upcoming_payments_use_case.dart';
+import 'package:kopim/features/recurring_transactions/domain/entities/recurring_rule.dart';
 import 'package:kopim/features/transactions/domain/entities/transaction.dart';
 import 'package:kopim/features/transactions/domain/entities/transaction_type.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -58,6 +62,32 @@ Category? homeCategoryById(Ref ref, String id) {
       .watch(homeCategoriesProvider)
       .maybeWhen(
         data: (List<Category> categories) => _findCategoryById(categories, id),
+        orElse: () => null,
+      );
+}
+
+@riverpod
+Stream<List<RecurringRule>> homeRecurringRules(Ref ref) {
+  return ref.watch(watchRecurringRulesUseCaseProvider).call();
+}
+
+@riverpod
+Stream<List<UpcomingPayment>> homeUpcomingPayments(Ref ref) {
+  final WatchUpcomingPaymentsUseCase useCase = ref.watch(
+    watchUpcomingPaymentsUseCaseProvider,
+  );
+  final DateTime now = DateTime.now();
+  final DateTime end = now.add(const Duration(days: 30));
+  return useCase(from: now, to: end);
+}
+
+@riverpod
+RecurringRule? homeRecurringRuleById(Ref ref, String id) {
+  return ref
+      .watch(homeRecurringRulesProvider)
+      .maybeWhen(
+        data: (List<RecurringRule> rules) =>
+            rules.firstWhereOrNull((RecurringRule rule) => rule.id == id),
         orElse: () => null,
       );
 }

--- a/lib/features/home/presentation/controllers/home_providers.g.dart
+++ b/lib/features/home/presentation/controllers/home_providers.g.dart
@@ -407,6 +407,168 @@ final class HomeCategoryByIdFamily extends $Family
   String toString() => r'homeCategoryByIdProvider';
 }
 
+@ProviderFor(homeRecurringRules)
+const homeRecurringRulesProvider = HomeRecurringRulesProvider._();
+
+final class HomeRecurringRulesProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<RecurringRule>>,
+          List<RecurringRule>,
+          Stream<List<RecurringRule>>
+        >
+    with
+        $FutureModifier<List<RecurringRule>>,
+        $StreamProvider<List<RecurringRule>> {
+  const HomeRecurringRulesProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'homeRecurringRulesProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$homeRecurringRulesHash();
+
+  @$internal
+  @override
+  $StreamProviderElement<List<RecurringRule>> $createElement(
+    $ProviderPointer pointer,
+  ) => $StreamProviderElement(pointer);
+
+  @override
+  Stream<List<RecurringRule>> create(Ref ref) {
+    return homeRecurringRules(ref);
+  }
+}
+
+String _$homeRecurringRulesHash() =>
+    r'6167f3eb4fe196ab12c1d50ceff60763959ee89e';
+
+@ProviderFor(homeUpcomingPayments)
+const homeUpcomingPaymentsProvider = HomeUpcomingPaymentsProvider._();
+
+final class HomeUpcomingPaymentsProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<UpcomingPayment>>,
+          List<UpcomingPayment>,
+          Stream<List<UpcomingPayment>>
+        >
+    with
+        $FutureModifier<List<UpcomingPayment>>,
+        $StreamProvider<List<UpcomingPayment>> {
+  const HomeUpcomingPaymentsProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'homeUpcomingPaymentsProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$homeUpcomingPaymentsHash();
+
+  @$internal
+  @override
+  $StreamProviderElement<List<UpcomingPayment>> $createElement(
+    $ProviderPointer pointer,
+  ) => $StreamProviderElement(pointer);
+
+  @override
+  Stream<List<UpcomingPayment>> create(Ref ref) {
+    return homeUpcomingPayments(ref);
+  }
+}
+
+String _$homeUpcomingPaymentsHash() =>
+    r'ade3465651c1d76a203ad59f06a4f7fdf8e8b833';
+
+@ProviderFor(homeRecurringRuleById)
+const homeRecurringRuleByIdProvider = HomeRecurringRuleByIdFamily._();
+
+final class HomeRecurringRuleByIdProvider
+    extends $FunctionalProvider<RecurringRule?, RecurringRule?, RecurringRule?>
+    with $Provider<RecurringRule?> {
+  const HomeRecurringRuleByIdProvider._({
+    required HomeRecurringRuleByIdFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'homeRecurringRuleByIdProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$homeRecurringRuleByIdHash();
+
+  @override
+  String toString() {
+    return r'homeRecurringRuleByIdProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $ProviderElement<RecurringRule?> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  RecurringRule? create(Ref ref) {
+    final argument = this.argument as String;
+    return homeRecurringRuleById(ref, argument);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(RecurringRule? value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<RecurringRule?>(value),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is HomeRecurringRuleByIdProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$homeRecurringRuleByIdHash() =>
+    r'6e1b6520ce11f37a115550e6332a3ffeb2098dfd';
+
+final class HomeRecurringRuleByIdFamily extends $Family
+    with $FunctionalFamilyOverride<RecurringRule?, String> {
+  const HomeRecurringRuleByIdFamily._()
+    : super(
+        retry: null,
+        name: r'homeRecurringRuleByIdProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  HomeRecurringRuleByIdProvider call(String id) =>
+      HomeRecurringRuleByIdProvider._(argument: id, from: this);
+
+  @override
+  String toString() => r'homeRecurringRuleByIdProvider';
+}
+
 @ProviderFor(homeGroupedTransactions)
 const homeGroupedTransactionsProvider = HomeGroupedTransactionsProvider._();
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -554,6 +554,58 @@
   "@homeTransactionsUncategorized": {
     "description": "Fallback text when a transaction has no category"
   },
+  "homeUpcomingPaymentsTitle": "Upcoming payments",
+  "@homeUpcomingPaymentsTitle": {
+    "description": "Header for the upcoming payments widget"
+  },
+  "homeUpcomingPaymentsEmpty": "Nothing here.",
+  "@homeUpcomingPaymentsEmpty": {
+    "description": "Empty state when there are no upcoming payments"
+  },
+  "homeUpcomingPaymentsEmptyHeader": "No upcoming payments",
+  "@homeUpcomingPaymentsEmptyHeader": {
+    "description": "Subtitle shown when no upcoming payment is scheduled"
+  },
+  "homeUpcomingPaymentsNextDate": "Next due: {date}",
+  "@homeUpcomingPaymentsNextDate": {
+    "description": "Subtitle with the nearest upcoming payment date",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "homeUpcomingPaymentsError": "Couldn't load upcoming payments: {error}",
+  "@homeUpcomingPaymentsError": {
+    "description": "Error shown when loading upcoming payments fails",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "homeUpcomingPaymentsMissingRule": "This recurring rule is no longer available.",
+  "@homeUpcomingPaymentsMissingRule": {
+    "description": "Snackbar message when the source recurring rule is missing"
+  },
+  "homeUpcomingPaymentsDueDate": "Due {date}",
+  "@homeUpcomingPaymentsDueDate": {
+    "description": "Subtitle for individual upcoming payment entries",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "homeUpcomingPaymentsCountSemantics": "{count, plural, =0 {No scheduled payments} one {# upcoming payment} other {# upcoming payments}}",
+  "@homeUpcomingPaymentsCountSemantics": {
+    "description": "Accessibility label for the upcoming payments badge",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "homeNavHome": "Home",
   "@homeNavHome": {
     "description": "Bottom navigation label for home"
@@ -590,13 +642,21 @@
   "@analyticsSummaryNetLabel": {
     "description": "Label for net balance in analytics summary"
   },
-  "analyticsTopCategoriesTitle": "Top expense categories",
+  "analyticsTopCategoriesTitle": "Top categories",
   "@analyticsTopCategoriesTitle": {
-    "description": "Heading for the list of top expense categories"
+    "description": "Heading for the list of top categories"
   },
-  "analyticsTopCategoriesEmpty": "Not enough expense data to show category trends yet.",
+  "analyticsTopCategoriesExpensesTab": "Expenses",
+  "@analyticsTopCategoriesExpensesTab": {
+    "description": "Tab label for expense categories"
+  },
+  "analyticsTopCategoriesIncomeTab": "Income",
+  "@analyticsTopCategoriesIncomeTab": {
+    "description": "Tab label for income categories"
+  },
+  "analyticsTopCategoriesEmpty": "Not enough data to show category trends yet.",
   "@analyticsTopCategoriesEmpty": {
-    "description": "Message displayed when there are no expense categories to show"
+    "description": "Message displayed when there are no categories to show"
   },
   "analyticsCategoryUncategorized": "Uncategorized",
   "@analyticsCategoryUncategorized": {
@@ -608,6 +668,19 @@
     "placeholders": {
       "range": {
         "type": "String"
+      }
+    }
+  },
+  "analyticsFiltersButtonLabel": "Filters",
+  "@analyticsFiltersButtonLabel": {
+    "description": "Label for the filters expansion tile"
+  },
+  "analyticsFiltersBadgeSemantics": "{count, plural, =0 {No active filters} one {# active filter} other {# active filters}}",
+  "@analyticsFiltersBadgeSemantics": {
+    "description": "Accessibility label for the filters badge",
+    "placeholders": {
+      "count": {
+        "type": "int"
       }
     }
   },

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -854,6 +854,54 @@ abstract class AppLocalizations {
   /// **'Uncategorized'**
   String get homeTransactionsUncategorized;
 
+  /// Header for the upcoming payments widget
+  ///
+  /// In en, this message translates to:
+  /// **'Upcoming payments'**
+  String get homeUpcomingPaymentsTitle;
+
+  /// Empty state when there are no upcoming payments
+  ///
+  /// In en, this message translates to:
+  /// **'Nothing here.'**
+  String get homeUpcomingPaymentsEmpty;
+
+  /// Subtitle shown when no upcoming payment is scheduled
+  ///
+  /// In en, this message translates to:
+  /// **'No upcoming payments'**
+  String get homeUpcomingPaymentsEmptyHeader;
+
+  /// Subtitle with the nearest upcoming payment date
+  ///
+  /// In en, this message translates to:
+  /// **'Next due: {date}'**
+  String homeUpcomingPaymentsNextDate(String date);
+
+  /// Error shown when loading upcoming payments fails
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t load upcoming payments: {error}'**
+  String homeUpcomingPaymentsError(String error);
+
+  /// Snackbar message when the source recurring rule is missing
+  ///
+  /// In en, this message translates to:
+  /// **'This recurring rule is no longer available.'**
+  String get homeUpcomingPaymentsMissingRule;
+
+  /// Subtitle for individual upcoming payment entries
+  ///
+  /// In en, this message translates to:
+  /// **'Due {date}'**
+  String homeUpcomingPaymentsDueDate(String date);
+
+  /// Accessibility label for the upcoming payments badge
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =0 {No scheduled payments} one {# upcoming payment} other {# upcoming payments}}'**
+  String homeUpcomingPaymentsCountSemantics(int count);
+
   /// Bottom navigation label for home
   ///
   /// In en, this message translates to:
@@ -908,16 +956,28 @@ abstract class AppLocalizations {
   /// **'Net'**
   String get analyticsSummaryNetLabel;
 
-  /// Heading for the list of top expense categories
+  /// Heading for the list of top categories
   ///
   /// In en, this message translates to:
-  /// **'Top expense categories'**
+  /// **'Top categories'**
   String get analyticsTopCategoriesTitle;
 
-  /// Message displayed when there are no expense categories to show
+  /// Tab label for expense categories
   ///
   /// In en, this message translates to:
-  /// **'Not enough expense data to show category trends yet.'**
+  /// **'Expenses'**
+  String get analyticsTopCategoriesExpensesTab;
+
+  /// Tab label for income categories
+  ///
+  /// In en, this message translates to:
+  /// **'Income'**
+  String get analyticsTopCategoriesIncomeTab;
+
+  /// Message displayed when there are no categories to show
+  ///
+  /// In en, this message translates to:
+  /// **'Not enough data to show category trends yet.'**
   String get analyticsTopCategoriesEmpty;
 
   /// Label for expenses without a category
@@ -931,6 +991,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Overview for {range}'**
   String analyticsOverviewRangeTitle(String range);
+
+  /// Label for the filters expansion tile
+  ///
+  /// In en, this message translates to:
+  /// **'Filters'**
+  String get analyticsFiltersButtonLabel;
+
+  /// Accessibility label for the filters badge
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =0 {No active filters} one {# active filter} other {# active filters}}'**
+  String analyticsFiltersBadgeSemantics(int count);
 
   /// Label for the analytics date filter button
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -415,6 +415,46 @@ class AppLocalizationsEn extends AppLocalizations {
   String get homeTransactionsUncategorized => 'Uncategorized';
 
   @override
+  String get homeUpcomingPaymentsTitle => 'Upcoming payments';
+
+  @override
+  String get homeUpcomingPaymentsEmpty => 'Nothing here.';
+
+  @override
+  String get homeUpcomingPaymentsEmptyHeader => 'No upcoming payments';
+
+  @override
+  String homeUpcomingPaymentsNextDate(String date) {
+    return 'Next due: $date';
+  }
+
+  @override
+  String homeUpcomingPaymentsError(String error) {
+    return 'Couldn\'t load upcoming payments: $error';
+  }
+
+  @override
+  String get homeUpcomingPaymentsMissingRule =>
+      'This recurring rule is no longer available.';
+
+  @override
+  String homeUpcomingPaymentsDueDate(String date) {
+    return 'Due $date';
+  }
+
+  @override
+  String homeUpcomingPaymentsCountSemantics(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '# upcoming payments',
+      one: '# upcoming payment',
+      zero: 'No scheduled payments',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get homeNavHome => 'Home';
 
   @override
@@ -442,11 +482,17 @@ class AppLocalizationsEn extends AppLocalizations {
   String get analyticsSummaryNetLabel => 'Net';
 
   @override
-  String get analyticsTopCategoriesTitle => 'Top expense categories';
+  String get analyticsTopCategoriesTitle => 'Top categories';
+
+  @override
+  String get analyticsTopCategoriesExpensesTab => 'Expenses';
+
+  @override
+  String get analyticsTopCategoriesIncomeTab => 'Income';
 
   @override
   String get analyticsTopCategoriesEmpty =>
-      'Not enough expense data to show category trends yet.';
+      'Not enough data to show category trends yet.';
 
   @override
   String get analyticsCategoryUncategorized => 'Uncategorized';
@@ -454,6 +500,21 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String analyticsOverviewRangeTitle(String range) {
     return 'Overview for $range';
+  }
+
+  @override
+  String get analyticsFiltersButtonLabel => 'Filters';
+
+  @override
+  String analyticsFiltersBadgeSemantics(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '# active filters',
+      one: '# active filter',
+      zero: 'No active filters',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -416,6 +416,48 @@ class AppLocalizationsRu extends AppLocalizations {
   String get homeTransactionsUncategorized => 'Без категории';
 
   @override
+  String get homeUpcomingPaymentsTitle => 'Ближайшие платежи';
+
+  @override
+  String get homeUpcomingPaymentsEmpty => 'Здесь пока ничего нет.';
+
+  @override
+  String get homeUpcomingPaymentsEmptyHeader => 'Нет ближайших платежей';
+
+  @override
+  String homeUpcomingPaymentsNextDate(String date) {
+    return 'Ближайшая дата: $date';
+  }
+
+  @override
+  String homeUpcomingPaymentsError(String error) {
+    return 'Не удалось загрузить ближайшие платежи: $error';
+  }
+
+  @override
+  String get homeUpcomingPaymentsMissingRule =>
+      'Правило повторений больше не доступно.';
+
+  @override
+  String homeUpcomingPaymentsDueDate(String date) {
+    return 'Срок $date';
+  }
+
+  @override
+  String homeUpcomingPaymentsCountSemantics(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '# запланированных платежей',
+      many: '# запланированных платежей',
+      few: '# запланированных платежа',
+      one: '# запланированный платеж',
+      zero: 'Нет запланированных платежей',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get homeNavHome => 'Главная';
 
   @override
@@ -443,11 +485,17 @@ class AppLocalizationsRu extends AppLocalizations {
   String get analyticsSummaryNetLabel => 'Баланс';
 
   @override
-  String get analyticsTopCategoriesTitle => 'Топ категорий расходов';
+  String get analyticsTopCategoriesTitle => 'Топ категорий';
+
+  @override
+  String get analyticsTopCategoriesExpensesTab => 'Расходы';
+
+  @override
+  String get analyticsTopCategoriesIncomeTab => 'Доходы';
 
   @override
   String get analyticsTopCategoriesEmpty =>
-      'Недостаточно данных о расходах для анализа.';
+      'Недостаточно данных для анализа категорий.';
 
   @override
   String get analyticsCategoryUncategorized => 'Без категории';
@@ -455,6 +503,23 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String analyticsOverviewRangeTitle(String range) {
     return 'Обзор за $range';
+  }
+
+  @override
+  String get analyticsFiltersButtonLabel => 'Фильтры';
+
+  @override
+  String analyticsFiltersBadgeSemantics(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '# активных фильтров',
+      many: '# активных фильтров',
+      few: '# активных фильтра',
+      one: '# активный фильтр',
+      zero: 'Нет активных фильтров',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -554,6 +554,58 @@
   "@homeTransactionsUncategorized": {
     "description": "Подпись при отсутствии категории"
   },
+  "homeUpcomingPaymentsTitle": "Ближайшие платежи",
+  "@homeUpcomingPaymentsTitle": {
+    "description": "Заголовок виджета с ближайшими платежами"
+  },
+  "homeUpcomingPaymentsEmpty": "Здесь пока ничего нет.",
+  "@homeUpcomingPaymentsEmpty": {
+    "description": "Состояние, когда ближайших платежей нет"
+  },
+  "homeUpcomingPaymentsEmptyHeader": "Нет ближайших платежей",
+  "@homeUpcomingPaymentsEmptyHeader": {
+    "description": "Подзаголовок, когда платежей нет"
+  },
+  "homeUpcomingPaymentsNextDate": "Ближайшая дата: {date}",
+  "@homeUpcomingPaymentsNextDate": {
+    "description": "Подзаголовок с ближайшей датой платежа",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "homeUpcomingPaymentsError": "Не удалось загрузить ближайшие платежи: {error}",
+  "@homeUpcomingPaymentsError": {
+    "description": "Ошибка загрузки ближайших платежей",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "homeUpcomingPaymentsMissingRule": "Правило повторений больше не доступно.",
+  "@homeUpcomingPaymentsMissingRule": {
+    "description": "Сообщение, когда правило повторений отсутствует"
+  },
+  "homeUpcomingPaymentsDueDate": "Срок {date}",
+  "@homeUpcomingPaymentsDueDate": {
+    "description": "Подпись для строки ближайшего платежа",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "homeUpcomingPaymentsCountSemantics": "{count, plural, =0 {Нет запланированных платежей} one {# запланированный платеж} few {# запланированных платежа} many {# запланированных платежей} other {# запланированных платежей}}",
+  "@homeUpcomingPaymentsCountSemantics": {
+    "description": "Подпись для бейджа количества ближайших платежей",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "homeNavHome": "Главная",
   "@homeNavHome": {
     "description": "Подпись для навигации на главный экран"
@@ -590,13 +642,21 @@
   "@analyticsSummaryNetLabel": {
     "description": "Подпись чистого результата"
   },
-  "analyticsTopCategoriesTitle": "Топ категорий расходов",
+  "analyticsTopCategoriesTitle": "Топ категорий",
   "@analyticsTopCategoriesTitle": {
     "description": "Заголовок списка категорий"
   },
-  "analyticsTopCategoriesEmpty": "Недостаточно данных о расходах для анализа.",
+  "analyticsTopCategoriesExpensesTab": "Расходы",
+  "@analyticsTopCategoriesExpensesTab": {
+    "description": "Подпись вкладки с категориями расходов"
+  },
+  "analyticsTopCategoriesIncomeTab": "Доходы",
+  "@analyticsTopCategoriesIncomeTab": {
+    "description": "Подпись вкладки с категориями доходов"
+  },
+  "analyticsTopCategoriesEmpty": "Недостаточно данных для анализа категорий.",
   "@analyticsTopCategoriesEmpty": {
-    "description": "Сообщение при отсутствии категорий"
+    "description": "Сообщение при отсутствии данных для категорий"
   },
   "analyticsCategoryUncategorized": "Без категории",
   "@analyticsCategoryUncategorized": {
@@ -608,6 +668,19 @@
     "placeholders": {
       "range": {
         "type": "String"
+      }
+    }
+  },
+  "analyticsFiltersButtonLabel": "Фильтры",
+  "@analyticsFiltersButtonLabel": {
+    "description": "Подпись раскрывающегося блока фильтров"
+  },
+  "analyticsFiltersBadgeSemantics": "{count, plural, =0 {Нет активных фильтров} one {# активный фильтр} few {# активных фильтра} many {# активных фильтров} other {# активных фильтров}}",
+  "@analyticsFiltersBadgeSemantics": {
+    "description": "Подпись для бейджа количества активных фильтров",
+    "placeholders": {
+      "count": {
+        "type": "int"
       }
     }
   },

--- a/test/features/analytics/domain/use_cases/watch_monthly_analytics_use_case_test.dart
+++ b/test/features/analytics/domain/use_cases/watch_monthly_analytics_use_case_test.dart
@@ -32,6 +32,7 @@ void main() {
       expect(overview.totalExpense, 0);
       expect(overview.netBalance, 0);
       expect(overview.topExpenseCategories, isEmpty);
+      expect(overview.topIncomeCategories, isEmpty);
     });
 
     test('applies date range filter', () async {
@@ -77,6 +78,9 @@ void main() {
       expect(overview.topExpenseCategories, hasLength(1));
       expect(overview.topExpenseCategories.first.categoryId, 'cat-food');
       expect(overview.topExpenseCategories.first.amount, 40);
+      expect(overview.topIncomeCategories, hasLength(1));
+      expect(overview.topIncomeCategories.first.categoryId, 'cat-ent');
+      expect(overview.topIncomeCategories.first.amount, 120);
     });
 
     test('filters by account and category', () async {
@@ -132,6 +136,9 @@ void main() {
       expect(overview.topExpenseCategories, hasLength(1));
       expect(overview.topExpenseCategories.first.categoryId, 'cat-ent');
       expect(overview.topExpenseCategories.first.amount, 30);
+      expect(overview.topIncomeCategories, hasLength(1));
+      expect(overview.topIncomeCategories.first.categoryId, 'cat-ent');
+      expect(overview.topIncomeCategories.first.amount, 150);
     });
   });
 }

--- a/test/features/home/domain/use_cases/watch_upcoming_payments_use_case_test.dart
+++ b/test/features/home/domain/use_cases/watch_upcoming_payments_use_case_test.dart
@@ -1,0 +1,117 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kopim/features/home/domain/models/upcoming_payment.dart';
+import 'package:kopim/features/home/domain/use_cases/watch_upcoming_payments_use_case.dart';
+import 'package:kopim/features/recurring_transactions/domain/entities/recurring_occurrence.dart';
+import 'package:kopim/features/recurring_transactions/domain/entities/recurring_rule.dart';
+
+void main() {
+  group('WatchUpcomingPaymentsUseCase.mapToUpcomingPayments', () {
+    test('filters by status and rule activity, sorts by due date', () {
+      final List<RecurringOccurrence> occurrences = <RecurringOccurrence>[
+        RecurringOccurrence(
+          id: 'o1',
+          ruleId: 'r1',
+          dueAt: DateTime.utc(2024, 10, 20),
+          status: RecurringOccurrenceStatus.scheduled,
+          createdAt: DateTime.utc(2024, 9, 1),
+        ),
+        RecurringOccurrence(
+          id: 'o2',
+          ruleId: 'r1',
+          dueAt: DateTime.utc(2024, 10, 18),
+          status: RecurringOccurrenceStatus.scheduled,
+          createdAt: DateTime.utc(2024, 9, 1),
+        ),
+        RecurringOccurrence(
+          id: 'o3',
+          ruleId: 'r2',
+          dueAt: DateTime.utc(2024, 10, 17),
+          status: RecurringOccurrenceStatus.posted,
+          createdAt: DateTime.utc(2024, 9, 1),
+        ),
+      ];
+
+      final List<RecurringRule> rules = <RecurringRule>[
+        RecurringRule(
+          id: 'r1',
+          title: 'Rent',
+          accountId: 'acc-1',
+          categoryId: 'cat-1',
+          amount: 800,
+          currency: 'usd',
+          startAt: DateTime.utc(2024, 1, 1),
+          timezone: 'UTC',
+          rrule: 'FREQ=MONTHLY',
+          createdAt: DateTime.utc(2024, 1, 1),
+          updatedAt: DateTime.utc(2024, 1, 1),
+        ),
+        RecurringRule(
+          id: 'r2',
+          title: 'Gym',
+          accountId: 'acc-1',
+          categoryId: 'cat-2',
+          amount: 50,
+          currency: 'usd',
+          startAt: DateTime.utc(2024, 1, 1),
+          timezone: 'UTC',
+          rrule: 'FREQ=MONTHLY',
+          createdAt: DateTime.utc(2024, 1, 1),
+          updatedAt: DateTime.utc(2024, 1, 1),
+          isActive: false,
+        ),
+      ];
+
+      final List<UpcomingPayment> payments =
+          WatchUpcomingPaymentsUseCase.mapToUpcomingPayments(
+            occurrences: occurrences,
+            rules: rules,
+          );
+
+      expect(payments, hasLength(2));
+      expect(payments.first.dueDate.isBefore(payments.last.dueDate), isTrue);
+      expect(
+        payments.every((UpcomingPayment payment) => payment.ruleId == 'r1'),
+        isTrue,
+      );
+    });
+
+    test('maps income amounts preserving sign', () {
+      final List<RecurringOccurrence> occurrences = <RecurringOccurrence>[
+        RecurringOccurrence(
+          id: 'o1',
+          ruleId: 'r-income',
+          dueAt: DateTime.utc(2024, 11, 1),
+          status: RecurringOccurrenceStatus.scheduled,
+          createdAt: DateTime.utc(2024, 9, 1),
+        ),
+      ];
+
+      final List<RecurringRule> rules = <RecurringRule>[
+        RecurringRule(
+          id: 'r-income',
+          title: 'Salary',
+          accountId: 'acc-2',
+          categoryId: 'cat-income',
+          amount: -2500,
+          currency: 'eur',
+          startAt: DateTime.utc(2024, 1, 1),
+          timezone: 'UTC',
+          rrule: 'FREQ=MONTHLY',
+          createdAt: DateTime.utc(2024, 1, 1),
+          updatedAt: DateTime.utc(2024, 1, 1),
+        ),
+      ];
+
+      final List<UpcomingPayment> payments =
+          WatchUpcomingPaymentsUseCase.mapToUpcomingPayments(
+            occurrences: occurrences,
+            rules: rules,
+          );
+
+      expect(payments, hasLength(1));
+      expect(payments.single.amount, -2500);
+      expect(payments.single.currency, 'eur');
+      expect(payments.single.isExpense, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- добавлена модель `UpcomingPayment`, потоковый use case и интеграция в DI для вычисления ближайших повторяющихся списаний
- домашний экран получил карточку предстоящих платежей, счётчики без устаревших цветов и список транзакций без времени суток
- аналитика использует коллапсируемые фильтры и новый пейджер для топовых категорий расходов/доходов, обновлены локализации и тесты
- переработан пикер иконок без подписей, навигационная оболочка скрывает нижнюю панель на вторичных маршрутах

## Testing
- `dart format --set-exit-if-changed .`
- `flutter analyze`
- `dart run build_runner build --delete-conflicting-outputs`
- `flutter test --reporter expanded`
- `flutter pub outdated`


------
https://chatgpt.com/codex/tasks/task_e_68e10a0c6e7c832e812506437eb70da3