### PR TITLE
feat: обновить тему и диаграмму аналитики

### DIFF
--- a/lib/core/config/app_config.dart
+++ b/lib/core/config/app_config.dart
@@ -2,6 +2,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'theme.dart';
+
 // Provider для locale (init по умолчанию ru, или из хранилища)
 final Provider<Locale> appLocaleProvider = Provider<Locale>((Ref ref) {
   // Здесь можно читать из SharedPreferences или Drift для persistent locale
@@ -10,5 +12,9 @@ final Provider<Locale> appLocaleProvider = Provider<Locale>((Ref ref) {
 
 // Другие providers: theme, auth и т.д.
 final Provider<ThemeData> appThemeProvider = Provider<ThemeData>((Ref ref) {
-  return ThemeData(primarySwatch: Colors.blue);
+  return buildAppTheme(brightness: Brightness.light);
+});
+
+final Provider<ThemeData> appDarkThemeProvider = Provider<ThemeData>((Ref ref) {
+  return buildAppTheme(brightness: Brightness.dark);
 });

--- a/lib/core/config/theme.dart
+++ b/lib/core/config/theme.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+/// Создаёт тему приложения с учётом Material 3 и новой базовой палитры.
+ThemeData buildAppTheme({required Brightness brightness}) {
+  const Color seedColor = Color(0xFF8AEDAB);
+  final ColorScheme colorScheme = ColorScheme.fromSeed(
+    seedColor: seedColor,
+    brightness: brightness,
+  );
+
+  return ThemeData(
+    useMaterial3: true,
+    colorScheme: colorScheme,
+    inputDecorationTheme: const InputDecorationTheme(
+      border: InputBorder.none,
+      enabledBorder: InputBorder.none,
+      focusedBorder: InputBorder.none,
+      errorBorder: InputBorder.none,
+      focusedErrorBorder: InputBorder.none,
+      disabledBorder: InputBorder.none,
+    ),
+    outlinedButtonTheme: OutlinedButtonThemeData(
+      style: OutlinedButton.styleFrom(side: BorderSide.none),
+    ),
+    dropdownMenuTheme: const DropdownMenuThemeData(
+      inputDecorationTheme: InputDecorationTheme(
+        border: InputBorder.none,
+        enabledBorder: InputBorder.none,
+        focusedBorder: InputBorder.none,
+      ),
+    ),
+  );
+}

--- a/lib/features/analytics/presentation/widgets/analytics_chart.dart
+++ b/lib/features/analytics/presentation/widgets/analytics_chart.dart
@@ -1,0 +1,205 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+class AnalyticsChartItem {
+  const AnalyticsChartItem({
+    required this.title,
+    required this.amount,
+    required this.color,
+  });
+
+  final String title;
+  final double amount;
+  final Color color;
+
+  double get absoluteAmount => amount.abs();
+}
+
+class AnalyticsDonutChart extends StatelessWidget {
+  const AnalyticsDonutChart({
+    super.key,
+    required this.items,
+    required this.backgroundColor,
+  });
+
+  final List<AnalyticsChartItem> items;
+  final Color backgroundColor;
+
+  @override
+  Widget build(BuildContext context) {
+    if (items.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return AspectRatio(
+      aspectRatio: 1,
+      child: LayoutBuilder(
+        builder: (BuildContext context, BoxConstraints constraints) {
+          final Size biggest = constraints.biggest;
+          double size = biggest.shortestSide;
+          if (!size.isFinite || size <= 0) {
+            size = biggest.longestSide;
+          }
+          if (!size.isFinite || size <= 0) {
+            size = 200;
+          }
+          final double strokeWidth = math.max(size * 0.18, 12);
+          final List<_DonutSegment> segments = _buildSegments();
+          final double radius = size / 2;
+          final double labelRadius = math.max(radius - strokeWidth * 0.6, 0);
+          final double alignmentFactor = radius == 0 ? 0 : labelRadius / radius;
+
+          return Center(
+            child: SizedBox(
+              width: size,
+              height: size,
+              child: Stack(
+                alignment: Alignment.center,
+                children: <Widget>[
+                  CustomPaint(
+                    size: Size.square(size),
+                    painter: _DonutChartPainter(
+                      segments: segments,
+                      strokeWidth: strokeWidth,
+                      backgroundColor: backgroundColor,
+                    ),
+                  ),
+                  for (final _DonutSegment segment in segments)
+                    Align(
+                      alignment: Alignment(
+                        math.cos(segment.midAngle) * alignmentFactor,
+                        math.sin(segment.midAngle) * alignmentFactor,
+                      ),
+                      child: _DonutPercentageLabel(
+                        percentage: segment.percentage,
+                        color: segment.color,
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  List<_DonutSegment> _buildSegments() {
+    final double total = items.fold<double>(
+      0,
+      (double previous, AnalyticsChartItem item) =>
+          previous + item.absoluteAmount,
+    );
+    if (total <= 0) {
+      return <_DonutSegment>[];
+    }
+    double startAngle = -math.pi / 2;
+    final List<_DonutSegment> segments = <_DonutSegment>[];
+    for (final AnalyticsChartItem item in items) {
+      if (item.absoluteAmount <= 0) {
+        continue;
+      }
+      final double sweep = (item.absoluteAmount / total) * (2 * math.pi);
+      final double percentage = item.absoluteAmount / total * 100;
+      segments.add(
+        _DonutSegment(
+          color: item.color,
+          startAngle: startAngle,
+          sweepAngle: sweep,
+          percentage: percentage,
+        ),
+      );
+      startAngle += sweep;
+    }
+    return segments;
+  }
+}
+
+class _DonutSegment {
+  const _DonutSegment({
+    required this.color,
+    required this.startAngle,
+    required this.sweepAngle,
+    required this.percentage,
+  });
+
+  final Color color;
+  final double startAngle;
+  final double sweepAngle;
+  final double percentage;
+
+  double get midAngle => startAngle + sweepAngle / 2;
+}
+
+class _DonutChartPainter extends CustomPainter {
+  _DonutChartPainter({
+    required this.segments,
+    required this.strokeWidth,
+    required this.backgroundColor,
+  });
+
+  final List<_DonutSegment> segments;
+  final double strokeWidth;
+  final Color backgroundColor;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final Offset center = size.center(Offset.zero);
+    final double radius = size.shortestSide / 2 - strokeWidth / 2;
+    final Rect rect = Rect.fromCircle(center: center, radius: radius);
+    final Paint paint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeCap = StrokeCap.butt
+      ..strokeWidth = strokeWidth;
+
+    paint.color = backgroundColor;
+    canvas.drawArc(rect, 0, 2 * math.pi, false, paint);
+
+    for (final _DonutSegment segment in segments) {
+      paint.color = segment.color;
+      canvas.drawArc(
+        rect,
+        segment.startAngle,
+        segment.sweepAngle,
+        false,
+        paint,
+      );
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _DonutChartPainter oldDelegate) {
+    return oldDelegate.segments != segments ||
+        oldDelegate.strokeWidth != strokeWidth ||
+        oldDelegate.backgroundColor != backgroundColor;
+  }
+}
+
+class _DonutPercentageLabel extends StatelessWidget {
+  const _DonutPercentageLabel({required this.percentage, required this.color});
+
+  final double percentage;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Brightness brightness = ThemeData.estimateBrightnessForColor(color);
+    final Color textColor = brightness == Brightness.dark
+        ? Colors.white
+        : Colors.black.withValues(alpha: 0.87);
+    final TextStyle style =
+        theme.textTheme.labelSmall?.copyWith(
+          color: textColor,
+          fontWeight: FontWeight.w600,
+        ) ??
+        TextStyle(color: textColor, fontWeight: FontWeight.w600, fontSize: 12);
+
+    final String formatted = percentage >= 1
+        ? '${percentage.round()}%'
+        : '${percentage.toStringAsFixed(1)}%';
+
+    return Text(formatted, style: style);
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -45,10 +45,14 @@ class _MyAppState extends ConsumerState<MyApp> {
     final AsyncValue<void> startupState = ref.watch(
       appStartupControllerProvider,
     );
+    final ThemeData lightTheme = ref.watch(appThemeProvider);
+    final ThemeData darkTheme = ref.watch(appDarkThemeProvider);
 
     return MaterialApp(
       title: 'Kopim',
-      theme: ThemeData(primarySwatch: Colors.blue),
+      theme: lightTheme,
+      darkTheme: darkTheme,
+      themeMode: ThemeMode.system,
       locale: appLocale,
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,


### PR DESCRIPTION
## Summary
- перевёл приложение на Material 3 с сидом #8AEDAB и убрал контуры элементов согласно требованиям аналитики
- переработал карточку сводки и диаграмму топ‑категорий, заменив столбцы на пончиковый график с легендой и обновлённой типографикой

## Testing
- dart format --set-exit-if-changed .
- flutter analyze
- dart run build_runner build --delete-conflicting-outputs
- flutter test --reporter expanded
- flutter pub outdated

------
https://chatgpt.com/codex/tasks/task_e_68e1246ac944832eb6a191abdc190517