### PR TITLE
Добавить функциональность бюджетов и вкладку в нижней навигации

### DIFF
--- a/lib/core/data/converters/string_list_converter.dart
+++ b/lib/core/data/converters/string_list_converter.dart
@@ -1,0 +1,40 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart';
+
+class StringListConverter extends TypeConverter<List<String>, String> {
+  const StringListConverter();
+
+  @override
+  List<String> fromSql(String fromDb) {
+    if (fromDb.isEmpty) {
+      return const <String>[];
+    }
+    try {
+      final Object? decoded = jsonDecode(fromDb);
+      if (decoded is List) {
+        return decoded
+            .whereType<Object?>()
+            .map((Object? value) => value?.toString() ?? '')
+            .where((String value) => value.isNotEmpty)
+            .toList(growable: false);
+      }
+    } catch (_) {
+      // Fallback to treating the stored string as comma-separated values.
+      return fromDb
+          .split(',')
+          .map((String value) => value.trim())
+          .where((String value) => value.isNotEmpty)
+          .toList(growable: false);
+    }
+    return const <String>[];
+  }
+
+  @override
+  String toSql(List<String> value) {
+    if (value.isEmpty) {
+      return '[]';
+    }
+    return jsonEncode(value);
+  }
+}

--- a/lib/core/data/database.g.dart
+++ b/lib/core/data/database.g.dart
@@ -5469,6 +5469,1281 @@ class JobQueueCompanion extends UpdateCompanion<JobQueueRow> {
   }
 }
 
+class $BudgetsTable extends Budgets with TableInfo<$BudgetsTable, BudgetRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $BudgetsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<String> id = GeneratedColumn<String>(
+    'id',
+    aliasedName,
+    false,
+    additionalChecks: GeneratedColumn.checkTextLength(
+      minTextLength: 1,
+      maxTextLength: 60,
+    ),
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _titleMeta = const VerificationMeta('title');
+  @override
+  late final GeneratedColumn<String> title = GeneratedColumn<String>(
+    'title',
+    aliasedName,
+    false,
+    additionalChecks: GeneratedColumn.checkTextLength(
+      minTextLength: 1,
+      maxTextLength: 160,
+    ),
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _periodMeta = const VerificationMeta('period');
+  @override
+  late final GeneratedColumn<String> period = GeneratedColumn<String>(
+    'period',
+    aliasedName,
+    false,
+    additionalChecks: GeneratedColumn.checkTextLength(
+      minTextLength: 1,
+      maxTextLength: 20,
+    ),
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _startDateMeta = const VerificationMeta(
+    'startDate',
+  );
+  @override
+  late final GeneratedColumn<DateTime> startDate = GeneratedColumn<DateTime>(
+    'start_date',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _endDateMeta = const VerificationMeta(
+    'endDate',
+  );
+  @override
+  late final GeneratedColumn<DateTime> endDate = GeneratedColumn<DateTime>(
+    'end_date',
+    aliasedName,
+    true,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _amountMeta = const VerificationMeta('amount');
+  @override
+  late final GeneratedColumn<double> amount = GeneratedColumn<double>(
+    'amount',
+    aliasedName,
+    false,
+    type: DriftSqlType.double,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _scopeMeta = const VerificationMeta('scope');
+  @override
+  late final GeneratedColumn<String> scope = GeneratedColumn<String>(
+    'scope',
+    aliasedName,
+    false,
+    additionalChecks: GeneratedColumn.checkTextLength(
+      minTextLength: 1,
+      maxTextLength: 32,
+    ),
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  @override
+  late final GeneratedColumnWithTypeConverter<List<String>, String> categories =
+      GeneratedColumn<String>(
+        'categories',
+        aliasedName,
+        false,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+        clientDefault: () => '[]',
+      ).withConverter<List<String>>($BudgetsTable.$convertercategories);
+  @override
+  late final GeneratedColumnWithTypeConverter<List<String>, String> accounts =
+      GeneratedColumn<String>(
+        'accounts',
+        aliasedName,
+        false,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+        clientDefault: () => '[]',
+      ).withConverter<List<String>>($BudgetsTable.$converteraccounts);
+  static const VerificationMeta _createdAtMeta = const VerificationMeta(
+    'createdAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
+    'created_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+    defaultValue: currentDateAndTime,
+  );
+  static const VerificationMeta _updatedAtMeta = const VerificationMeta(
+    'updatedAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> updatedAt = GeneratedColumn<DateTime>(
+    'updated_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+    defaultValue: currentDateAndTime,
+  );
+  static const VerificationMeta _isDeletedMeta = const VerificationMeta(
+    'isDeleted',
+  );
+  @override
+  late final GeneratedColumn<bool> isDeleted = GeneratedColumn<bool>(
+    'is_deleted',
+    aliasedName,
+    false,
+    type: DriftSqlType.bool,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'CHECK ("is_deleted" IN (0, 1))',
+    ),
+    defaultValue: const Constant<bool>(false),
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    title,
+    period,
+    startDate,
+    endDate,
+    amount,
+    scope,
+    categories,
+    accounts,
+    createdAt,
+    updatedAt,
+    isDeleted,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'budgets';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<BudgetRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    } else if (isInserting) {
+      context.missing(_idMeta);
+    }
+    if (data.containsKey('title')) {
+      context.handle(
+        _titleMeta,
+        title.isAcceptableOrUnknown(data['title']!, _titleMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_titleMeta);
+    }
+    if (data.containsKey('period')) {
+      context.handle(
+        _periodMeta,
+        period.isAcceptableOrUnknown(data['period']!, _periodMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_periodMeta);
+    }
+    if (data.containsKey('start_date')) {
+      context.handle(
+        _startDateMeta,
+        startDate.isAcceptableOrUnknown(data['start_date']!, _startDateMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_startDateMeta);
+    }
+    if (data.containsKey('end_date')) {
+      context.handle(
+        _endDateMeta,
+        endDate.isAcceptableOrUnknown(data['end_date']!, _endDateMeta),
+      );
+    }
+    if (data.containsKey('amount')) {
+      context.handle(
+        _amountMeta,
+        amount.isAcceptableOrUnknown(data['amount']!, _amountMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_amountMeta);
+    }
+    if (data.containsKey('scope')) {
+      context.handle(
+        _scopeMeta,
+        scope.isAcceptableOrUnknown(data['scope']!, _scopeMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_scopeMeta);
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(
+        _createdAtMeta,
+        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
+      );
+    }
+    if (data.containsKey('updated_at')) {
+      context.handle(
+        _updatedAtMeta,
+        updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta),
+      );
+    }
+    if (data.containsKey('is_deleted')) {
+      context.handle(
+        _isDeletedMeta,
+        isDeleted.isAcceptableOrUnknown(data['is_deleted']!, _isDeletedMeta),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  BudgetRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return BudgetRow(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}id'],
+      )!,
+      title: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}title'],
+      )!,
+      period: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}period'],
+      )!,
+      startDate: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}start_date'],
+      )!,
+      endDate: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}end_date'],
+      ),
+      amount: attachedDatabase.typeMapping.read(
+        DriftSqlType.double,
+        data['${effectivePrefix}amount'],
+      )!,
+      scope: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}scope'],
+      )!,
+      categories: $BudgetsTable.$convertercategories.fromSql(
+        attachedDatabase.typeMapping.read(
+          DriftSqlType.string,
+          data['${effectivePrefix}categories'],
+        )!,
+      ),
+      accounts: $BudgetsTable.$converteraccounts.fromSql(
+        attachedDatabase.typeMapping.read(
+          DriftSqlType.string,
+          data['${effectivePrefix}accounts'],
+        )!,
+      ),
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}created_at'],
+      )!,
+      updatedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}updated_at'],
+      )!,
+      isDeleted: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}is_deleted'],
+      )!,
+    );
+  }
+
+  @override
+  $BudgetsTable createAlias(String alias) {
+    return $BudgetsTable(attachedDatabase, alias);
+  }
+
+  static TypeConverter<List<String>, String> $convertercategories =
+      const StringListConverter();
+  static TypeConverter<List<String>, String> $converteraccounts =
+      const StringListConverter();
+}
+
+class BudgetRow extends DataClass implements Insertable<BudgetRow> {
+  final String id;
+  final String title;
+  final String period;
+  final DateTime startDate;
+  final DateTime? endDate;
+  final double amount;
+  final String scope;
+  final List<String> categories;
+  final List<String> accounts;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final bool isDeleted;
+  const BudgetRow({
+    required this.id,
+    required this.title,
+    required this.period,
+    required this.startDate,
+    this.endDate,
+    required this.amount,
+    required this.scope,
+    required this.categories,
+    required this.accounts,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.isDeleted,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<String>(id);
+    map['title'] = Variable<String>(title);
+    map['period'] = Variable<String>(period);
+    map['start_date'] = Variable<DateTime>(startDate);
+    if (!nullToAbsent || endDate != null) {
+      map['end_date'] = Variable<DateTime>(endDate);
+    }
+    map['amount'] = Variable<double>(amount);
+    map['scope'] = Variable<String>(scope);
+    {
+      map['categories'] = Variable<String>(
+        $BudgetsTable.$convertercategories.toSql(categories),
+      );
+    }
+    {
+      map['accounts'] = Variable<String>(
+        $BudgetsTable.$converteraccounts.toSql(accounts),
+      );
+    }
+    map['created_at'] = Variable<DateTime>(createdAt);
+    map['updated_at'] = Variable<DateTime>(updatedAt);
+    map['is_deleted'] = Variable<bool>(isDeleted);
+    return map;
+  }
+
+  BudgetsCompanion toCompanion(bool nullToAbsent) {
+    return BudgetsCompanion(
+      id: Value(id),
+      title: Value(title),
+      period: Value(period),
+      startDate: Value(startDate),
+      endDate: endDate == null && nullToAbsent
+          ? const Value.absent()
+          : Value(endDate),
+      amount: Value(amount),
+      scope: Value(scope),
+      categories: Value(categories),
+      accounts: Value(accounts),
+      createdAt: Value(createdAt),
+      updatedAt: Value(updatedAt),
+      isDeleted: Value(isDeleted),
+    );
+  }
+
+  factory BudgetRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return BudgetRow(
+      id: serializer.fromJson<String>(json['id']),
+      title: serializer.fromJson<String>(json['title']),
+      period: serializer.fromJson<String>(json['period']),
+      startDate: serializer.fromJson<DateTime>(json['startDate']),
+      endDate: serializer.fromJson<DateTime?>(json['endDate']),
+      amount: serializer.fromJson<double>(json['amount']),
+      scope: serializer.fromJson<String>(json['scope']),
+      categories: serializer.fromJson<List<String>>(json['categories']),
+      accounts: serializer.fromJson<List<String>>(json['accounts']),
+      createdAt: serializer.fromJson<DateTime>(json['createdAt']),
+      updatedAt: serializer.fromJson<DateTime>(json['updatedAt']),
+      isDeleted: serializer.fromJson<bool>(json['isDeleted']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<String>(id),
+      'title': serializer.toJson<String>(title),
+      'period': serializer.toJson<String>(period),
+      'startDate': serializer.toJson<DateTime>(startDate),
+      'endDate': serializer.toJson<DateTime?>(endDate),
+      'amount': serializer.toJson<double>(amount),
+      'scope': serializer.toJson<String>(scope),
+      'categories': serializer.toJson<List<String>>(categories),
+      'accounts': serializer.toJson<List<String>>(accounts),
+      'createdAt': serializer.toJson<DateTime>(createdAt),
+      'updatedAt': serializer.toJson<DateTime>(updatedAt),
+      'isDeleted': serializer.toJson<bool>(isDeleted),
+    };
+  }
+
+  BudgetRow copyWith({
+    String? id,
+    String? title,
+    String? period,
+    DateTime? startDate,
+    Value<DateTime?> endDate = const Value.absent(),
+    double? amount,
+    String? scope,
+    List<String>? categories,
+    List<String>? accounts,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    bool? isDeleted,
+  }) => BudgetRow(
+    id: id ?? this.id,
+    title: title ?? this.title,
+    period: period ?? this.period,
+    startDate: startDate ?? this.startDate,
+    endDate: endDate.present ? endDate.value : this.endDate,
+    amount: amount ?? this.amount,
+    scope: scope ?? this.scope,
+    categories: categories ?? this.categories,
+    accounts: accounts ?? this.accounts,
+    createdAt: createdAt ?? this.createdAt,
+    updatedAt: updatedAt ?? this.updatedAt,
+    isDeleted: isDeleted ?? this.isDeleted,
+  );
+  BudgetRow copyWithCompanion(BudgetsCompanion data) {
+    return BudgetRow(
+      id: data.id.present ? data.id.value : this.id,
+      title: data.title.present ? data.title.value : this.title,
+      period: data.period.present ? data.period.value : this.period,
+      startDate: data.startDate.present ? data.startDate.value : this.startDate,
+      endDate: data.endDate.present ? data.endDate.value : this.endDate,
+      amount: data.amount.present ? data.amount.value : this.amount,
+      scope: data.scope.present ? data.scope.value : this.scope,
+      categories: data.categories.present
+          ? data.categories.value
+          : this.categories,
+      accounts: data.accounts.present ? data.accounts.value : this.accounts,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+      updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
+      isDeleted: data.isDeleted.present ? data.isDeleted.value : this.isDeleted,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('BudgetRow(')
+          ..write('id: $id, ')
+          ..write('title: $title, ')
+          ..write('period: $period, ')
+          ..write('startDate: $startDate, ')
+          ..write('endDate: $endDate, ')
+          ..write('amount: $amount, ')
+          ..write('scope: $scope, ')
+          ..write('categories: $categories, ')
+          ..write('accounts: $accounts, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('isDeleted: $isDeleted')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    title,
+    period,
+    startDate,
+    endDate,
+    amount,
+    scope,
+    categories,
+    accounts,
+    createdAt,
+    updatedAt,
+    isDeleted,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is BudgetRow &&
+          other.id == this.id &&
+          other.title == this.title &&
+          other.period == this.period &&
+          other.startDate == this.startDate &&
+          other.endDate == this.endDate &&
+          other.amount == this.amount &&
+          other.scope == this.scope &&
+          other.categories == this.categories &&
+          other.accounts == this.accounts &&
+          other.createdAt == this.createdAt &&
+          other.updatedAt == this.updatedAt &&
+          other.isDeleted == this.isDeleted);
+}
+
+class BudgetsCompanion extends UpdateCompanion<BudgetRow> {
+  final Value<String> id;
+  final Value<String> title;
+  final Value<String> period;
+  final Value<DateTime> startDate;
+  final Value<DateTime?> endDate;
+  final Value<double> amount;
+  final Value<String> scope;
+  final Value<List<String>> categories;
+  final Value<List<String>> accounts;
+  final Value<DateTime> createdAt;
+  final Value<DateTime> updatedAt;
+  final Value<bool> isDeleted;
+  final Value<int> rowid;
+  const BudgetsCompanion({
+    this.id = const Value.absent(),
+    this.title = const Value.absent(),
+    this.period = const Value.absent(),
+    this.startDate = const Value.absent(),
+    this.endDate = const Value.absent(),
+    this.amount = const Value.absent(),
+    this.scope = const Value.absent(),
+    this.categories = const Value.absent(),
+    this.accounts = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+    this.isDeleted = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  BudgetsCompanion.insert({
+    required String id,
+    required String title,
+    required String period,
+    required DateTime startDate,
+    this.endDate = const Value.absent(),
+    required double amount,
+    required String scope,
+    this.categories = const Value.absent(),
+    this.accounts = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+    this.isDeleted = const Value.absent(),
+    this.rowid = const Value.absent(),
+  }) : id = Value(id),
+       title = Value(title),
+       period = Value(period),
+       startDate = Value(startDate),
+       amount = Value(amount),
+       scope = Value(scope);
+  static Insertable<BudgetRow> custom({
+    Expression<String>? id,
+    Expression<String>? title,
+    Expression<String>? period,
+    Expression<DateTime>? startDate,
+    Expression<DateTime>? endDate,
+    Expression<double>? amount,
+    Expression<String>? scope,
+    Expression<String>? categories,
+    Expression<String>? accounts,
+    Expression<DateTime>? createdAt,
+    Expression<DateTime>? updatedAt,
+    Expression<bool>? isDeleted,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (title != null) 'title': title,
+      if (period != null) 'period': period,
+      if (startDate != null) 'start_date': startDate,
+      if (endDate != null) 'end_date': endDate,
+      if (amount != null) 'amount': amount,
+      if (scope != null) 'scope': scope,
+      if (categories != null) 'categories': categories,
+      if (accounts != null) 'accounts': accounts,
+      if (createdAt != null) 'created_at': createdAt,
+      if (updatedAt != null) 'updated_at': updatedAt,
+      if (isDeleted != null) 'is_deleted': isDeleted,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  BudgetsCompanion copyWith({
+    Value<String>? id,
+    Value<String>? title,
+    Value<String>? period,
+    Value<DateTime>? startDate,
+    Value<DateTime?>? endDate,
+    Value<double>? amount,
+    Value<String>? scope,
+    Value<List<String>>? categories,
+    Value<List<String>>? accounts,
+    Value<DateTime>? createdAt,
+    Value<DateTime>? updatedAt,
+    Value<bool>? isDeleted,
+    Value<int>? rowid,
+  }) {
+    return BudgetsCompanion(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      period: period ?? this.period,
+      startDate: startDate ?? this.startDate,
+      endDate: endDate ?? this.endDate,
+      amount: amount ?? this.amount,
+      scope: scope ?? this.scope,
+      categories: categories ?? this.categories,
+      accounts: accounts ?? this.accounts,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      isDeleted: isDeleted ?? this.isDeleted,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<String>(id.value);
+    }
+    if (title.present) {
+      map['title'] = Variable<String>(title.value);
+    }
+    if (period.present) {
+      map['period'] = Variable<String>(period.value);
+    }
+    if (startDate.present) {
+      map['start_date'] = Variable<DateTime>(startDate.value);
+    }
+    if (endDate.present) {
+      map['end_date'] = Variable<DateTime>(endDate.value);
+    }
+    if (amount.present) {
+      map['amount'] = Variable<double>(amount.value);
+    }
+    if (scope.present) {
+      map['scope'] = Variable<String>(scope.value);
+    }
+    if (categories.present) {
+      map['categories'] = Variable<String>(
+        $BudgetsTable.$convertercategories.toSql(categories.value),
+      );
+    }
+    if (accounts.present) {
+      map['accounts'] = Variable<String>(
+        $BudgetsTable.$converteraccounts.toSql(accounts.value),
+      );
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<DateTime>(createdAt.value);
+    }
+    if (updatedAt.present) {
+      map['updated_at'] = Variable<DateTime>(updatedAt.value);
+    }
+    if (isDeleted.present) {
+      map['is_deleted'] = Variable<bool>(isDeleted.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('BudgetsCompanion(')
+          ..write('id: $id, ')
+          ..write('title: $title, ')
+          ..write('period: $period, ')
+          ..write('startDate: $startDate, ')
+          ..write('endDate: $endDate, ')
+          ..write('amount: $amount, ')
+          ..write('scope: $scope, ')
+          ..write('categories: $categories, ')
+          ..write('accounts: $accounts, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('isDeleted: $isDeleted, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $BudgetInstancesTable extends BudgetInstances
+    with TableInfo<$BudgetInstancesTable, BudgetInstanceRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $BudgetInstancesTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<String> id = GeneratedColumn<String>(
+    'id',
+    aliasedName,
+    false,
+    additionalChecks: GeneratedColumn.checkTextLength(
+      minTextLength: 1,
+      maxTextLength: 80,
+    ),
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _budgetIdMeta = const VerificationMeta(
+    'budgetId',
+  );
+  @override
+  late final GeneratedColumn<String> budgetId = GeneratedColumn<String>(
+    'budget_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'REFERENCES budgets (id) ON DELETE CASCADE',
+    ),
+  );
+  static const VerificationMeta _periodStartMeta = const VerificationMeta(
+    'periodStart',
+  );
+  @override
+  late final GeneratedColumn<DateTime> periodStart = GeneratedColumn<DateTime>(
+    'period_start',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _periodEndMeta = const VerificationMeta(
+    'periodEnd',
+  );
+  @override
+  late final GeneratedColumn<DateTime> periodEnd = GeneratedColumn<DateTime>(
+    'period_end',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _amountMeta = const VerificationMeta('amount');
+  @override
+  late final GeneratedColumn<double> amount = GeneratedColumn<double>(
+    'amount',
+    aliasedName,
+    false,
+    type: DriftSqlType.double,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _spentMeta = const VerificationMeta('spent');
+  @override
+  late final GeneratedColumn<double> spent = GeneratedColumn<double>(
+    'spent',
+    aliasedName,
+    false,
+    type: DriftSqlType.double,
+    requiredDuringInsert: false,
+    defaultValue: const Constant<double>(0),
+  );
+  static const VerificationMeta _statusMeta = const VerificationMeta('status');
+  @override
+  late final GeneratedColumn<String> status = GeneratedColumn<String>(
+    'status',
+    aliasedName,
+    false,
+    additionalChecks: GeneratedColumn.checkTextLength(
+      minTextLength: 1,
+      maxTextLength: 20,
+    ),
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    defaultValue: const Constant<String>('pending'),
+  );
+  static const VerificationMeta _createdAtMeta = const VerificationMeta(
+    'createdAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
+    'created_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+    defaultValue: currentDateAndTime,
+  );
+  static const VerificationMeta _updatedAtMeta = const VerificationMeta(
+    'updatedAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> updatedAt = GeneratedColumn<DateTime>(
+    'updated_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+    defaultValue: currentDateAndTime,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    budgetId,
+    periodStart,
+    periodEnd,
+    amount,
+    spent,
+    status,
+    createdAt,
+    updatedAt,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'budget_instances';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<BudgetInstanceRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    } else if (isInserting) {
+      context.missing(_idMeta);
+    }
+    if (data.containsKey('budget_id')) {
+      context.handle(
+        _budgetIdMeta,
+        budgetId.isAcceptableOrUnknown(data['budget_id']!, _budgetIdMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_budgetIdMeta);
+    }
+    if (data.containsKey('period_start')) {
+      context.handle(
+        _periodStartMeta,
+        periodStart.isAcceptableOrUnknown(
+          data['period_start']!,
+          _periodStartMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_periodStartMeta);
+    }
+    if (data.containsKey('period_end')) {
+      context.handle(
+        _periodEndMeta,
+        periodEnd.isAcceptableOrUnknown(data['period_end']!, _periodEndMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_periodEndMeta);
+    }
+    if (data.containsKey('amount')) {
+      context.handle(
+        _amountMeta,
+        amount.isAcceptableOrUnknown(data['amount']!, _amountMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_amountMeta);
+    }
+    if (data.containsKey('spent')) {
+      context.handle(
+        _spentMeta,
+        spent.isAcceptableOrUnknown(data['spent']!, _spentMeta),
+      );
+    }
+    if (data.containsKey('status')) {
+      context.handle(
+        _statusMeta,
+        status.isAcceptableOrUnknown(data['status']!, _statusMeta),
+      );
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(
+        _createdAtMeta,
+        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
+      );
+    }
+    if (data.containsKey('updated_at')) {
+      context.handle(
+        _updatedAtMeta,
+        updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  BudgetInstanceRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return BudgetInstanceRow(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}id'],
+      )!,
+      budgetId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}budget_id'],
+      )!,
+      periodStart: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}period_start'],
+      )!,
+      periodEnd: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}period_end'],
+      )!,
+      amount: attachedDatabase.typeMapping.read(
+        DriftSqlType.double,
+        data['${effectivePrefix}amount'],
+      )!,
+      spent: attachedDatabase.typeMapping.read(
+        DriftSqlType.double,
+        data['${effectivePrefix}spent'],
+      )!,
+      status: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}status'],
+      )!,
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}created_at'],
+      )!,
+      updatedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}updated_at'],
+      )!,
+    );
+  }
+
+  @override
+  $BudgetInstancesTable createAlias(String alias) {
+    return $BudgetInstancesTable(attachedDatabase, alias);
+  }
+}
+
+class BudgetInstanceRow extends DataClass
+    implements Insertable<BudgetInstanceRow> {
+  final String id;
+  final String budgetId;
+  final DateTime periodStart;
+  final DateTime periodEnd;
+  final double amount;
+  final double spent;
+  final String status;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  const BudgetInstanceRow({
+    required this.id,
+    required this.budgetId,
+    required this.periodStart,
+    required this.periodEnd,
+    required this.amount,
+    required this.spent,
+    required this.status,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<String>(id);
+    map['budget_id'] = Variable<String>(budgetId);
+    map['period_start'] = Variable<DateTime>(periodStart);
+    map['period_end'] = Variable<DateTime>(periodEnd);
+    map['amount'] = Variable<double>(amount);
+    map['spent'] = Variable<double>(spent);
+    map['status'] = Variable<String>(status);
+    map['created_at'] = Variable<DateTime>(createdAt);
+    map['updated_at'] = Variable<DateTime>(updatedAt);
+    return map;
+  }
+
+  BudgetInstancesCompanion toCompanion(bool nullToAbsent) {
+    return BudgetInstancesCompanion(
+      id: Value(id),
+      budgetId: Value(budgetId),
+      periodStart: Value(periodStart),
+      periodEnd: Value(periodEnd),
+      amount: Value(amount),
+      spent: Value(spent),
+      status: Value(status),
+      createdAt: Value(createdAt),
+      updatedAt: Value(updatedAt),
+    );
+  }
+
+  factory BudgetInstanceRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return BudgetInstanceRow(
+      id: serializer.fromJson<String>(json['id']),
+      budgetId: serializer.fromJson<String>(json['budgetId']),
+      periodStart: serializer.fromJson<DateTime>(json['periodStart']),
+      periodEnd: serializer.fromJson<DateTime>(json['periodEnd']),
+      amount: serializer.fromJson<double>(json['amount']),
+      spent: serializer.fromJson<double>(json['spent']),
+      status: serializer.fromJson<String>(json['status']),
+      createdAt: serializer.fromJson<DateTime>(json['createdAt']),
+      updatedAt: serializer.fromJson<DateTime>(json['updatedAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<String>(id),
+      'budgetId': serializer.toJson<String>(budgetId),
+      'periodStart': serializer.toJson<DateTime>(periodStart),
+      'periodEnd': serializer.toJson<DateTime>(periodEnd),
+      'amount': serializer.toJson<double>(amount),
+      'spent': serializer.toJson<double>(spent),
+      'status': serializer.toJson<String>(status),
+      'createdAt': serializer.toJson<DateTime>(createdAt),
+      'updatedAt': serializer.toJson<DateTime>(updatedAt),
+    };
+  }
+
+  BudgetInstanceRow copyWith({
+    String? id,
+    String? budgetId,
+    DateTime? periodStart,
+    DateTime? periodEnd,
+    double? amount,
+    double? spent,
+    String? status,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) => BudgetInstanceRow(
+    id: id ?? this.id,
+    budgetId: budgetId ?? this.budgetId,
+    periodStart: periodStart ?? this.periodStart,
+    periodEnd: periodEnd ?? this.periodEnd,
+    amount: amount ?? this.amount,
+    spent: spent ?? this.spent,
+    status: status ?? this.status,
+    createdAt: createdAt ?? this.createdAt,
+    updatedAt: updatedAt ?? this.updatedAt,
+  );
+  BudgetInstanceRow copyWithCompanion(BudgetInstancesCompanion data) {
+    return BudgetInstanceRow(
+      id: data.id.present ? data.id.value : this.id,
+      budgetId: data.budgetId.present ? data.budgetId.value : this.budgetId,
+      periodStart: data.periodStart.present
+          ? data.periodStart.value
+          : this.periodStart,
+      periodEnd: data.periodEnd.present ? data.periodEnd.value : this.periodEnd,
+      amount: data.amount.present ? data.amount.value : this.amount,
+      spent: data.spent.present ? data.spent.value : this.spent,
+      status: data.status.present ? data.status.value : this.status,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+      updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('BudgetInstanceRow(')
+          ..write('id: $id, ')
+          ..write('budgetId: $budgetId, ')
+          ..write('periodStart: $periodStart, ')
+          ..write('periodEnd: $periodEnd, ')
+          ..write('amount: $amount, ')
+          ..write('spent: $spent, ')
+          ..write('status: $status, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('updatedAt: $updatedAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    budgetId,
+    periodStart,
+    periodEnd,
+    amount,
+    spent,
+    status,
+    createdAt,
+    updatedAt,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is BudgetInstanceRow &&
+          other.id == this.id &&
+          other.budgetId == this.budgetId &&
+          other.periodStart == this.periodStart &&
+          other.periodEnd == this.periodEnd &&
+          other.amount == this.amount &&
+          other.spent == this.spent &&
+          other.status == this.status &&
+          other.createdAt == this.createdAt &&
+          other.updatedAt == this.updatedAt);
+}
+
+class BudgetInstancesCompanion extends UpdateCompanion<BudgetInstanceRow> {
+  final Value<String> id;
+  final Value<String> budgetId;
+  final Value<DateTime> periodStart;
+  final Value<DateTime> periodEnd;
+  final Value<double> amount;
+  final Value<double> spent;
+  final Value<String> status;
+  final Value<DateTime> createdAt;
+  final Value<DateTime> updatedAt;
+  final Value<int> rowid;
+  const BudgetInstancesCompanion({
+    this.id = const Value.absent(),
+    this.budgetId = const Value.absent(),
+    this.periodStart = const Value.absent(),
+    this.periodEnd = const Value.absent(),
+    this.amount = const Value.absent(),
+    this.spent = const Value.absent(),
+    this.status = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  BudgetInstancesCompanion.insert({
+    required String id,
+    required String budgetId,
+    required DateTime periodStart,
+    required DateTime periodEnd,
+    required double amount,
+    this.spent = const Value.absent(),
+    this.status = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  }) : id = Value(id),
+       budgetId = Value(budgetId),
+       periodStart = Value(periodStart),
+       periodEnd = Value(periodEnd),
+       amount = Value(amount);
+  static Insertable<BudgetInstanceRow> custom({
+    Expression<String>? id,
+    Expression<String>? budgetId,
+    Expression<DateTime>? periodStart,
+    Expression<DateTime>? periodEnd,
+    Expression<double>? amount,
+    Expression<double>? spent,
+    Expression<String>? status,
+    Expression<DateTime>? createdAt,
+    Expression<DateTime>? updatedAt,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (budgetId != null) 'budget_id': budgetId,
+      if (periodStart != null) 'period_start': periodStart,
+      if (periodEnd != null) 'period_end': periodEnd,
+      if (amount != null) 'amount': amount,
+      if (spent != null) 'spent': spent,
+      if (status != null) 'status': status,
+      if (createdAt != null) 'created_at': createdAt,
+      if (updatedAt != null) 'updated_at': updatedAt,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  BudgetInstancesCompanion copyWith({
+    Value<String>? id,
+    Value<String>? budgetId,
+    Value<DateTime>? periodStart,
+    Value<DateTime>? periodEnd,
+    Value<double>? amount,
+    Value<double>? spent,
+    Value<String>? status,
+    Value<DateTime>? createdAt,
+    Value<DateTime>? updatedAt,
+    Value<int>? rowid,
+  }) {
+    return BudgetInstancesCompanion(
+      id: id ?? this.id,
+      budgetId: budgetId ?? this.budgetId,
+      periodStart: periodStart ?? this.periodStart,
+      periodEnd: periodEnd ?? this.periodEnd,
+      amount: amount ?? this.amount,
+      spent: spent ?? this.spent,
+      status: status ?? this.status,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<String>(id.value);
+    }
+    if (budgetId.present) {
+      map['budget_id'] = Variable<String>(budgetId.value);
+    }
+    if (periodStart.present) {
+      map['period_start'] = Variable<DateTime>(periodStart.value);
+    }
+    if (periodEnd.present) {
+      map['period_end'] = Variable<DateTime>(periodEnd.value);
+    }
+    if (amount.present) {
+      map['amount'] = Variable<double>(amount.value);
+    }
+    if (spent.present) {
+      map['spent'] = Variable<double>(spent.value);
+    }
+    if (status.present) {
+      map['status'] = Variable<String>(status.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<DateTime>(createdAt.value);
+    }
+    if (updatedAt.present) {
+      map['updated_at'] = Variable<DateTime>(updatedAt.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('BudgetInstancesCompanion(')
+          ..write('id: $id, ')
+          ..write('budgetId: $budgetId, ')
+          ..write('periodStart: $periodStart, ')
+          ..write('periodEnd: $periodEnd, ')
+          ..write('amount: $amount, ')
+          ..write('spent: $spent, ')
+          ..write('status: $status, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$AppDatabase extends GeneratedDatabase {
   _$AppDatabase(QueryExecutor e) : super(e);
   $AppDatabaseManager get managers => $AppDatabaseManager(this);
@@ -5483,6 +6758,10 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final $RecurringRuleExecutionsTable recurringRuleExecutions =
       $RecurringRuleExecutionsTable(this);
   late final $JobQueueTable jobQueue = $JobQueueTable(this);
+  late final $BudgetsTable budgets = $BudgetsTable(this);
+  late final $BudgetInstancesTable budgetInstances = $BudgetInstancesTable(
+    this,
+  );
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
@@ -5497,6 +6776,8 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     recurringOccurrences,
     recurringRuleExecutions,
     jobQueue,
+    budgets,
+    budgetInstances,
   ];
   @override
   StreamQueryUpdateRules get streamUpdateRules => const StreamQueryUpdateRules([
@@ -5543,6 +6824,13 @@ abstract class _$AppDatabase extends GeneratedDatabase {
       result: [
         TableUpdate('recurring_rule_executions', kind: UpdateKind.delete),
       ],
+    ),
+    WritePropagation(
+      on: TableUpdateQuery.onTableName(
+        'budgets',
+        limitUpdateKind: UpdateKind.delete,
+      ),
+      result: [TableUpdate('budget_instances', kind: UpdateKind.delete)],
     ),
   ]);
 }
@@ -9507,6 +10795,858 @@ typedef $$JobQueueTableProcessedTableManager =
       JobQueueRow,
       PrefetchHooks Function()
     >;
+typedef $$BudgetsTableCreateCompanionBuilder =
+    BudgetsCompanion Function({
+      required String id,
+      required String title,
+      required String period,
+      required DateTime startDate,
+      Value<DateTime?> endDate,
+      required double amount,
+      required String scope,
+      Value<List<String>> categories,
+      Value<List<String>> accounts,
+      Value<DateTime> createdAt,
+      Value<DateTime> updatedAt,
+      Value<bool> isDeleted,
+      Value<int> rowid,
+    });
+typedef $$BudgetsTableUpdateCompanionBuilder =
+    BudgetsCompanion Function({
+      Value<String> id,
+      Value<String> title,
+      Value<String> period,
+      Value<DateTime> startDate,
+      Value<DateTime?> endDate,
+      Value<double> amount,
+      Value<String> scope,
+      Value<List<String>> categories,
+      Value<List<String>> accounts,
+      Value<DateTime> createdAt,
+      Value<DateTime> updatedAt,
+      Value<bool> isDeleted,
+      Value<int> rowid,
+    });
+
+final class $$BudgetsTableReferences
+    extends BaseReferences<_$AppDatabase, $BudgetsTable, BudgetRow> {
+  $$BudgetsTableReferences(super.$_db, super.$_table, super.$_typedResult);
+
+  static MultiTypedResultKey<$BudgetInstancesTable, List<BudgetInstanceRow>>
+  _budgetInstancesRefsTable(_$AppDatabase db) => MultiTypedResultKey.fromTable(
+    db.budgetInstances,
+    aliasName: $_aliasNameGenerator(db.budgets.id, db.budgetInstances.budgetId),
+  );
+
+  $$BudgetInstancesTableProcessedTableManager get budgetInstancesRefs {
+    final manager = $$BudgetInstancesTableTableManager(
+      $_db,
+      $_db.budgetInstances,
+    ).filter((f) => f.budgetId.id.sqlEquals($_itemColumn<String>('id')!));
+
+    final cache = $_typedResult.readTableOrNull(
+      _budgetInstancesRefsTable($_db),
+    );
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: cache),
+    );
+  }
+}
+
+class $$BudgetsTableFilterComposer
+    extends Composer<_$AppDatabase, $BudgetsTable> {
+  $$BudgetsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get title => $composableBuilder(
+    column: $table.title,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get period => $composableBuilder(
+    column: $table.period,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get startDate => $composableBuilder(
+    column: $table.startDate,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get endDate => $composableBuilder(
+    column: $table.endDate,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<double> get amount => $composableBuilder(
+    column: $table.amount,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get scope => $composableBuilder(
+    column: $table.scope,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnWithTypeConverterFilters<List<String>, List<String>, String>
+  get categories => $composableBuilder(
+    column: $table.categories,
+    builder: (column) => ColumnWithTypeConverterFilters(column),
+  );
+
+  ColumnWithTypeConverterFilters<List<String>, List<String>, String>
+  get accounts => $composableBuilder(
+    column: $table.accounts,
+    builder: (column) => ColumnWithTypeConverterFilters(column),
+  );
+
+  ColumnFilters<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get isDeleted => $composableBuilder(
+    column: $table.isDeleted,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  Expression<bool> budgetInstancesRefs(
+    Expression<bool> Function($$BudgetInstancesTableFilterComposer f) f,
+  ) {
+    final $$BudgetInstancesTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.budgetInstances,
+      getReferencedColumn: (t) => t.budgetId,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$BudgetInstancesTableFilterComposer(
+            $db: $db,
+            $table: $db.budgetInstances,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
+}
+
+class $$BudgetsTableOrderingComposer
+    extends Composer<_$AppDatabase, $BudgetsTable> {
+  $$BudgetsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get title => $composableBuilder(
+    column: $table.title,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get period => $composableBuilder(
+    column: $table.period,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get startDate => $composableBuilder(
+    column: $table.startDate,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get endDate => $composableBuilder(
+    column: $table.endDate,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<double> get amount => $composableBuilder(
+    column: $table.amount,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get scope => $composableBuilder(
+    column: $table.scope,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get categories => $composableBuilder(
+    column: $table.categories,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get accounts => $composableBuilder(
+    column: $table.accounts,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<bool> get isDeleted => $composableBuilder(
+    column: $table.isDeleted,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$BudgetsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $BudgetsTable> {
+  $$BudgetsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get title =>
+      $composableBuilder(column: $table.title, builder: (column) => column);
+
+  GeneratedColumn<String> get period =>
+      $composableBuilder(column: $table.period, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get startDate =>
+      $composableBuilder(column: $table.startDate, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get endDate =>
+      $composableBuilder(column: $table.endDate, builder: (column) => column);
+
+  GeneratedColumn<double> get amount =>
+      $composableBuilder(column: $table.amount, builder: (column) => column);
+
+  GeneratedColumn<String> get scope =>
+      $composableBuilder(column: $table.scope, builder: (column) => column);
+
+  GeneratedColumnWithTypeConverter<List<String>, String> get categories =>
+      $composableBuilder(
+        column: $table.categories,
+        builder: (column) => column,
+      );
+
+  GeneratedColumnWithTypeConverter<List<String>, String> get accounts =>
+      $composableBuilder(column: $table.accounts, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get updatedAt =>
+      $composableBuilder(column: $table.updatedAt, builder: (column) => column);
+
+  GeneratedColumn<bool> get isDeleted =>
+      $composableBuilder(column: $table.isDeleted, builder: (column) => column);
+
+  Expression<T> budgetInstancesRefs<T extends Object>(
+    Expression<T> Function($$BudgetInstancesTableAnnotationComposer a) f,
+  ) {
+    final $$BudgetInstancesTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.budgetInstances,
+      getReferencedColumn: (t) => t.budgetId,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$BudgetInstancesTableAnnotationComposer(
+            $db: $db,
+            $table: $db.budgetInstances,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
+}
+
+class $$BudgetsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $BudgetsTable,
+          BudgetRow,
+          $$BudgetsTableFilterComposer,
+          $$BudgetsTableOrderingComposer,
+          $$BudgetsTableAnnotationComposer,
+          $$BudgetsTableCreateCompanionBuilder,
+          $$BudgetsTableUpdateCompanionBuilder,
+          (BudgetRow, $$BudgetsTableReferences),
+          BudgetRow,
+          PrefetchHooks Function({bool budgetInstancesRefs})
+        > {
+  $$BudgetsTableTableManager(_$AppDatabase db, $BudgetsTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$BudgetsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$BudgetsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$BudgetsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<String> id = const Value.absent(),
+                Value<String> title = const Value.absent(),
+                Value<String> period = const Value.absent(),
+                Value<DateTime> startDate = const Value.absent(),
+                Value<DateTime?> endDate = const Value.absent(),
+                Value<double> amount = const Value.absent(),
+                Value<String> scope = const Value.absent(),
+                Value<List<String>> categories = const Value.absent(),
+                Value<List<String>> accounts = const Value.absent(),
+                Value<DateTime> createdAt = const Value.absent(),
+                Value<DateTime> updatedAt = const Value.absent(),
+                Value<bool> isDeleted = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => BudgetsCompanion(
+                id: id,
+                title: title,
+                period: period,
+                startDate: startDate,
+                endDate: endDate,
+                amount: amount,
+                scope: scope,
+                categories: categories,
+                accounts: accounts,
+                createdAt: createdAt,
+                updatedAt: updatedAt,
+                isDeleted: isDeleted,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String id,
+                required String title,
+                required String period,
+                required DateTime startDate,
+                Value<DateTime?> endDate = const Value.absent(),
+                required double amount,
+                required String scope,
+                Value<List<String>> categories = const Value.absent(),
+                Value<List<String>> accounts = const Value.absent(),
+                Value<DateTime> createdAt = const Value.absent(),
+                Value<DateTime> updatedAt = const Value.absent(),
+                Value<bool> isDeleted = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => BudgetsCompanion.insert(
+                id: id,
+                title: title,
+                period: period,
+                startDate: startDate,
+                endDate: endDate,
+                amount: amount,
+                scope: scope,
+                categories: categories,
+                accounts: accounts,
+                createdAt: createdAt,
+                updatedAt: updatedAt,
+                isDeleted: isDeleted,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map(
+                (e) => (
+                  e.readTable(table),
+                  $$BudgetsTableReferences(db, table, e),
+                ),
+              )
+              .toList(),
+          prefetchHooksCallback: ({budgetInstancesRefs = false}) {
+            return PrefetchHooks(
+              db: db,
+              explicitlyWatchedTables: [
+                if (budgetInstancesRefs) db.budgetInstances,
+              ],
+              addJoins: null,
+              getPrefetchedDataCallback: (items) async {
+                return [
+                  if (budgetInstancesRefs)
+                    await $_getPrefetchedData<
+                      BudgetRow,
+                      $BudgetsTable,
+                      BudgetInstanceRow
+                    >(
+                      currentTable: table,
+                      referencedTable: $$BudgetsTableReferences
+                          ._budgetInstancesRefsTable(db),
+                      managerFromTypedResult: (p0) => $$BudgetsTableReferences(
+                        db,
+                        table,
+                        p0,
+                      ).budgetInstancesRefs,
+                      referencedItemsForCurrentItem: (item, referencedItems) =>
+                          referencedItems.where((e) => e.budgetId == item.id),
+                      typedResults: items,
+                    ),
+                ];
+              },
+            );
+          },
+        ),
+      );
+}
+
+typedef $$BudgetsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $BudgetsTable,
+      BudgetRow,
+      $$BudgetsTableFilterComposer,
+      $$BudgetsTableOrderingComposer,
+      $$BudgetsTableAnnotationComposer,
+      $$BudgetsTableCreateCompanionBuilder,
+      $$BudgetsTableUpdateCompanionBuilder,
+      (BudgetRow, $$BudgetsTableReferences),
+      BudgetRow,
+      PrefetchHooks Function({bool budgetInstancesRefs})
+    >;
+typedef $$BudgetInstancesTableCreateCompanionBuilder =
+    BudgetInstancesCompanion Function({
+      required String id,
+      required String budgetId,
+      required DateTime periodStart,
+      required DateTime periodEnd,
+      required double amount,
+      Value<double> spent,
+      Value<String> status,
+      Value<DateTime> createdAt,
+      Value<DateTime> updatedAt,
+      Value<int> rowid,
+    });
+typedef $$BudgetInstancesTableUpdateCompanionBuilder =
+    BudgetInstancesCompanion Function({
+      Value<String> id,
+      Value<String> budgetId,
+      Value<DateTime> periodStart,
+      Value<DateTime> periodEnd,
+      Value<double> amount,
+      Value<double> spent,
+      Value<String> status,
+      Value<DateTime> createdAt,
+      Value<DateTime> updatedAt,
+      Value<int> rowid,
+    });
+
+final class $$BudgetInstancesTableReferences
+    extends
+        BaseReferences<
+          _$AppDatabase,
+          $BudgetInstancesTable,
+          BudgetInstanceRow
+        > {
+  $$BudgetInstancesTableReferences(
+    super.$_db,
+    super.$_table,
+    super.$_typedResult,
+  );
+
+  static $BudgetsTable _budgetIdTable(_$AppDatabase db) =>
+      db.budgets.createAlias(
+        $_aliasNameGenerator(db.budgetInstances.budgetId, db.budgets.id),
+      );
+
+  $$BudgetsTableProcessedTableManager get budgetId {
+    final $_column = $_itemColumn<String>('budget_id')!;
+
+    final manager = $$BudgetsTableTableManager(
+      $_db,
+      $_db.budgets,
+    ).filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_budgetIdTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: [item]),
+    );
+  }
+}
+
+class $$BudgetInstancesTableFilterComposer
+    extends Composer<_$AppDatabase, $BudgetInstancesTable> {
+  $$BudgetInstancesTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get periodStart => $composableBuilder(
+    column: $table.periodStart,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get periodEnd => $composableBuilder(
+    column: $table.periodEnd,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<double> get amount => $composableBuilder(
+    column: $table.amount,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<double> get spent => $composableBuilder(
+    column: $table.spent,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get status => $composableBuilder(
+    column: $table.status,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  $$BudgetsTableFilterComposer get budgetId {
+    final $$BudgetsTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.budgetId,
+      referencedTable: $db.budgets,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$BudgetsTableFilterComposer(
+            $db: $db,
+            $table: $db.budgets,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$BudgetInstancesTableOrderingComposer
+    extends Composer<_$AppDatabase, $BudgetInstancesTable> {
+  $$BudgetInstancesTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get periodStart => $composableBuilder(
+    column: $table.periodStart,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get periodEnd => $composableBuilder(
+    column: $table.periodEnd,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<double> get amount => $composableBuilder(
+    column: $table.amount,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<double> get spent => $composableBuilder(
+    column: $table.spent,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get status => $composableBuilder(
+    column: $table.status,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  $$BudgetsTableOrderingComposer get budgetId {
+    final $$BudgetsTableOrderingComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.budgetId,
+      referencedTable: $db.budgets,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$BudgetsTableOrderingComposer(
+            $db: $db,
+            $table: $db.budgets,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$BudgetInstancesTableAnnotationComposer
+    extends Composer<_$AppDatabase, $BudgetInstancesTable> {
+  $$BudgetInstancesTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get periodStart => $composableBuilder(
+    column: $table.periodStart,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<DateTime> get periodEnd =>
+      $composableBuilder(column: $table.periodEnd, builder: (column) => column);
+
+  GeneratedColumn<double> get amount =>
+      $composableBuilder(column: $table.amount, builder: (column) => column);
+
+  GeneratedColumn<double> get spent =>
+      $composableBuilder(column: $table.spent, builder: (column) => column);
+
+  GeneratedColumn<String> get status =>
+      $composableBuilder(column: $table.status, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get updatedAt =>
+      $composableBuilder(column: $table.updatedAt, builder: (column) => column);
+
+  $$BudgetsTableAnnotationComposer get budgetId {
+    final $$BudgetsTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.budgetId,
+      referencedTable: $db.budgets,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$BudgetsTableAnnotationComposer(
+            $db: $db,
+            $table: $db.budgets,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$BudgetInstancesTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $BudgetInstancesTable,
+          BudgetInstanceRow,
+          $$BudgetInstancesTableFilterComposer,
+          $$BudgetInstancesTableOrderingComposer,
+          $$BudgetInstancesTableAnnotationComposer,
+          $$BudgetInstancesTableCreateCompanionBuilder,
+          $$BudgetInstancesTableUpdateCompanionBuilder,
+          (BudgetInstanceRow, $$BudgetInstancesTableReferences),
+          BudgetInstanceRow,
+          PrefetchHooks Function({bool budgetId})
+        > {
+  $$BudgetInstancesTableTableManager(
+    _$AppDatabase db,
+    $BudgetInstancesTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$BudgetInstancesTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$BudgetInstancesTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$BudgetInstancesTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<String> id = const Value.absent(),
+                Value<String> budgetId = const Value.absent(),
+                Value<DateTime> periodStart = const Value.absent(),
+                Value<DateTime> periodEnd = const Value.absent(),
+                Value<double> amount = const Value.absent(),
+                Value<double> spent = const Value.absent(),
+                Value<String> status = const Value.absent(),
+                Value<DateTime> createdAt = const Value.absent(),
+                Value<DateTime> updatedAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => BudgetInstancesCompanion(
+                id: id,
+                budgetId: budgetId,
+                periodStart: periodStart,
+                periodEnd: periodEnd,
+                amount: amount,
+                spent: spent,
+                status: status,
+                createdAt: createdAt,
+                updatedAt: updatedAt,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String id,
+                required String budgetId,
+                required DateTime periodStart,
+                required DateTime periodEnd,
+                required double amount,
+                Value<double> spent = const Value.absent(),
+                Value<String> status = const Value.absent(),
+                Value<DateTime> createdAt = const Value.absent(),
+                Value<DateTime> updatedAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => BudgetInstancesCompanion.insert(
+                id: id,
+                budgetId: budgetId,
+                periodStart: periodStart,
+                periodEnd: periodEnd,
+                amount: amount,
+                spent: spent,
+                status: status,
+                createdAt: createdAt,
+                updatedAt: updatedAt,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map(
+                (e) => (
+                  e.readTable(table),
+                  $$BudgetInstancesTableReferences(db, table, e),
+                ),
+              )
+              .toList(),
+          prefetchHooksCallback: ({budgetId = false}) {
+            return PrefetchHooks(
+              db: db,
+              explicitlyWatchedTables: [],
+              addJoins:
+                  <
+                    T extends TableManagerState<
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic
+                    >
+                  >(state) {
+                    if (budgetId) {
+                      state =
+                          state.withJoin(
+                                currentTable: table,
+                                currentColumn: table.budgetId,
+                                referencedTable:
+                                    $$BudgetInstancesTableReferences
+                                        ._budgetIdTable(db),
+                                referencedColumn:
+                                    $$BudgetInstancesTableReferences
+                                        ._budgetIdTable(db)
+                                        .id,
+                              )
+                              as T;
+                    }
+
+                    return state;
+                  },
+              getPrefetchedDataCallback: (items) async {
+                return [];
+              },
+            );
+          },
+        ),
+      );
+}
+
+typedef $$BudgetInstancesTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $BudgetInstancesTable,
+      BudgetInstanceRow,
+      $$BudgetInstancesTableFilterComposer,
+      $$BudgetInstancesTableOrderingComposer,
+      $$BudgetInstancesTableAnnotationComposer,
+      $$BudgetInstancesTableCreateCompanionBuilder,
+      $$BudgetInstancesTableUpdateCompanionBuilder,
+      (BudgetInstanceRow, $$BudgetInstancesTableReferences),
+      BudgetInstanceRow,
+      PrefetchHooks Function({bool budgetId})
+    >;
 
 class $AppDatabaseManager {
   final _$AppDatabase _db;
@@ -9532,4 +11672,8 @@ class $AppDatabaseManager {
       );
   $$JobQueueTableTableManager get jobQueue =>
       $$JobQueueTableTableManager(_db, _db.jobQueue);
+  $$BudgetsTableTableManager get budgets =>
+      $$BudgetsTableTableManager(_db, _db.budgets);
+  $$BudgetInstancesTableTableManager get budgetInstances =>
+      $$BudgetInstancesTableTableManager(_db, _db.budgetInstances);
 }

--- a/lib/core/di/injectors.dart
+++ b/lib/core/di/injectors.dart
@@ -20,6 +20,16 @@ import 'package:kopim/features/accounts/data/sources/remote/account_remote_data_
 import 'package:kopim/features/accounts/domain/repositories/account_repository.dart';
 import 'package:kopim/features/accounts/domain/use_cases/add_account_use_case.dart';
 import 'package:kopim/features/accounts/domain/use_cases/watch_accounts_use_case.dart';
+import 'package:kopim/features/budgets/data/repositories/budget_repository_impl.dart';
+import 'package:kopim/features/budgets/data/sources/local/budget_dao.dart';
+import 'package:kopim/features/budgets/data/sources/remote/budget_instance_remote_data_source.dart';
+import 'package:kopim/features/budgets/data/sources/remote/budget_remote_data_source.dart';
+import 'package:kopim/features/budgets/domain/repositories/budget_repository.dart';
+import 'package:kopim/features/budgets/domain/services/budget_schedule.dart';
+import 'package:kopim/features/budgets/domain/use_cases/compute_budget_progress_use_case.dart';
+import 'package:kopim/features/budgets/domain/use_cases/delete_budget_use_case.dart';
+import 'package:kopim/features/budgets/domain/use_cases/save_budget_use_case.dart';
+import 'package:kopim/features/budgets/domain/use_cases/watch_budgets_use_case.dart';
 import 'package:kopim/features/analytics/domain/use_cases/watch_monthly_analytics_use_case.dart';
 import 'package:kopim/features/home/domain/use_cases/watch_upcoming_payments_use_case.dart';
 import 'package:kopim/features/categories/data/repositories/category_repository_impl.dart';
@@ -108,6 +118,13 @@ TransactionDao transactionDao(Ref ref) =>
     TransactionDao(ref.watch(appDatabaseProvider));
 
 @riverpod
+BudgetDao budgetDao(Ref ref) => BudgetDao(ref.watch(appDatabaseProvider));
+
+@riverpod
+BudgetInstanceDao budgetInstanceDao(Ref ref) =>
+    BudgetInstanceDao(ref.watch(appDatabaseProvider));
+
+@riverpod
 ProfileDao profileDao(Ref ref) => ProfileDao(ref.watch(appDatabaseProvider));
 
 @riverpod
@@ -136,6 +153,9 @@ Workmanager workmanager(Ref ref) => Workmanager();
 RecurringRuleEngine recurringRuleEngine(Ref ref) => RecurringRuleEngine();
 
 @riverpod
+BudgetSchedule budgetSchedule(Ref ref) => const BudgetSchedule();
+
+@riverpod
 AccountRemoteDataSource accountRemoteDataSource(Ref ref) =>
     AccountRemoteDataSource(ref.watch(firestoreProvider));
 
@@ -150,6 +170,14 @@ TransactionRemoteDataSource transactionRemoteDataSource(Ref ref) =>
 @riverpod
 ProfileRemoteDataSource profileRemoteDataSource(Ref ref) =>
     ProfileRemoteDataSource(ref.watch(firestoreProvider));
+
+@riverpod
+BudgetRemoteDataSource budgetRemoteDataSource(Ref ref) =>
+    BudgetRemoteDataSource(ref.watch(firestoreProvider));
+
+@riverpod
+BudgetInstanceRemoteDataSource budgetInstanceRemoteDataSource(Ref ref) =>
+    BudgetInstanceRemoteDataSource(ref.watch(firestoreProvider));
 
 @riverpod
 RecurringNotificationService recurringNotificationService(Ref ref) =>
@@ -171,6 +199,22 @@ AddAccountUseCase addAccountUseCase(Ref ref) =>
 @riverpod
 WatchAccountsUseCase watchAccountsUseCase(Ref ref) =>
     WatchAccountsUseCase(ref.watch(accountRepositoryProvider));
+
+@riverpod
+WatchBudgetsUseCase watchBudgetsUseCase(Ref ref) =>
+    WatchBudgetsUseCase(repository: ref.watch(budgetRepositoryProvider));
+
+@riverpod
+SaveBudgetUseCase saveBudgetUseCase(Ref ref) =>
+    SaveBudgetUseCase(repository: ref.watch(budgetRepositoryProvider));
+
+@riverpod
+DeleteBudgetUseCase deleteBudgetUseCase(Ref ref) =>
+    DeleteBudgetUseCase(repository: ref.watch(budgetRepositoryProvider));
+
+@riverpod
+ComputeBudgetProgressUseCase computeBudgetProgressUseCase(Ref ref) =>
+    ComputeBudgetProgressUseCase(schedule: ref.watch(budgetScheduleProvider));
 
 @riverpod
 CategoryRepository categoryRepository(Ref ref) => CategoryRepositoryImpl(
@@ -204,6 +248,14 @@ TransactionRepository transactionRepository(Ref ref) =>
       transactionDao: ref.watch(transactionDaoProvider),
       outboxDao: ref.watch(outboxDaoProvider),
     );
+
+@riverpod
+BudgetRepository budgetRepository(Ref ref) => BudgetRepositoryImpl(
+  database: ref.watch(appDatabaseProvider),
+  budgetDao: ref.watch(budgetDaoProvider),
+  budgetInstanceDao: ref.watch(budgetInstanceDaoProvider),
+  outboxDao: ref.watch(outboxDaoProvider),
+);
 
 @riverpod
 RecurringTransactionsRepository recurringTransactionsRepository(Ref ref) =>
@@ -337,6 +389,10 @@ SyncService syncService(Ref ref) {
     categoryRemoteDataSource: ref.watch(categoryRemoteDataSourceProvider),
     transactionRemoteDataSource: ref.watch(transactionRemoteDataSourceProvider),
     profileRemoteDataSource: ref.watch(profileRemoteDataSourceProvider),
+    budgetRemoteDataSource: ref.watch(budgetRemoteDataSourceProvider),
+    budgetInstanceRemoteDataSource: ref.watch(
+      budgetInstanceRemoteDataSourceProvider,
+    ),
     firebaseAuth: ref.watch(firebaseAuthProvider),
     connectivity: ref.watch(connectivityProvider),
   );
@@ -360,10 +416,16 @@ AuthSyncService authSyncService(Ref ref) => AuthSyncService(
   accountDao: ref.watch(accountDaoProvider),
   categoryDao: ref.watch(categoryDaoProvider),
   transactionDao: ref.watch(transactionDaoProvider),
+  budgetDao: ref.watch(budgetDaoProvider),
+  budgetInstanceDao: ref.watch(budgetInstanceDaoProvider),
   profileDao: ref.watch(profileDaoProvider),
   accountRemoteDataSource: ref.watch(accountRemoteDataSourceProvider),
   categoryRemoteDataSource: ref.watch(categoryRemoteDataSourceProvider),
   transactionRemoteDataSource: ref.watch(transactionRemoteDataSourceProvider),
+  budgetRemoteDataSource: ref.watch(budgetRemoteDataSourceProvider),
+  budgetInstanceRemoteDataSource: ref.watch(
+    budgetInstanceRemoteDataSourceProvider,
+  ),
   profileRemoteDataSource: ref.watch(profileRemoteDataSourceProvider),
   firestore: ref.watch(firestoreProvider),
   loggerService: ref.watch(loggerServiceProvider),

--- a/lib/core/di/injectors.g.dart
+++ b/lib/core/di/injectors.g.dart
@@ -511,6 +511,94 @@ final class TransactionDaoProvider
 
 String _$transactionDaoHash() => r'6dd75d3118f0e2e23be1b05fe5ebcee148e69f7f';
 
+@ProviderFor(budgetDao)
+const budgetDaoProvider = BudgetDaoProvider._();
+
+final class BudgetDaoProvider
+    extends $FunctionalProvider<BudgetDao, BudgetDao, BudgetDao>
+    with $Provider<BudgetDao> {
+  const BudgetDaoProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'budgetDaoProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$budgetDaoHash();
+
+  @$internal
+  @override
+  $ProviderElement<BudgetDao> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  BudgetDao create(Ref ref) {
+    return budgetDao(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(BudgetDao value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<BudgetDao>(value),
+    );
+  }
+}
+
+String _$budgetDaoHash() => r'6d271f84e0c1c8337fc10b0be34145e244e5d8d5';
+
+@ProviderFor(budgetInstanceDao)
+const budgetInstanceDaoProvider = BudgetInstanceDaoProvider._();
+
+final class BudgetInstanceDaoProvider
+    extends
+        $FunctionalProvider<
+          BudgetInstanceDao,
+          BudgetInstanceDao,
+          BudgetInstanceDao
+        >
+    with $Provider<BudgetInstanceDao> {
+  const BudgetInstanceDaoProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'budgetInstanceDaoProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$budgetInstanceDaoHash();
+
+  @$internal
+  @override
+  $ProviderElement<BudgetInstanceDao> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  BudgetInstanceDao create(Ref ref) {
+    return budgetInstanceDao(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(BudgetInstanceDao value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<BudgetInstanceDao>(value),
+    );
+  }
+}
+
+String _$budgetInstanceDaoHash() => r'f2ff161d2210b373bff95923b0810a8acb8f09bb';
+
 @ProviderFor(profileDao)
 const profileDaoProvider = ProfileDaoProvider._();
 
@@ -875,6 +963,47 @@ final class RecurringRuleEngineProvider
 String _$recurringRuleEngineHash() =>
     r'94d207ac7439ca6dcb8f24b9d37a5644705d6c6a';
 
+@ProviderFor(budgetSchedule)
+const budgetScheduleProvider = BudgetScheduleProvider._();
+
+final class BudgetScheduleProvider
+    extends $FunctionalProvider<BudgetSchedule, BudgetSchedule, BudgetSchedule>
+    with $Provider<BudgetSchedule> {
+  const BudgetScheduleProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'budgetScheduleProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$budgetScheduleHash();
+
+  @$internal
+  @override
+  $ProviderElement<BudgetSchedule> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  BudgetSchedule create(Ref ref) {
+    return budgetSchedule(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(BudgetSchedule value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<BudgetSchedule>(value),
+    );
+  }
+}
+
+String _$budgetScheduleHash() => r'dd4e864d9533d6685fa5d4333c2cad4cef43b5d1';
+
 @ProviderFor(accountRemoteDataSource)
 const accountRemoteDataSourceProvider = AccountRemoteDataSourceProvider._();
 
@@ -1068,6 +1197,105 @@ final class ProfileRemoteDataSourceProvider
 String _$profileRemoteDataSourceHash() =>
     r'45baf2527988bcc7389803c7cea36c9fa578effb';
 
+@ProviderFor(budgetRemoteDataSource)
+const budgetRemoteDataSourceProvider = BudgetRemoteDataSourceProvider._();
+
+final class BudgetRemoteDataSourceProvider
+    extends
+        $FunctionalProvider<
+          BudgetRemoteDataSource,
+          BudgetRemoteDataSource,
+          BudgetRemoteDataSource
+        >
+    with $Provider<BudgetRemoteDataSource> {
+  const BudgetRemoteDataSourceProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'budgetRemoteDataSourceProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$budgetRemoteDataSourceHash();
+
+  @$internal
+  @override
+  $ProviderElement<BudgetRemoteDataSource> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  BudgetRemoteDataSource create(Ref ref) {
+    return budgetRemoteDataSource(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(BudgetRemoteDataSource value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<BudgetRemoteDataSource>(value),
+    );
+  }
+}
+
+String _$budgetRemoteDataSourceHash() =>
+    r'f2f3bcea8c010c92da9b9f1dc18eaf363350c1da';
+
+@ProviderFor(budgetInstanceRemoteDataSource)
+const budgetInstanceRemoteDataSourceProvider =
+    BudgetInstanceRemoteDataSourceProvider._();
+
+final class BudgetInstanceRemoteDataSourceProvider
+    extends
+        $FunctionalProvider<
+          BudgetInstanceRemoteDataSource,
+          BudgetInstanceRemoteDataSource,
+          BudgetInstanceRemoteDataSource
+        >
+    with $Provider<BudgetInstanceRemoteDataSource> {
+  const BudgetInstanceRemoteDataSourceProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'budgetInstanceRemoteDataSourceProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$budgetInstanceRemoteDataSourceHash();
+
+  @$internal
+  @override
+  $ProviderElement<BudgetInstanceRemoteDataSource> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  BudgetInstanceRemoteDataSource create(Ref ref) {
+    return budgetInstanceRemoteDataSource(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(BudgetInstanceRemoteDataSource value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<BudgetInstanceRemoteDataSource>(
+        value,
+      ),
+    );
+  }
+}
+
+String _$budgetInstanceRemoteDataSourceHash() =>
+    r'a020e9c9816dcaffaf93de641281dc389b6c4a5d';
+
 @ProviderFor(recurringNotificationService)
 const recurringNotificationServiceProvider =
     RecurringNotificationServiceProvider._();
@@ -1258,6 +1486,198 @@ final class WatchAccountsUseCaseProvider
 
 String _$watchAccountsUseCaseHash() =>
     r'1e591c8756219ebead3e51c5a37138b7013df854';
+
+@ProviderFor(watchBudgetsUseCase)
+const watchBudgetsUseCaseProvider = WatchBudgetsUseCaseProvider._();
+
+final class WatchBudgetsUseCaseProvider
+    extends
+        $FunctionalProvider<
+          WatchBudgetsUseCase,
+          WatchBudgetsUseCase,
+          WatchBudgetsUseCase
+        >
+    with $Provider<WatchBudgetsUseCase> {
+  const WatchBudgetsUseCaseProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'watchBudgetsUseCaseProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$watchBudgetsUseCaseHash();
+
+  @$internal
+  @override
+  $ProviderElement<WatchBudgetsUseCase> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  WatchBudgetsUseCase create(Ref ref) {
+    return watchBudgetsUseCase(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(WatchBudgetsUseCase value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<WatchBudgetsUseCase>(value),
+    );
+  }
+}
+
+String _$watchBudgetsUseCaseHash() =>
+    r'2f2b4e2b4764abb13a5d62a06dad6ac899d28210';
+
+@ProviderFor(saveBudgetUseCase)
+const saveBudgetUseCaseProvider = SaveBudgetUseCaseProvider._();
+
+final class SaveBudgetUseCaseProvider
+    extends
+        $FunctionalProvider<
+          SaveBudgetUseCase,
+          SaveBudgetUseCase,
+          SaveBudgetUseCase
+        >
+    with $Provider<SaveBudgetUseCase> {
+  const SaveBudgetUseCaseProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'saveBudgetUseCaseProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$saveBudgetUseCaseHash();
+
+  @$internal
+  @override
+  $ProviderElement<SaveBudgetUseCase> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  SaveBudgetUseCase create(Ref ref) {
+    return saveBudgetUseCase(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(SaveBudgetUseCase value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<SaveBudgetUseCase>(value),
+    );
+  }
+}
+
+String _$saveBudgetUseCaseHash() => r'2b1ace00122d33da63c69892fc13e82f1323385e';
+
+@ProviderFor(deleteBudgetUseCase)
+const deleteBudgetUseCaseProvider = DeleteBudgetUseCaseProvider._();
+
+final class DeleteBudgetUseCaseProvider
+    extends
+        $FunctionalProvider<
+          DeleteBudgetUseCase,
+          DeleteBudgetUseCase,
+          DeleteBudgetUseCase
+        >
+    with $Provider<DeleteBudgetUseCase> {
+  const DeleteBudgetUseCaseProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'deleteBudgetUseCaseProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$deleteBudgetUseCaseHash();
+
+  @$internal
+  @override
+  $ProviderElement<DeleteBudgetUseCase> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  DeleteBudgetUseCase create(Ref ref) {
+    return deleteBudgetUseCase(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(DeleteBudgetUseCase value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<DeleteBudgetUseCase>(value),
+    );
+  }
+}
+
+String _$deleteBudgetUseCaseHash() =>
+    r'a6fb7a342d2508fdd4b4cf21c9db445192eb25d2';
+
+@ProviderFor(computeBudgetProgressUseCase)
+const computeBudgetProgressUseCaseProvider =
+    ComputeBudgetProgressUseCaseProvider._();
+
+final class ComputeBudgetProgressUseCaseProvider
+    extends
+        $FunctionalProvider<
+          ComputeBudgetProgressUseCase,
+          ComputeBudgetProgressUseCase,
+          ComputeBudgetProgressUseCase
+        >
+    with $Provider<ComputeBudgetProgressUseCase> {
+  const ComputeBudgetProgressUseCaseProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'computeBudgetProgressUseCaseProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$computeBudgetProgressUseCaseHash();
+
+  @$internal
+  @override
+  $ProviderElement<ComputeBudgetProgressUseCase> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  ComputeBudgetProgressUseCase create(Ref ref) {
+    return computeBudgetProgressUseCase(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(ComputeBudgetProgressUseCase value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<ComputeBudgetProgressUseCase>(value),
+    );
+  }
+}
+
+String _$computeBudgetProgressUseCaseHash() =>
+    r'6e959206f2a50fea51f6fda1927229c34dbd7a52';
 
 @ProviderFor(categoryRepository)
 const categoryRepositoryProvider = CategoryRepositoryProvider._();
@@ -1450,6 +1870,52 @@ final class TransactionRepositoryProvider
 
 String _$transactionRepositoryHash() =>
     r'3799c3525d6954f2ece515445c06171d0fba71ef';
+
+@ProviderFor(budgetRepository)
+const budgetRepositoryProvider = BudgetRepositoryProvider._();
+
+final class BudgetRepositoryProvider
+    extends
+        $FunctionalProvider<
+          BudgetRepository,
+          BudgetRepository,
+          BudgetRepository
+        >
+    with $Provider<BudgetRepository> {
+  const BudgetRepositoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'budgetRepositoryProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$budgetRepositoryHash();
+
+  @$internal
+  @override
+  $ProviderElement<BudgetRepository> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  BudgetRepository create(Ref ref) {
+    return budgetRepository(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(BudgetRepository value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<BudgetRepository>(value),
+    );
+  }
+}
+
+String _$budgetRepositoryHash() => r'04bad8edb2ea732d9f98e0e2c0bbcf28348162f3';
 
 @ProviderFor(recurringTransactionsRepository)
 const recurringTransactionsRepositoryProvider =
@@ -2278,7 +2744,7 @@ final class SyncServiceProvider
   }
 }
 
-String _$syncServiceHash() => r'3b1f8d33016de3a04b4396c8857479d15fdb495a';
+String _$syncServiceHash() => r'f93c4ee941a1783d4a3b7054cdc10e857120af73';
 
 @ProviderFor(authRepository)
 const authRepositoryProvider = AuthRepositoryProvider._();
@@ -2361,4 +2827,4 @@ final class AuthSyncServiceProvider
   }
 }
 
-String _$authSyncServiceHash() => r'a53d963aa290c2c23d1410c64da95d4089173caa';
+String _$authSyncServiceHash() => r'4149ebf6b09190bad7171152e6de60fda970ada9';

--- a/lib/features/app_shell/presentation/providers/main_navigation_tabs_provider.dart
+++ b/lib/features/app_shell/presentation/providers/main_navigation_tabs_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:kopim/features/analytics/presentation/analytics_screen.dart';
+import 'package:kopim/features/budgets/presentation/budgets_screen.dart';
 import 'package:kopim/features/home/presentation/screens/home_screen.dart';
 import 'package:kopim/features/profile/presentation/screens/profile_screen.dart';
 import 'package:kopim/l10n/app_localizations.dart';
@@ -25,6 +26,14 @@ final Provider<List<NavigationTabConfig>> mainNavigationTabsProvider =
           labelBuilder: (BuildContext context) =>
               AppLocalizations.of(context)!.homeNavAnalytics,
           contentBuilder: buildAnalyticsTabContent,
+        ),
+        NavigationTabConfig(
+          id: 'budgets',
+          icon: Icons.account_balance_wallet_outlined,
+          activeIcon: Icons.account_balance_wallet,
+          labelBuilder: (BuildContext context) =>
+              AppLocalizations.of(context)!.homeNavBudgets,
+          contentBuilder: buildBudgetsTabContent,
         ),
         NavigationTabConfig(
           id: 'settings',

--- a/lib/features/budgets/data/repositories/budget_repository_impl.dart
+++ b/lib/features/budgets/data/repositories/budget_repository_impl.dart
@@ -1,0 +1,137 @@
+import 'package:kopim/core/data/database.dart' as db;
+import 'package:kopim/core/data/outbox/outbox_dao.dart';
+import 'package:kopim/features/budgets/data/sources/local/budget_dao.dart';
+import 'package:kopim/features/budgets/domain/entities/budget.dart';
+import 'package:kopim/features/budgets/domain/entities/budget_instance.dart';
+import 'package:kopim/features/budgets/domain/repositories/budget_repository.dart';
+
+class BudgetRepositoryImpl implements BudgetRepository {
+  BudgetRepositoryImpl({
+    required db.AppDatabase database,
+    required BudgetDao budgetDao,
+    required BudgetInstanceDao budgetInstanceDao,
+    required OutboxDao outboxDao,
+  }) : _database = database,
+       _budgetDao = budgetDao,
+       _budgetInstanceDao = budgetInstanceDao,
+       _outboxDao = outboxDao;
+
+  final db.AppDatabase _database;
+  final BudgetDao _budgetDao;
+  final BudgetInstanceDao _budgetInstanceDao;
+  final OutboxDao _outboxDao;
+
+  static const String _budgetEntityType = 'budget';
+  static const String _instanceEntityType = 'budget_instance';
+
+  @override
+  Stream<List<Budget>> watchBudgets() {
+    return _budgetDao.watchActiveBudgets();
+  }
+
+  @override
+  Future<List<Budget>> loadBudgets() async {
+    return _budgetDao.getActiveBudgets();
+  }
+
+  @override
+  Future<Budget?> findById(String id) async {
+    return _budgetDao.findById(id);
+  }
+
+  @override
+  Future<void> upsert(Budget budget) async {
+    final DateTime now = DateTime.now();
+    final Budget toPersist = budget.copyWith(updatedAt: now);
+    await _database.transaction(() async {
+      await _budgetDao.upsert(toPersist);
+      await _outboxDao.enqueue(
+        entityType: _budgetEntityType,
+        entityId: toPersist.id,
+        operation: OutboxOperation.upsert,
+        payload: _mapBudgetPayload(toPersist),
+      );
+    });
+  }
+
+  @override
+  Future<void> softDelete(String id) async {
+    final DateTime now = DateTime.now();
+    await _database.transaction(() async {
+      await _budgetDao.markDeleted(id, now);
+      final Budget? budget = await _budgetDao.findById(id);
+      if (budget == null) {
+        return;
+      }
+      final Budget removed = budget.copyWith(isDeleted: true, updatedAt: now);
+      await _outboxDao.enqueue(
+        entityType: _budgetEntityType,
+        entityId: id,
+        operation: OutboxOperation.delete,
+        payload: _mapBudgetPayload(removed),
+      );
+      await _budgetInstanceDao.deleteByBudgetId(id);
+    });
+  }
+
+  @override
+  Stream<List<BudgetInstance>> watchInstances(String budgetId) {
+    return _budgetInstanceDao.watchByBudgetId(budgetId);
+  }
+
+  @override
+  Future<List<BudgetInstance>> loadInstances(String budgetId) async {
+    return _budgetInstanceDao.getByBudgetId(budgetId);
+  }
+
+  @override
+  Future<void> upsertInstance(BudgetInstance instance) async {
+    final DateTime now = DateTime.now();
+    final BudgetInstance toPersist = instance.copyWith(updatedAt: now);
+    await _database.transaction(() async {
+      await _budgetInstanceDao.upsert(toPersist);
+      await _outboxDao.enqueue(
+        entityType: _instanceEntityType,
+        entityId: toPersist.id,
+        operation: OutboxOperation.upsert,
+        payload: _mapInstancePayload(toPersist),
+      );
+    });
+  }
+
+  @override
+  Future<void> deleteInstance(String id) async {
+    final BudgetInstance? instance = await _budgetInstanceDao.findById(id);
+    if (instance == null) {
+      return;
+    }
+    final DateTime now = DateTime.now();
+    await _database.transaction(() async {
+      await _budgetInstanceDao.deleteById(id);
+      await _outboxDao.enqueue(
+        entityType: _instanceEntityType,
+        entityId: id,
+        operation: OutboxOperation.delete,
+        payload: _mapInstancePayload(instance.copyWith(updatedAt: now)),
+      );
+    });
+  }
+
+  Map<String, dynamic> _mapBudgetPayload(Budget budget) {
+    final Map<String, dynamic> json = budget.toJson();
+    json['startDate'] = budget.startDate.toIso8601String();
+    json['endDate'] = budget.endDate?.toIso8601String();
+    json['createdAt'] = budget.createdAt.toIso8601String();
+    json['updatedAt'] = budget.updatedAt.toIso8601String();
+    return json;
+  }
+
+  Map<String, dynamic> _mapInstancePayload(BudgetInstance instance) {
+    final Map<String, dynamic> json = instance.toJson();
+    json['periodStart'] = instance.periodStart.toIso8601String();
+    json['periodEnd'] = instance.periodEnd.toIso8601String();
+    json['createdAt'] = instance.createdAt.toIso8601String();
+    json['updatedAt'] = instance.updatedAt.toIso8601String();
+    return json;
+  }
+}

--- a/lib/features/budgets/data/sources/local/budget_dao.dart
+++ b/lib/features/budgets/data/sources/local/budget_dao.dart
@@ -1,0 +1,227 @@
+import 'package:drift/drift.dart';
+import 'package:kopim/core/data/database.dart' as db;
+import 'package:kopim/features/budgets/domain/entities/budget.dart';
+import 'package:kopim/features/budgets/domain/entities/budget_instance.dart';
+import 'package:kopim/features/budgets/domain/entities/budget_instance_status.dart';
+import 'package:kopim/features/budgets/domain/entities/budget_period.dart';
+import 'package:kopim/features/budgets/domain/entities/budget_scope.dart';
+
+class BudgetDao {
+  BudgetDao(this._db);
+
+  final db.AppDatabase _db;
+
+  Stream<List<Budget>> watchActiveBudgets() {
+    final SimpleSelectStatement<db.$BudgetsTable, db.BudgetRow> query =
+        _db.select(_db.budgets)
+          ..where((db.$BudgetsTable tbl) => tbl.isDeleted.equals(false))
+          ..orderBy(<OrderClauseGenerator<db.$BudgetsTable>>[
+            (db.$BudgetsTable tbl) => OrderingTerm(
+              expression: tbl.createdAt,
+              mode: OrderingMode.desc,
+            ),
+          ]);
+    return query.watch().map(
+      (List<db.BudgetRow> rows) =>
+          rows.map(_mapBudgetRow).toList(growable: false),
+    );
+  }
+
+  Future<List<Budget>> getActiveBudgets() async {
+    final SimpleSelectStatement<db.$BudgetsTable, db.BudgetRow> query =
+        _db.select(_db.budgets)
+          ..where((db.$BudgetsTable tbl) => tbl.isDeleted.equals(false))
+          ..orderBy(<OrderClauseGenerator<db.$BudgetsTable>>[
+            (db.$BudgetsTable tbl) => OrderingTerm(
+              expression: tbl.createdAt,
+              mode: OrderingMode.desc,
+            ),
+          ]);
+    final List<db.BudgetRow> rows = await query.get();
+    return rows.map(_mapBudgetRow).toList(growable: false);
+  }
+
+  Future<Budget?> findById(String id) async {
+    final SimpleSelectStatement<db.$BudgetsTable, db.BudgetRow> query =
+        _db.select(_db.budgets)
+          ..where((db.$BudgetsTable tbl) => tbl.id.equals(id));
+    final db.BudgetRow? row = await query.getSingleOrNull();
+    if (row == null) {
+      return null;
+    }
+    return _mapBudgetRow(row);
+  }
+
+  Future<List<Budget>> getAllBudgets() async {
+    final List<db.BudgetRow> rows = await _db.select(_db.budgets).get();
+    return rows.map(_mapBudgetRow).toList(growable: false);
+  }
+
+  Future<void> upsert(Budget budget) {
+    return _db
+        .into(_db.budgets)
+        .insertOnConflictUpdate(_mapBudgetToCompanion(budget));
+  }
+
+  Future<void> upsertAll(List<Budget> budgets) async {
+    if (budgets.isEmpty) return;
+    await _db.batch((Batch batch) {
+      batch.insertAllOnConflictUpdate(
+        _db.budgets,
+        budgets.map(_mapBudgetToCompanion).toList(growable: false),
+      );
+    });
+  }
+
+  Future<void> markDeleted(String id, DateTime deletedAt) {
+    return (_db.update(
+      _db.budgets,
+    )..where((db.$BudgetsTable tbl) => tbl.id.equals(id))).write(
+      db.BudgetsCompanion(
+        isDeleted: const Value<bool>(true),
+        updatedAt: Value<DateTime>(deletedAt),
+      ),
+    );
+  }
+
+  db.BudgetsCompanion _mapBudgetToCompanion(Budget budget) {
+    return db.BudgetsCompanion(
+      id: Value<String>(budget.id),
+      title: Value<String>(budget.title),
+      period: Value<String>(budget.period.storageValue),
+      startDate: Value<DateTime>(budget.startDate),
+      endDate: Value<DateTime?>(budget.endDate),
+      amount: Value<double>(budget.amount),
+      scope: Value<String>(budget.scope.storageValue),
+      categories: Value<List<String>>(budget.categories),
+      accounts: Value<List<String>>(budget.accounts),
+      createdAt: Value<DateTime>(budget.createdAt),
+      updatedAt: Value<DateTime>(budget.updatedAt),
+      isDeleted: Value<bool>(budget.isDeleted),
+    );
+  }
+
+  Budget _mapBudgetRow(db.BudgetRow row) {
+    return Budget(
+      id: row.id,
+      title: row.title,
+      period: BudgetPeriodX.fromStorage(row.period),
+      startDate: row.startDate,
+      endDate: row.endDate,
+      amount: row.amount,
+      scope: BudgetScopeX.fromStorage(row.scope),
+      categories: row.categories,
+      accounts: row.accounts,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+      isDeleted: row.isDeleted,
+    );
+  }
+}
+
+class BudgetInstanceDao {
+  BudgetInstanceDao(this._db);
+
+  final db.AppDatabase _db;
+
+  Stream<List<BudgetInstance>> watchByBudgetId(String budgetId) {
+    final SimpleSelectStatement<db.$BudgetInstancesTable, db.BudgetInstanceRow>
+    query = _db.select(_db.budgetInstances)
+      ..where((db.$BudgetInstancesTable tbl) => tbl.budgetId.equals(budgetId))
+      ..orderBy(<OrderClauseGenerator<db.$BudgetInstancesTable>>[
+        (db.$BudgetInstancesTable tbl) =>
+            OrderingTerm(expression: tbl.periodStart, mode: OrderingMode.asc),
+      ]);
+    return query.watch().map(
+      (List<db.BudgetInstanceRow> rows) =>
+          rows.map(_mapInstanceRow).toList(growable: false),
+    );
+  }
+
+  Future<List<BudgetInstance>> getByBudgetId(String budgetId) async {
+    final SimpleSelectStatement<db.$BudgetInstancesTable, db.BudgetInstanceRow>
+    query = _db.select(_db.budgetInstances)
+      ..where((db.$BudgetInstancesTable tbl) => tbl.budgetId.equals(budgetId))
+      ..orderBy(<OrderClauseGenerator<db.$BudgetInstancesTable>>[
+        (db.$BudgetInstancesTable tbl) =>
+            OrderingTerm(expression: tbl.periodStart, mode: OrderingMode.asc),
+      ]);
+    final List<db.BudgetInstanceRow> rows = await query.get();
+    return rows.map(_mapInstanceRow).toList(growable: false);
+  }
+
+  Future<BudgetInstance?> findById(String id) async {
+    final SimpleSelectStatement<db.$BudgetInstancesTable, db.BudgetInstanceRow>
+    query = _db.select(_db.budgetInstances)
+      ..where((db.$BudgetInstancesTable tbl) => tbl.id.equals(id));
+    final db.BudgetInstanceRow? row = await query.getSingleOrNull();
+    if (row == null) {
+      return null;
+    }
+    return _mapInstanceRow(row);
+  }
+
+  Future<List<BudgetInstance>> getAllInstances() async {
+    final List<db.BudgetInstanceRow> rows = await _db
+        .select(_db.budgetInstances)
+        .get();
+    return rows.map(_mapInstanceRow).toList(growable: false);
+  }
+
+  Future<void> upsert(BudgetInstance instance) {
+    return _db
+        .into(_db.budgetInstances)
+        .insertOnConflictUpdate(_mapInstanceToCompanion(instance));
+  }
+
+  Future<void> upsertAll(List<BudgetInstance> instances) async {
+    if (instances.isEmpty) return;
+    await _db.batch((Batch batch) {
+      batch.insertAllOnConflictUpdate(
+        _db.budgetInstances,
+        instances.map(_mapInstanceToCompanion).toList(growable: false),
+      );
+    });
+  }
+
+  Future<void> deleteById(String id) {
+    return (_db.delete(
+      _db.budgetInstances,
+    )..where((db.$BudgetInstancesTable tbl) => tbl.id.equals(id))).go();
+  }
+
+  Future<void> deleteByBudgetId(String budgetId) {
+    return (_db.delete(_db.budgetInstances)..where(
+          (db.$BudgetInstancesTable tbl) => tbl.budgetId.equals(budgetId),
+        ))
+        .go();
+  }
+
+  db.BudgetInstancesCompanion _mapInstanceToCompanion(BudgetInstance instance) {
+    return db.BudgetInstancesCompanion(
+      id: Value<String>(instance.id),
+      budgetId: Value<String>(instance.budgetId),
+      periodStart: Value<DateTime>(instance.periodStart),
+      periodEnd: Value<DateTime>(instance.periodEnd),
+      amount: Value<double>(instance.amount),
+      spent: Value<double>(instance.spent),
+      status: Value<String>(instance.status.storageValue),
+      createdAt: Value<DateTime>(instance.createdAt),
+      updatedAt: Value<DateTime>(instance.updatedAt),
+    );
+  }
+
+  BudgetInstance _mapInstanceRow(db.BudgetInstanceRow row) {
+    return BudgetInstance(
+      id: row.id,
+      budgetId: row.budgetId,
+      periodStart: row.periodStart,
+      periodEnd: row.periodEnd,
+      amount: row.amount,
+      spent: row.spent,
+      status: BudgetInstanceStatusX.fromStorage(row.status),
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    );
+  }
+}

--- a/lib/features/budgets/data/sources/remote/budget_instance_remote_data_source.dart
+++ b/lib/features/budgets/data/sources/remote/budget_instance_remote_data_source.dart
@@ -1,0 +1,112 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:kopim/features/budgets/domain/entities/budget_instance.dart';
+import 'package:kopim/features/budgets/domain/entities/budget_instance_status.dart';
+
+class BudgetInstanceRemoteDataSource {
+  BudgetInstanceRemoteDataSource(this._firestore);
+
+  final FirebaseFirestore _firestore;
+
+  CollectionReference<Map<String, dynamic>> _collection(String userId) {
+    return _firestore
+        .collection('users')
+        .doc(userId)
+        .collection('budget_instances');
+  }
+
+  DocumentReference<Map<String, dynamic>> _doc(String userId, String id) {
+    return _collection(userId).doc(id);
+  }
+
+  Future<void> upsert(String userId, BudgetInstance instance) {
+    return _doc(
+      userId,
+      instance.id,
+    ).set(_mapInstance(instance), SetOptions(merge: true));
+  }
+
+  Future<void> delete(String userId, BudgetInstance instance) {
+    return _doc(userId, instance.id).set(<String, dynamic>{
+      'id': instance.id,
+      'deleted': true,
+      'updatedAt': Timestamp.fromDate(instance.updatedAt.toUtc()),
+    }, SetOptions(merge: true));
+  }
+
+  void upsertInTransaction(
+    Transaction transaction,
+    String userId,
+    BudgetInstance instance,
+  ) {
+    transaction.set(
+      _doc(userId, instance.id),
+      _mapInstance(instance),
+      SetOptions(merge: true),
+    );
+  }
+
+  void deleteInTransaction(
+    Transaction transaction,
+    String userId,
+    BudgetInstance instance,
+  ) {
+    transaction.set(_doc(userId, instance.id), <String, dynamic>{
+      'id': instance.id,
+      'deleted': true,
+      'updatedAt': Timestamp.fromDate(instance.updatedAt.toUtc()),
+    }, SetOptions(merge: true));
+  }
+
+  Future<List<BudgetInstance>> fetchAll(String userId) async {
+    final QuerySnapshot<Map<String, dynamic>> snapshot = await _collection(
+      userId,
+    ).get();
+    return snapshot.docs.map(_fromDocument).toList();
+  }
+
+  Map<String, dynamic> _mapInstance(BudgetInstance instance) {
+    return <String, dynamic>{
+      'id': instance.id,
+      'budgetId': instance.budgetId,
+      'periodStart': Timestamp.fromDate(instance.periodStart.toUtc()),
+      'periodEnd': Timestamp.fromDate(instance.periodEnd.toUtc()),
+      'amount': instance.amount,
+      'spent': instance.spent,
+      'status': instance.status.storageValue,
+      'createdAt': Timestamp.fromDate(instance.createdAt.toUtc()),
+      'updatedAt': Timestamp.fromDate(instance.updatedAt.toUtc()),
+      'deleted': false,
+    }..removeWhere((String key, Object? value) => value == null);
+  }
+
+  BudgetInstance _fromDocument(
+    QueryDocumentSnapshot<Map<String, dynamic>> doc,
+  ) {
+    final Map<String, dynamic> data = doc.data();
+    final bool deleted = data['deleted'] as bool? ?? false;
+    final BudgetInstanceStatus status = deleted
+        ? BudgetInstanceStatus.closed
+        : BudgetInstanceStatusX.fromStorage(data['status'] as String?);
+    return BudgetInstance(
+      id: data['id'] as String? ?? doc.id,
+      budgetId: data['budgetId'] as String? ?? '',
+      periodStart: _parseTimestamp(data['periodStart']),
+      periodEnd: _parseTimestamp(data['periodEnd']),
+      amount: (data['amount'] as num?)?.toDouble() ?? 0,
+      spent: (data['spent'] as num?)?.toDouble() ?? 0,
+      status: status,
+      createdAt: _parseTimestamp(data['createdAt']),
+      updatedAt: _parseTimestamp(data['updatedAt']),
+    );
+  }
+
+  DateTime _parseTimestamp(Object? value) {
+    if (value is Timestamp) {
+      return value.toDate().toUtc();
+    }
+    if (value is DateTime) {
+      return value.toUtc();
+    }
+    return DateTime.now().toUtc();
+  }
+}

--- a/lib/features/budgets/data/sources/remote/budget_remote_data_source.dart
+++ b/lib/features/budgets/data/sources/remote/budget_remote_data_source.dart
@@ -1,0 +1,126 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:kopim/features/budgets/domain/entities/budget.dart';
+import 'package:kopim/features/budgets/domain/entities/budget_period.dart';
+import 'package:kopim/features/budgets/domain/entities/budget_scope.dart';
+
+class BudgetRemoteDataSource {
+  BudgetRemoteDataSource(this._firestore);
+
+  final FirebaseFirestore _firestore;
+
+  CollectionReference<Map<String, dynamic>> _collection(String userId) {
+    return _firestore.collection('users').doc(userId).collection('budgets');
+  }
+
+  DocumentReference<Map<String, dynamic>> _doc(String userId, String id) {
+    return _collection(userId).doc(id);
+  }
+
+  Future<void> upsert(String userId, Budget budget) {
+    return _doc(
+      userId,
+      budget.id,
+    ).set(_mapBudget(budget), SetOptions(merge: true));
+  }
+
+  Future<void> delete(String userId, Budget budget) {
+    return _doc(userId, budget.id).set(
+      _mapBudget(budget.copyWith(isDeleted: true)),
+      SetOptions(merge: true),
+    );
+  }
+
+  void upsertInTransaction(
+    Transaction transaction,
+    String userId,
+    Budget budget,
+  ) {
+    transaction.set(
+      _doc(userId, budget.id),
+      _mapBudget(budget),
+      SetOptions(merge: true),
+    );
+  }
+
+  void deleteInTransaction(
+    Transaction transaction,
+    String userId,
+    Budget budget,
+  ) {
+    transaction.set(
+      _doc(userId, budget.id),
+      _mapBudget(budget.copyWith(isDeleted: true)),
+      SetOptions(merge: true),
+    );
+  }
+
+  Future<List<Budget>> fetchAll(String userId) async {
+    final QuerySnapshot<Map<String, dynamic>> snapshot = await _collection(
+      userId,
+    ).get();
+    return snapshot.docs.map(_fromDocument).toList();
+  }
+
+  Map<String, dynamic> _mapBudget(Budget budget) {
+    return <String, dynamic>{
+      'id': budget.id,
+      'title': budget.title,
+      'period': budget.period.storageValue,
+      'startDate': Timestamp.fromDate(budget.startDate.toUtc()),
+      'endDate': budget.endDate != null
+          ? Timestamp.fromDate(budget.endDate!.toUtc())
+          : null,
+      'amount': budget.amount,
+      'scope': budget.scope.storageValue,
+      'categories': budget.categories,
+      'accounts': budget.accounts,
+      'createdAt': Timestamp.fromDate(budget.createdAt.toUtc()),
+      'updatedAt': Timestamp.fromDate(budget.updatedAt.toUtc()),
+      'isDeleted': budget.isDeleted,
+    }..removeWhere((String key, Object? value) => value == null);
+  }
+
+  Budget _fromDocument(QueryDocumentSnapshot<Map<String, dynamic>> doc) {
+    final Map<String, dynamic> data = doc.data();
+    return Budget(
+      id: data['id'] as String? ?? doc.id,
+      title: data['title'] as String? ?? '',
+      period: BudgetPeriodX.fromStorage(data['period'] as String?),
+      startDate: _parseTimestamp(data['startDate']),
+      endDate: _parseOptionalTimestamp(data['endDate']),
+      amount: (data['amount'] as num?)?.toDouble() ?? 0,
+      scope: BudgetScopeX.fromStorage(data['scope'] as String?),
+      categories: _parseStringList(data['categories']),
+      accounts: _parseStringList(data['accounts']),
+      createdAt: _parseTimestamp(data['createdAt']),
+      updatedAt: _parseTimestamp(data['updatedAt']),
+      isDeleted: data['isDeleted'] as bool? ?? false,
+    );
+  }
+
+  DateTime _parseTimestamp(Object? value) {
+    if (value is Timestamp) {
+      return value.toDate().toUtc();
+    }
+    if (value is DateTime) {
+      return value.toUtc();
+    }
+    return DateTime.now().toUtc();
+  }
+
+  DateTime? _parseOptionalTimestamp(Object? value) {
+    if (value == null) return null;
+    return _parseTimestamp(value);
+  }
+
+  List<String> _parseStringList(Object? value) {
+    if (value is Iterable) {
+      return value
+          .whereType<Object?>()
+          .map((Object? item) => item?.toString() ?? '')
+          .where((String item) => item.isNotEmpty)
+          .toList();
+    }
+    return const <String>[];
+  }
+}

--- a/lib/features/budgets/domain/entities/budget.dart
+++ b/lib/features/budgets/domain/entities/budget.dart
@@ -1,0 +1,35 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'budget_period.dart';
+import 'budget_scope.dart';
+
+part 'budget.freezed.dart';
+part 'budget.g.dart';
+
+@freezed
+abstract class Budget with _$Budget {
+  const Budget._();
+
+  const factory Budget({
+    required String id,
+    required String title,
+    @JsonKey(fromJson: BudgetPeriodX.fromStorage, toJson: _periodToJson)
+    required BudgetPeriod period,
+    required DateTime startDate,
+    DateTime? endDate,
+    required double amount,
+    @JsonKey(fromJson: BudgetScopeX.fromStorage, toJson: _scopeToJson)
+    required BudgetScope scope,
+    @Default(<String>[]) List<String> categories,
+    @Default(<String>[]) List<String> accounts,
+    required DateTime createdAt,
+    required DateTime updatedAt,
+    @Default(false) bool isDeleted,
+  }) = _Budget;
+
+  factory Budget.fromJson(Map<String, Object?> json) => _$BudgetFromJson(json);
+}
+
+String _periodToJson(BudgetPeriod period) => period.storageValue;
+
+String _scopeToJson(BudgetScope scope) => scope.storageValue;

--- a/lib/features/budgets/domain/entities/budget.freezed.dart
+++ b/lib/features/budgets/domain/entities/budget.freezed.dart
@@ -1,0 +1,322 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'budget.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$Budget {
+
+ String get id; String get title;@JsonKey(fromJson: BudgetPeriodX.fromStorage, toJson: _periodToJson) BudgetPeriod get period; DateTime get startDate; DateTime? get endDate; double get amount;@JsonKey(fromJson: BudgetScopeX.fromStorage, toJson: _scopeToJson) BudgetScope get scope; List<String> get categories; List<String> get accounts; DateTime get createdAt; DateTime get updatedAt; bool get isDeleted;
+/// Create a copy of Budget
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$BudgetCopyWith<Budget> get copyWith => _$BudgetCopyWithImpl<Budget>(this as Budget, _$identity);
+
+  /// Serializes this Budget to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Budget&&(identical(other.id, id) || other.id == id)&&(identical(other.title, title) || other.title == title)&&(identical(other.period, period) || other.period == period)&&(identical(other.startDate, startDate) || other.startDate == startDate)&&(identical(other.endDate, endDate) || other.endDate == endDate)&&(identical(other.amount, amount) || other.amount == amount)&&(identical(other.scope, scope) || other.scope == scope)&&const DeepCollectionEquality().equals(other.categories, categories)&&const DeepCollectionEquality().equals(other.accounts, accounts)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.isDeleted, isDeleted) || other.isDeleted == isDeleted));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,title,period,startDate,endDate,amount,scope,const DeepCollectionEquality().hash(categories),const DeepCollectionEquality().hash(accounts),createdAt,updatedAt,isDeleted);
+
+@override
+String toString() {
+  return 'Budget(id: $id, title: $title, period: $period, startDate: $startDate, endDate: $endDate, amount: $amount, scope: $scope, categories: $categories, accounts: $accounts, createdAt: $createdAt, updatedAt: $updatedAt, isDeleted: $isDeleted)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $BudgetCopyWith<$Res>  {
+  factory $BudgetCopyWith(Budget value, $Res Function(Budget) _then) = _$BudgetCopyWithImpl;
+@useResult
+$Res call({
+ String id, String title,@JsonKey(fromJson: BudgetPeriodX.fromStorage, toJson: _periodToJson) BudgetPeriod period, DateTime startDate, DateTime? endDate, double amount,@JsonKey(fromJson: BudgetScopeX.fromStorage, toJson: _scopeToJson) BudgetScope scope, List<String> categories, List<String> accounts, DateTime createdAt, DateTime updatedAt, bool isDeleted
+});
+
+
+
+
+}
+/// @nodoc
+class _$BudgetCopyWithImpl<$Res>
+    implements $BudgetCopyWith<$Res> {
+  _$BudgetCopyWithImpl(this._self, this._then);
+
+  final Budget _self;
+  final $Res Function(Budget) _then;
+
+/// Create a copy of Budget
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? title = null,Object? period = null,Object? startDate = null,Object? endDate = freezed,Object? amount = null,Object? scope = null,Object? categories = null,Object? accounts = null,Object? createdAt = null,Object? updatedAt = null,Object? isDeleted = null,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,period: null == period ? _self.period : period // ignore: cast_nullable_to_non_nullable
+as BudgetPeriod,startDate: null == startDate ? _self.startDate : startDate // ignore: cast_nullable_to_non_nullable
+as DateTime,endDate: freezed == endDate ? _self.endDate : endDate // ignore: cast_nullable_to_non_nullable
+as DateTime?,amount: null == amount ? _self.amount : amount // ignore: cast_nullable_to_non_nullable
+as double,scope: null == scope ? _self.scope : scope // ignore: cast_nullable_to_non_nullable
+as BudgetScope,categories: null == categories ? _self.categories : categories // ignore: cast_nullable_to_non_nullable
+as List<String>,accounts: null == accounts ? _self.accounts : accounts // ignore: cast_nullable_to_non_nullable
+as List<String>,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,isDeleted: null == isDeleted ? _self.isDeleted : isDeleted // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [Budget].
+extension BudgetPatterns on Budget {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Budget value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Budget() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Budget value)  $default,){
+final _that = this;
+switch (_that) {
+case _Budget():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Budget value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Budget() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String title, @JsonKey(fromJson: BudgetPeriodX.fromStorage, toJson: _periodToJson)  BudgetPeriod period,  DateTime startDate,  DateTime? endDate,  double amount, @JsonKey(fromJson: BudgetScopeX.fromStorage, toJson: _scopeToJson)  BudgetScope scope,  List<String> categories,  List<String> accounts,  DateTime createdAt,  DateTime updatedAt,  bool isDeleted)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Budget() when $default != null:
+return $default(_that.id,_that.title,_that.period,_that.startDate,_that.endDate,_that.amount,_that.scope,_that.categories,_that.accounts,_that.createdAt,_that.updatedAt,_that.isDeleted);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String title, @JsonKey(fromJson: BudgetPeriodX.fromStorage, toJson: _periodToJson)  BudgetPeriod period,  DateTime startDate,  DateTime? endDate,  double amount, @JsonKey(fromJson: BudgetScopeX.fromStorage, toJson: _scopeToJson)  BudgetScope scope,  List<String> categories,  List<String> accounts,  DateTime createdAt,  DateTime updatedAt,  bool isDeleted)  $default,) {final _that = this;
+switch (_that) {
+case _Budget():
+return $default(_that.id,_that.title,_that.period,_that.startDate,_that.endDate,_that.amount,_that.scope,_that.categories,_that.accounts,_that.createdAt,_that.updatedAt,_that.isDeleted);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String title, @JsonKey(fromJson: BudgetPeriodX.fromStorage, toJson: _periodToJson)  BudgetPeriod period,  DateTime startDate,  DateTime? endDate,  double amount, @JsonKey(fromJson: BudgetScopeX.fromStorage, toJson: _scopeToJson)  BudgetScope scope,  List<String> categories,  List<String> accounts,  DateTime createdAt,  DateTime updatedAt,  bool isDeleted)?  $default,) {final _that = this;
+switch (_that) {
+case _Budget() when $default != null:
+return $default(_that.id,_that.title,_that.period,_that.startDate,_that.endDate,_that.amount,_that.scope,_that.categories,_that.accounts,_that.createdAt,_that.updatedAt,_that.isDeleted);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _Budget extends Budget {
+  const _Budget({required this.id, required this.title, @JsonKey(fromJson: BudgetPeriodX.fromStorage, toJson: _periodToJson) required this.period, required this.startDate, this.endDate, required this.amount, @JsonKey(fromJson: BudgetScopeX.fromStorage, toJson: _scopeToJson) required this.scope, final  List<String> categories = const <String>[], final  List<String> accounts = const <String>[], required this.createdAt, required this.updatedAt, this.isDeleted = false}): _categories = categories,_accounts = accounts,super._();
+  factory _Budget.fromJson(Map<String, dynamic> json) => _$BudgetFromJson(json);
+
+@override final  String id;
+@override final  String title;
+@override@JsonKey(fromJson: BudgetPeriodX.fromStorage, toJson: _periodToJson) final  BudgetPeriod period;
+@override final  DateTime startDate;
+@override final  DateTime? endDate;
+@override final  double amount;
+@override@JsonKey(fromJson: BudgetScopeX.fromStorage, toJson: _scopeToJson) final  BudgetScope scope;
+ final  List<String> _categories;
+@override@JsonKey() List<String> get categories {
+  if (_categories is EqualUnmodifiableListView) return _categories;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_categories);
+}
+
+ final  List<String> _accounts;
+@override@JsonKey() List<String> get accounts {
+  if (_accounts is EqualUnmodifiableListView) return _accounts;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_accounts);
+}
+
+@override final  DateTime createdAt;
+@override final  DateTime updatedAt;
+@override@JsonKey() final  bool isDeleted;
+
+/// Create a copy of Budget
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$BudgetCopyWith<_Budget> get copyWith => __$BudgetCopyWithImpl<_Budget>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$BudgetToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Budget&&(identical(other.id, id) || other.id == id)&&(identical(other.title, title) || other.title == title)&&(identical(other.period, period) || other.period == period)&&(identical(other.startDate, startDate) || other.startDate == startDate)&&(identical(other.endDate, endDate) || other.endDate == endDate)&&(identical(other.amount, amount) || other.amount == amount)&&(identical(other.scope, scope) || other.scope == scope)&&const DeepCollectionEquality().equals(other._categories, _categories)&&const DeepCollectionEquality().equals(other._accounts, _accounts)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.isDeleted, isDeleted) || other.isDeleted == isDeleted));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,title,period,startDate,endDate,amount,scope,const DeepCollectionEquality().hash(_categories),const DeepCollectionEquality().hash(_accounts),createdAt,updatedAt,isDeleted);
+
+@override
+String toString() {
+  return 'Budget(id: $id, title: $title, period: $period, startDate: $startDate, endDate: $endDate, amount: $amount, scope: $scope, categories: $categories, accounts: $accounts, createdAt: $createdAt, updatedAt: $updatedAt, isDeleted: $isDeleted)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$BudgetCopyWith<$Res> implements $BudgetCopyWith<$Res> {
+  factory _$BudgetCopyWith(_Budget value, $Res Function(_Budget) _then) = __$BudgetCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, String title,@JsonKey(fromJson: BudgetPeriodX.fromStorage, toJson: _periodToJson) BudgetPeriod period, DateTime startDate, DateTime? endDate, double amount,@JsonKey(fromJson: BudgetScopeX.fromStorage, toJson: _scopeToJson) BudgetScope scope, List<String> categories, List<String> accounts, DateTime createdAt, DateTime updatedAt, bool isDeleted
+});
+
+
+
+
+}
+/// @nodoc
+class __$BudgetCopyWithImpl<$Res>
+    implements _$BudgetCopyWith<$Res> {
+  __$BudgetCopyWithImpl(this._self, this._then);
+
+  final _Budget _self;
+  final $Res Function(_Budget) _then;
+
+/// Create a copy of Budget
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? title = null,Object? period = null,Object? startDate = null,Object? endDate = freezed,Object? amount = null,Object? scope = null,Object? categories = null,Object? accounts = null,Object? createdAt = null,Object? updatedAt = null,Object? isDeleted = null,}) {
+  return _then(_Budget(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,period: null == period ? _self.period : period // ignore: cast_nullable_to_non_nullable
+as BudgetPeriod,startDate: null == startDate ? _self.startDate : startDate // ignore: cast_nullable_to_non_nullable
+as DateTime,endDate: freezed == endDate ? _self.endDate : endDate // ignore: cast_nullable_to_non_nullable
+as DateTime?,amount: null == amount ? _self.amount : amount // ignore: cast_nullable_to_non_nullable
+as double,scope: null == scope ? _self.scope : scope // ignore: cast_nullable_to_non_nullable
+as BudgetScope,categories: null == categories ? _self._categories : categories // ignore: cast_nullable_to_non_nullable
+as List<String>,accounts: null == accounts ? _self._accounts : accounts // ignore: cast_nullable_to_non_nullable
+as List<String>,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,isDeleted: null == isDeleted ? _self.isDeleted : isDeleted // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/features/budgets/domain/entities/budget.g.dart
+++ b/lib/features/budgets/domain/entities/budget.g.dart
@@ -1,0 +1,45 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'budget.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_Budget _$BudgetFromJson(Map<String, dynamic> json) => _Budget(
+  id: json['id'] as String,
+  title: json['title'] as String,
+  period: BudgetPeriodX.fromStorage(json['period'] as String?),
+  startDate: DateTime.parse(json['startDate'] as String),
+  endDate: json['endDate'] == null
+      ? null
+      : DateTime.parse(json['endDate'] as String),
+  amount: (json['amount'] as num).toDouble(),
+  scope: BudgetScopeX.fromStorage(json['scope'] as String?),
+  categories:
+      (json['categories'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList() ??
+      const <String>[],
+  accounts:
+      (json['accounts'] as List<dynamic>?)?.map((e) => e as String).toList() ??
+      const <String>[],
+  createdAt: DateTime.parse(json['createdAt'] as String),
+  updatedAt: DateTime.parse(json['updatedAt'] as String),
+  isDeleted: json['isDeleted'] as bool? ?? false,
+);
+
+Map<String, dynamic> _$BudgetToJson(_Budget instance) => <String, dynamic>{
+  'id': instance.id,
+  'title': instance.title,
+  'period': _periodToJson(instance.period),
+  'startDate': instance.startDate.toIso8601String(),
+  'endDate': instance.endDate?.toIso8601String(),
+  'amount': instance.amount,
+  'scope': _scopeToJson(instance.scope),
+  'categories': instance.categories,
+  'accounts': instance.accounts,
+  'createdAt': instance.createdAt.toIso8601String(),
+  'updatedAt': instance.updatedAt.toIso8601String(),
+  'isDeleted': instance.isDeleted,
+};

--- a/lib/features/budgets/domain/entities/budget_instance.dart
+++ b/lib/features/budgets/domain/entities/budget_instance.dart
@@ -1,0 +1,29 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'budget_instance_status.dart';
+
+part 'budget_instance.freezed.dart';
+part 'budget_instance.g.dart';
+
+@freezed
+abstract class BudgetInstance with _$BudgetInstance {
+  const BudgetInstance._();
+
+  const factory BudgetInstance({
+    required String id,
+    required String budgetId,
+    required DateTime periodStart,
+    required DateTime periodEnd,
+    required double amount,
+    @Default(0.0) double spent,
+    @JsonKey(fromJson: BudgetInstanceStatusX.fromStorage, toJson: _statusToJson)
+    required BudgetInstanceStatus status,
+    required DateTime createdAt,
+    required DateTime updatedAt,
+  }) = _BudgetInstance;
+
+  factory BudgetInstance.fromJson(Map<String, Object?> json) =>
+      _$BudgetInstanceFromJson(json);
+}
+
+String _statusToJson(BudgetInstanceStatus status) => status.storageValue;

--- a/lib/features/budgets/domain/entities/budget_instance.freezed.dart
+++ b/lib/features/budgets/domain/entities/budget_instance.freezed.dart
@@ -1,0 +1,301 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'budget_instance.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$BudgetInstance {
+
+ String get id; String get budgetId; DateTime get periodStart; DateTime get periodEnd; double get amount; double get spent;@JsonKey(fromJson: BudgetInstanceStatusX.fromStorage, toJson: _statusToJson) BudgetInstanceStatus get status; DateTime get createdAt; DateTime get updatedAt;
+/// Create a copy of BudgetInstance
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$BudgetInstanceCopyWith<BudgetInstance> get copyWith => _$BudgetInstanceCopyWithImpl<BudgetInstance>(this as BudgetInstance, _$identity);
+
+  /// Serializes this BudgetInstance to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is BudgetInstance&&(identical(other.id, id) || other.id == id)&&(identical(other.budgetId, budgetId) || other.budgetId == budgetId)&&(identical(other.periodStart, periodStart) || other.periodStart == periodStart)&&(identical(other.periodEnd, periodEnd) || other.periodEnd == periodEnd)&&(identical(other.amount, amount) || other.amount == amount)&&(identical(other.spent, spent) || other.spent == spent)&&(identical(other.status, status) || other.status == status)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,budgetId,periodStart,periodEnd,amount,spent,status,createdAt,updatedAt);
+
+@override
+String toString() {
+  return 'BudgetInstance(id: $id, budgetId: $budgetId, periodStart: $periodStart, periodEnd: $periodEnd, amount: $amount, spent: $spent, status: $status, createdAt: $createdAt, updatedAt: $updatedAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $BudgetInstanceCopyWith<$Res>  {
+  factory $BudgetInstanceCopyWith(BudgetInstance value, $Res Function(BudgetInstance) _then) = _$BudgetInstanceCopyWithImpl;
+@useResult
+$Res call({
+ String id, String budgetId, DateTime periodStart, DateTime periodEnd, double amount, double spent,@JsonKey(fromJson: BudgetInstanceStatusX.fromStorage, toJson: _statusToJson) BudgetInstanceStatus status, DateTime createdAt, DateTime updatedAt
+});
+
+
+
+
+}
+/// @nodoc
+class _$BudgetInstanceCopyWithImpl<$Res>
+    implements $BudgetInstanceCopyWith<$Res> {
+  _$BudgetInstanceCopyWithImpl(this._self, this._then);
+
+  final BudgetInstance _self;
+  final $Res Function(BudgetInstance) _then;
+
+/// Create a copy of BudgetInstance
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? budgetId = null,Object? periodStart = null,Object? periodEnd = null,Object? amount = null,Object? spent = null,Object? status = null,Object? createdAt = null,Object? updatedAt = null,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,budgetId: null == budgetId ? _self.budgetId : budgetId // ignore: cast_nullable_to_non_nullable
+as String,periodStart: null == periodStart ? _self.periodStart : periodStart // ignore: cast_nullable_to_non_nullable
+as DateTime,periodEnd: null == periodEnd ? _self.periodEnd : periodEnd // ignore: cast_nullable_to_non_nullable
+as DateTime,amount: null == amount ? _self.amount : amount // ignore: cast_nullable_to_non_nullable
+as double,spent: null == spent ? _self.spent : spent // ignore: cast_nullable_to_non_nullable
+as double,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as BudgetInstanceStatus,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [BudgetInstance].
+extension BudgetInstancePatterns on BudgetInstance {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _BudgetInstance value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _BudgetInstance() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _BudgetInstance value)  $default,){
+final _that = this;
+switch (_that) {
+case _BudgetInstance():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _BudgetInstance value)?  $default,){
+final _that = this;
+switch (_that) {
+case _BudgetInstance() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String budgetId,  DateTime periodStart,  DateTime periodEnd,  double amount,  double spent, @JsonKey(fromJson: BudgetInstanceStatusX.fromStorage, toJson: _statusToJson)  BudgetInstanceStatus status,  DateTime createdAt,  DateTime updatedAt)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _BudgetInstance() when $default != null:
+return $default(_that.id,_that.budgetId,_that.periodStart,_that.periodEnd,_that.amount,_that.spent,_that.status,_that.createdAt,_that.updatedAt);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String budgetId,  DateTime periodStart,  DateTime periodEnd,  double amount,  double spent, @JsonKey(fromJson: BudgetInstanceStatusX.fromStorage, toJson: _statusToJson)  BudgetInstanceStatus status,  DateTime createdAt,  DateTime updatedAt)  $default,) {final _that = this;
+switch (_that) {
+case _BudgetInstance():
+return $default(_that.id,_that.budgetId,_that.periodStart,_that.periodEnd,_that.amount,_that.spent,_that.status,_that.createdAt,_that.updatedAt);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String budgetId,  DateTime periodStart,  DateTime periodEnd,  double amount,  double spent, @JsonKey(fromJson: BudgetInstanceStatusX.fromStorage, toJson: _statusToJson)  BudgetInstanceStatus status,  DateTime createdAt,  DateTime updatedAt)?  $default,) {final _that = this;
+switch (_that) {
+case _BudgetInstance() when $default != null:
+return $default(_that.id,_that.budgetId,_that.periodStart,_that.periodEnd,_that.amount,_that.spent,_that.status,_that.createdAt,_that.updatedAt);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _BudgetInstance extends BudgetInstance {
+  const _BudgetInstance({required this.id, required this.budgetId, required this.periodStart, required this.periodEnd, required this.amount, this.spent = 0.0, @JsonKey(fromJson: BudgetInstanceStatusX.fromStorage, toJson: _statusToJson) required this.status, required this.createdAt, required this.updatedAt}): super._();
+  factory _BudgetInstance.fromJson(Map<String, dynamic> json) => _$BudgetInstanceFromJson(json);
+
+@override final  String id;
+@override final  String budgetId;
+@override final  DateTime periodStart;
+@override final  DateTime periodEnd;
+@override final  double amount;
+@override@JsonKey() final  double spent;
+@override@JsonKey(fromJson: BudgetInstanceStatusX.fromStorage, toJson: _statusToJson) final  BudgetInstanceStatus status;
+@override final  DateTime createdAt;
+@override final  DateTime updatedAt;
+
+/// Create a copy of BudgetInstance
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$BudgetInstanceCopyWith<_BudgetInstance> get copyWith => __$BudgetInstanceCopyWithImpl<_BudgetInstance>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$BudgetInstanceToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _BudgetInstance&&(identical(other.id, id) || other.id == id)&&(identical(other.budgetId, budgetId) || other.budgetId == budgetId)&&(identical(other.periodStart, periodStart) || other.periodStart == periodStart)&&(identical(other.periodEnd, periodEnd) || other.periodEnd == periodEnd)&&(identical(other.amount, amount) || other.amount == amount)&&(identical(other.spent, spent) || other.spent == spent)&&(identical(other.status, status) || other.status == status)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,budgetId,periodStart,periodEnd,amount,spent,status,createdAt,updatedAt);
+
+@override
+String toString() {
+  return 'BudgetInstance(id: $id, budgetId: $budgetId, periodStart: $periodStart, periodEnd: $periodEnd, amount: $amount, spent: $spent, status: $status, createdAt: $createdAt, updatedAt: $updatedAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$BudgetInstanceCopyWith<$Res> implements $BudgetInstanceCopyWith<$Res> {
+  factory _$BudgetInstanceCopyWith(_BudgetInstance value, $Res Function(_BudgetInstance) _then) = __$BudgetInstanceCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, String budgetId, DateTime periodStart, DateTime periodEnd, double amount, double spent,@JsonKey(fromJson: BudgetInstanceStatusX.fromStorage, toJson: _statusToJson) BudgetInstanceStatus status, DateTime createdAt, DateTime updatedAt
+});
+
+
+
+
+}
+/// @nodoc
+class __$BudgetInstanceCopyWithImpl<$Res>
+    implements _$BudgetInstanceCopyWith<$Res> {
+  __$BudgetInstanceCopyWithImpl(this._self, this._then);
+
+  final _BudgetInstance _self;
+  final $Res Function(_BudgetInstance) _then;
+
+/// Create a copy of BudgetInstance
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? budgetId = null,Object? periodStart = null,Object? periodEnd = null,Object? amount = null,Object? spent = null,Object? status = null,Object? createdAt = null,Object? updatedAt = null,}) {
+  return _then(_BudgetInstance(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,budgetId: null == budgetId ? _self.budgetId : budgetId // ignore: cast_nullable_to_non_nullable
+as String,periodStart: null == periodStart ? _self.periodStart : periodStart // ignore: cast_nullable_to_non_nullable
+as DateTime,periodEnd: null == periodEnd ? _self.periodEnd : periodEnd // ignore: cast_nullable_to_non_nullable
+as DateTime,amount: null == amount ? _self.amount : amount // ignore: cast_nullable_to_non_nullable
+as double,spent: null == spent ? _self.spent : spent // ignore: cast_nullable_to_non_nullable
+as double,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as BudgetInstanceStatus,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/features/budgets/domain/entities/budget_instance.g.dart
+++ b/lib/features/budgets/domain/entities/budget_instance.g.dart
@@ -1,0 +1,33 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'budget_instance.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_BudgetInstance _$BudgetInstanceFromJson(Map<String, dynamic> json) =>
+    _BudgetInstance(
+      id: json['id'] as String,
+      budgetId: json['budgetId'] as String,
+      periodStart: DateTime.parse(json['periodStart'] as String),
+      periodEnd: DateTime.parse(json['periodEnd'] as String),
+      amount: (json['amount'] as num).toDouble(),
+      spent: (json['spent'] as num?)?.toDouble() ?? 0.0,
+      status: BudgetInstanceStatusX.fromStorage(json['status'] as String?),
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      updatedAt: DateTime.parse(json['updatedAt'] as String),
+    );
+
+Map<String, dynamic> _$BudgetInstanceToJson(_BudgetInstance instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'budgetId': instance.budgetId,
+      'periodStart': instance.periodStart.toIso8601String(),
+      'periodEnd': instance.periodEnd.toIso8601String(),
+      'amount': instance.amount,
+      'spent': instance.spent,
+      'status': _statusToJson(instance.status),
+      'createdAt': instance.createdAt.toIso8601String(),
+      'updatedAt': instance.updatedAt.toIso8601String(),
+    };

--- a/lib/features/budgets/domain/entities/budget_instance_status.dart
+++ b/lib/features/budgets/domain/entities/budget_instance_status.dart
@@ -1,0 +1,15 @@
+enum BudgetInstanceStatus { pending, active, closed }
+
+extension BudgetInstanceStatusX on BudgetInstanceStatus {
+  String get storageValue => name;
+
+  static BudgetInstanceStatus fromStorage(String? value) {
+    if (value == null || value.isEmpty) {
+      return BudgetInstanceStatus.pending;
+    }
+    return BudgetInstanceStatus.values.firstWhere(
+      (BudgetInstanceStatus status) => status.storageValue == value,
+      orElse: () => BudgetInstanceStatus.pending,
+    );
+  }
+}

--- a/lib/features/budgets/domain/entities/budget_period.dart
+++ b/lib/features/budgets/domain/entities/budget_period.dart
@@ -1,0 +1,18 @@
+enum BudgetPeriod { monthly, weekly, custom }
+
+extension BudgetPeriodX on BudgetPeriod {
+  String get storageValue => name;
+
+  bool get isRecurring =>
+      this == BudgetPeriod.monthly || this == BudgetPeriod.weekly;
+
+  static BudgetPeriod fromStorage(String? value) {
+    if (value == null || value.isEmpty) {
+      return BudgetPeriod.monthly;
+    }
+    return BudgetPeriod.values.firstWhere(
+      (BudgetPeriod period) => period.storageValue == value,
+      orElse: () => BudgetPeriod.monthly,
+    );
+  }
+}

--- a/lib/features/budgets/domain/entities/budget_progress.dart
+++ b/lib/features/budgets/domain/entities/budget_progress.dart
@@ -1,0 +1,18 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'budget.dart';
+import 'budget_instance.dart';
+
+part 'budget_progress.freezed.dart';
+
+@freezed
+abstract class BudgetProgress with _$BudgetProgress {
+  const factory BudgetProgress({
+    required Budget budget,
+    required BudgetInstance instance,
+    required double spent,
+    required double remaining,
+    required double utilization,
+    required bool isExceeded,
+  }) = _BudgetProgress;
+}

--- a/lib/features/budgets/domain/entities/budget_progress.freezed.dart
+++ b/lib/features/budgets/domain/entities/budget_progress.freezed.dart
@@ -1,0 +1,322 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'budget_progress.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$BudgetProgress {
+
+ Budget get budget; BudgetInstance get instance; double get spent; double get remaining; double get utilization; bool get isExceeded;
+/// Create a copy of BudgetProgress
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$BudgetProgressCopyWith<BudgetProgress> get copyWith => _$BudgetProgressCopyWithImpl<BudgetProgress>(this as BudgetProgress, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is BudgetProgress&&(identical(other.budget, budget) || other.budget == budget)&&(identical(other.instance, instance) || other.instance == instance)&&(identical(other.spent, spent) || other.spent == spent)&&(identical(other.remaining, remaining) || other.remaining == remaining)&&(identical(other.utilization, utilization) || other.utilization == utilization)&&(identical(other.isExceeded, isExceeded) || other.isExceeded == isExceeded));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,budget,instance,spent,remaining,utilization,isExceeded);
+
+@override
+String toString() {
+  return 'BudgetProgress(budget: $budget, instance: $instance, spent: $spent, remaining: $remaining, utilization: $utilization, isExceeded: $isExceeded)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $BudgetProgressCopyWith<$Res>  {
+  factory $BudgetProgressCopyWith(BudgetProgress value, $Res Function(BudgetProgress) _then) = _$BudgetProgressCopyWithImpl;
+@useResult
+$Res call({
+ Budget budget, BudgetInstance instance, double spent, double remaining, double utilization, bool isExceeded
+});
+
+
+$BudgetCopyWith<$Res> get budget;$BudgetInstanceCopyWith<$Res> get instance;
+
+}
+/// @nodoc
+class _$BudgetProgressCopyWithImpl<$Res>
+    implements $BudgetProgressCopyWith<$Res> {
+  _$BudgetProgressCopyWithImpl(this._self, this._then);
+
+  final BudgetProgress _self;
+  final $Res Function(BudgetProgress) _then;
+
+/// Create a copy of BudgetProgress
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? budget = null,Object? instance = null,Object? spent = null,Object? remaining = null,Object? utilization = null,Object? isExceeded = null,}) {
+  return _then(_self.copyWith(
+budget: null == budget ? _self.budget : budget // ignore: cast_nullable_to_non_nullable
+as Budget,instance: null == instance ? _self.instance : instance // ignore: cast_nullable_to_non_nullable
+as BudgetInstance,spent: null == spent ? _self.spent : spent // ignore: cast_nullable_to_non_nullable
+as double,remaining: null == remaining ? _self.remaining : remaining // ignore: cast_nullable_to_non_nullable
+as double,utilization: null == utilization ? _self.utilization : utilization // ignore: cast_nullable_to_non_nullable
+as double,isExceeded: null == isExceeded ? _self.isExceeded : isExceeded // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+/// Create a copy of BudgetProgress
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$BudgetCopyWith<$Res> get budget {
+  
+  return $BudgetCopyWith<$Res>(_self.budget, (value) {
+    return _then(_self.copyWith(budget: value));
+  });
+}/// Create a copy of BudgetProgress
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$BudgetInstanceCopyWith<$Res> get instance {
+  
+  return $BudgetInstanceCopyWith<$Res>(_self.instance, (value) {
+    return _then(_self.copyWith(instance: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [BudgetProgress].
+extension BudgetProgressPatterns on BudgetProgress {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _BudgetProgress value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _BudgetProgress() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _BudgetProgress value)  $default,){
+final _that = this;
+switch (_that) {
+case _BudgetProgress():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _BudgetProgress value)?  $default,){
+final _that = this;
+switch (_that) {
+case _BudgetProgress() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( Budget budget,  BudgetInstance instance,  double spent,  double remaining,  double utilization,  bool isExceeded)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _BudgetProgress() when $default != null:
+return $default(_that.budget,_that.instance,_that.spent,_that.remaining,_that.utilization,_that.isExceeded);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( Budget budget,  BudgetInstance instance,  double spent,  double remaining,  double utilization,  bool isExceeded)  $default,) {final _that = this;
+switch (_that) {
+case _BudgetProgress():
+return $default(_that.budget,_that.instance,_that.spent,_that.remaining,_that.utilization,_that.isExceeded);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( Budget budget,  BudgetInstance instance,  double spent,  double remaining,  double utilization,  bool isExceeded)?  $default,) {final _that = this;
+switch (_that) {
+case _BudgetProgress() when $default != null:
+return $default(_that.budget,_that.instance,_that.spent,_that.remaining,_that.utilization,_that.isExceeded);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _BudgetProgress implements BudgetProgress {
+  const _BudgetProgress({required this.budget, required this.instance, required this.spent, required this.remaining, required this.utilization, required this.isExceeded});
+  
+
+@override final  Budget budget;
+@override final  BudgetInstance instance;
+@override final  double spent;
+@override final  double remaining;
+@override final  double utilization;
+@override final  bool isExceeded;
+
+/// Create a copy of BudgetProgress
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$BudgetProgressCopyWith<_BudgetProgress> get copyWith => __$BudgetProgressCopyWithImpl<_BudgetProgress>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _BudgetProgress&&(identical(other.budget, budget) || other.budget == budget)&&(identical(other.instance, instance) || other.instance == instance)&&(identical(other.spent, spent) || other.spent == spent)&&(identical(other.remaining, remaining) || other.remaining == remaining)&&(identical(other.utilization, utilization) || other.utilization == utilization)&&(identical(other.isExceeded, isExceeded) || other.isExceeded == isExceeded));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,budget,instance,spent,remaining,utilization,isExceeded);
+
+@override
+String toString() {
+  return 'BudgetProgress(budget: $budget, instance: $instance, spent: $spent, remaining: $remaining, utilization: $utilization, isExceeded: $isExceeded)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$BudgetProgressCopyWith<$Res> implements $BudgetProgressCopyWith<$Res> {
+  factory _$BudgetProgressCopyWith(_BudgetProgress value, $Res Function(_BudgetProgress) _then) = __$BudgetProgressCopyWithImpl;
+@override @useResult
+$Res call({
+ Budget budget, BudgetInstance instance, double spent, double remaining, double utilization, bool isExceeded
+});
+
+
+@override $BudgetCopyWith<$Res> get budget;@override $BudgetInstanceCopyWith<$Res> get instance;
+
+}
+/// @nodoc
+class __$BudgetProgressCopyWithImpl<$Res>
+    implements _$BudgetProgressCopyWith<$Res> {
+  __$BudgetProgressCopyWithImpl(this._self, this._then);
+
+  final _BudgetProgress _self;
+  final $Res Function(_BudgetProgress) _then;
+
+/// Create a copy of BudgetProgress
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? budget = null,Object? instance = null,Object? spent = null,Object? remaining = null,Object? utilization = null,Object? isExceeded = null,}) {
+  return _then(_BudgetProgress(
+budget: null == budget ? _self.budget : budget // ignore: cast_nullable_to_non_nullable
+as Budget,instance: null == instance ? _self.instance : instance // ignore: cast_nullable_to_non_nullable
+as BudgetInstance,spent: null == spent ? _self.spent : spent // ignore: cast_nullable_to_non_nullable
+as double,remaining: null == remaining ? _self.remaining : remaining // ignore: cast_nullable_to_non_nullable
+as double,utilization: null == utilization ? _self.utilization : utilization // ignore: cast_nullable_to_non_nullable
+as double,isExceeded: null == isExceeded ? _self.isExceeded : isExceeded // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+/// Create a copy of BudgetProgress
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$BudgetCopyWith<$Res> get budget {
+  
+  return $BudgetCopyWith<$Res>(_self.budget, (value) {
+    return _then(_self.copyWith(budget: value));
+  });
+}/// Create a copy of BudgetProgress
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$BudgetInstanceCopyWith<$Res> get instance {
+  
+  return $BudgetInstanceCopyWith<$Res>(_self.instance, (value) {
+    return _then(_self.copyWith(instance: value));
+  });
+}
+}
+
+// dart format on

--- a/lib/features/budgets/domain/entities/budget_scope.dart
+++ b/lib/features/budgets/domain/entities/budget_scope.dart
@@ -1,0 +1,15 @@
+enum BudgetScope { all, byCategory, byAccount }
+
+extension BudgetScopeX on BudgetScope {
+  String get storageValue => name;
+
+  static BudgetScope fromStorage(String? value) {
+    if (value == null || value.isEmpty) {
+      return BudgetScope.all;
+    }
+    return BudgetScope.values.firstWhere(
+      (BudgetScope scope) => scope.storageValue == value,
+      orElse: () => BudgetScope.all,
+    );
+  }
+}

--- a/lib/features/budgets/domain/repositories/budget_repository.dart
+++ b/lib/features/budgets/domain/repositories/budget_repository.dart
@@ -1,0 +1,15 @@
+import 'package:kopim/features/budgets/domain/entities/budget.dart';
+import 'package:kopim/features/budgets/domain/entities/budget_instance.dart';
+
+abstract class BudgetRepository {
+  Stream<List<Budget>> watchBudgets();
+  Future<List<Budget>> loadBudgets();
+  Future<Budget?> findById(String id);
+  Future<void> upsert(Budget budget);
+  Future<void> softDelete(String id);
+
+  Stream<List<BudgetInstance>> watchInstances(String budgetId);
+  Future<List<BudgetInstance>> loadInstances(String budgetId);
+  Future<void> upsertInstance(BudgetInstance instance);
+  Future<void> deleteInstance(String id);
+}

--- a/lib/features/budgets/domain/services/budget_schedule.dart
+++ b/lib/features/budgets/domain/services/budget_schedule.dart
@@ -1,0 +1,159 @@
+import 'package:kopim/features/budgets/domain/entities/budget.dart';
+import 'package:kopim/features/budgets/domain/entities/budget_instance.dart';
+import 'package:kopim/features/budgets/domain/entities/budget_instance_status.dart';
+import 'package:kopim/features/budgets/domain/entities/budget_period.dart';
+
+class BudgetSchedule {
+  const BudgetSchedule();
+
+  ({DateTime start, DateTime end}) periodFor({
+    required Budget budget,
+    DateTime? reference,
+  }) {
+    final DateTime ref = reference ?? DateTime.now();
+    final DateTime initialStart = _normalizeStart(budget.startDate);
+    if (!budget.period.isRecurring) {
+      final DateTime? rawEnd = budget.endDate;
+      DateTime normalizedEnd = rawEnd != null
+          ? _normalizeStart(rawEnd)
+          : initialStart.add(const Duration(days: 1));
+      if (!normalizedEnd.isAfter(initialStart)) {
+        normalizedEnd = initialStart.add(const Duration(days: 1));
+      }
+      return (start: initialStart, end: normalizedEnd);
+    }
+
+    DateTime start = initialStart;
+    DateTime end = _advance(budget.period, start);
+    final DateTime? cutoff = budget.endDate;
+
+    while (!ref.isBefore(end)) {
+      final DateTime nextStart = end;
+      if (cutoff != null && !nextStart.isBefore(cutoff)) {
+        break;
+      }
+      start = nextStart;
+      end = _advance(budget.period, start);
+    }
+
+    return (start: start, end: end);
+  }
+
+  BudgetInstance buildInstance({
+    required Budget budget,
+    required String instanceId,
+    DateTime? reference,
+    DateTime? now,
+  }) {
+    final ({DateTime start, DateTime end}) period = periodFor(
+      budget: budget,
+      reference: reference,
+    );
+    final DateTime clock = now ?? DateTime.now();
+    final BudgetInstanceStatus status = statusFor(
+      clock: clock,
+      start: period.start,
+      end: period.end,
+    );
+    return BudgetInstance(
+      id: instanceId,
+      budgetId: budget.id,
+      periodStart: period.start,
+      periodEnd: period.end,
+      amount: budget.amount,
+      status: status,
+      createdAt: clock,
+      updatedAt: clock,
+    );
+  }
+
+  Iterable<BudgetInstance> generateUpcomingInstances({
+    required Budget budget,
+    required String Function(DateTime start) idBuilder,
+    DateTime? from,
+    int count = 1,
+  }) sync* {
+    final DateTime reference = from ?? DateTime.now();
+    final ({DateTime start, DateTime end}) period = periodFor(
+      budget: budget,
+      reference: reference,
+    );
+    DateTime cursor = period.start;
+    for (int i = 0; i < count; i++) {
+      final DateTime instanceStart = i == 0 ? period.start : cursor;
+      final DateTime instanceEnd = budget.period.isRecurring
+          ? (i == 0 ? period.end : _advance(budget.period, instanceStart))
+          : period.end;
+      final BudgetInstanceStatus status = statusFor(
+        clock: reference,
+        start: instanceStart,
+        end: instanceEnd,
+      );
+      yield BudgetInstance(
+        id: idBuilder(instanceStart),
+        budgetId: budget.id,
+        periodStart: instanceStart,
+        periodEnd: instanceEnd,
+        amount: budget.amount,
+        status: status,
+        createdAt: reference,
+        updatedAt: reference,
+      );
+      cursor = instanceEnd;
+      if (!budget.period.isRecurring) {
+        break;
+      }
+    }
+  }
+
+  DateTime _advance(BudgetPeriod period, DateTime start) {
+    final DateTime normalized = _normalizeStart(start);
+    switch (period) {
+      case BudgetPeriod.monthly:
+        final DateTime firstOfNextMonth = DateTime(
+          normalized.year,
+          normalized.month + 1,
+          1,
+          0,
+          1,
+        );
+        final int lastDayOfNextMonth = DateTime(
+          firstOfNextMonth.year,
+          firstOfNextMonth.month + 1,
+          0,
+        ).day;
+        final int resolvedDay = normalized.day > lastDayOfNextMonth
+            ? lastDayOfNextMonth
+            : normalized.day;
+        return DateTime(
+          firstOfNextMonth.year,
+          firstOfNextMonth.month,
+          resolvedDay,
+          0,
+          1,
+        );
+      case BudgetPeriod.weekly:
+        return normalized.add(const Duration(days: 7));
+      case BudgetPeriod.custom:
+        return normalized;
+    }
+  }
+
+  DateTime _normalizeStart(DateTime date) {
+    return DateTime(date.year, date.month, date.day, 0, 1);
+  }
+
+  BudgetInstanceStatus statusFor({
+    required DateTime clock,
+    required DateTime start,
+    required DateTime end,
+  }) {
+    if (clock.isBefore(start)) {
+      return BudgetInstanceStatus.pending;
+    }
+    if (!clock.isBefore(end)) {
+      return BudgetInstanceStatus.closed;
+    }
+    return BudgetInstanceStatus.active;
+  }
+}

--- a/lib/features/budgets/domain/use_cases/compute_budget_progress_use_case.dart
+++ b/lib/features/budgets/domain/use_cases/compute_budget_progress_use_case.dart
@@ -1,0 +1,149 @@
+import 'dart:math' as math;
+
+import 'package:kopim/features/budgets/domain/entities/budget.dart';
+import 'package:kopim/features/budgets/domain/entities/budget_instance.dart';
+import 'package:kopim/features/budgets/domain/entities/budget_progress.dart';
+import 'package:kopim/features/budgets/domain/entities/budget_scope.dart';
+import 'package:kopim/features/budgets/domain/services/budget_schedule.dart';
+import 'package:kopim/features/transactions/domain/entities/transaction.dart';
+
+class ComputeBudgetProgressUseCase {
+  ComputeBudgetProgressUseCase({BudgetSchedule? schedule})
+    : _schedule = schedule ?? const BudgetSchedule();
+
+  final BudgetSchedule _schedule;
+
+  BudgetProgress call({
+    required Budget budget,
+    required List<TransactionEntity> transactions,
+    DateTime? reference,
+    BudgetInstance? existingInstance,
+  }) {
+    final DateTime now = reference ?? DateTime.now();
+    final _FilteredTransactions filtered = _filterTransactions(
+      budget: budget,
+      transactions: transactions,
+      reference: now,
+    );
+    final List<TransactionEntity> scopedTransactions = filtered.transactions;
+
+    double spent = 0;
+    for (final TransactionEntity tx in scopedTransactions) {
+      spent += tx.amount.abs();
+    }
+
+    final double remaining = budget.amount - spent;
+    final double utilization = budget.amount <= 0
+        ? (spent > 0 ? double.infinity : 0)
+        : spent / budget.amount;
+
+    final BudgetInstance instance =
+        (existingInstance != null &&
+            existingInstance.periodStart.isAtSameMomentAs(
+              filtered.period.start,
+            ))
+        ? existingInstance.copyWith(
+            periodEnd: filtered.period.end,
+            amount: budget.amount,
+            spent: spent,
+            status: _schedule.statusFor(
+              clock: now,
+              start: filtered.period.start,
+              end: filtered.period.end,
+            ),
+            updatedAt: now,
+          )
+        : BudgetInstance(
+            id: _buildInstanceId(budget.id, filtered.period.start),
+            budgetId: budget.id,
+            periodStart: filtered.period.start,
+            periodEnd: filtered.period.end,
+            amount: budget.amount,
+            spent: spent,
+            status: _schedule.statusFor(
+              clock: now,
+              start: filtered.period.start,
+              end: filtered.period.end,
+            ),
+            createdAt: existingInstance?.createdAt ?? now,
+            updatedAt: now,
+          );
+
+    return BudgetProgress(
+      budget: budget,
+      instance: instance,
+      spent: spent,
+      remaining: remaining,
+      utilization: utilization.isFinite
+          ? math.max(utilization, 0)
+          : double.infinity,
+      isExceeded: spent > budget.amount,
+    );
+  }
+
+  List<TransactionEntity> filterTransactions({
+    required Budget budget,
+    required List<TransactionEntity> transactions,
+    DateTime? reference,
+  }) {
+    return _filterTransactions(
+      budget: budget,
+      transactions: transactions,
+      reference: reference ?? DateTime.now(),
+    ).transactions;
+  }
+
+  _FilteredTransactions _filterTransactions({
+    required Budget budget,
+    required List<TransactionEntity> transactions,
+    required DateTime reference,
+  }) {
+    final ({DateTime start, DateTime end}) period = _schedule.periodFor(
+      budget: budget,
+      reference: reference,
+    );
+    final List<TransactionEntity> scopedTransactions = transactions
+        .where((TransactionEntity tx) => _matchesScope(budget, tx))
+        .where(
+          (TransactionEntity tx) =>
+              !tx.date.isBefore(period.start) && tx.date.isBefore(period.end),
+        )
+        .toList(growable: false);
+    return _FilteredTransactions(
+      period: period,
+      transactions: scopedTransactions,
+    );
+  }
+
+  bool _matchesScope(Budget budget, TransactionEntity transaction) {
+    switch (budget.scope) {
+      case BudgetScope.all:
+        return true;
+      case BudgetScope.byCategory:
+        if (budget.categories.isEmpty) {
+          return false;
+        }
+        final String? categoryId = transaction.categoryId;
+        return categoryId != null && budget.categories.contains(categoryId);
+      case BudgetScope.byAccount:
+        if (budget.accounts.isEmpty) {
+          return false;
+        }
+        return budget.accounts.contains(transaction.accountId);
+    }
+  }
+
+  String _buildInstanceId(String budgetId, DateTime start) {
+    return '$budgetId-${start.toIso8601String()}';
+  }
+}
+
+class _FilteredTransactions {
+  const _FilteredTransactions({
+    required this.period,
+    required this.transactions,
+  });
+
+  final ({DateTime start, DateTime end}) period;
+  final List<TransactionEntity> transactions;
+}

--- a/lib/features/budgets/domain/use_cases/delete_budget_use_case.dart
+++ b/lib/features/budgets/domain/use_cases/delete_budget_use_case.dart
@@ -1,0 +1,10 @@
+import 'package:kopim/features/budgets/domain/repositories/budget_repository.dart';
+
+class DeleteBudgetUseCase {
+  DeleteBudgetUseCase({required BudgetRepository repository})
+    : _repository = repository;
+
+  final BudgetRepository _repository;
+
+  Future<void> call(String id) => _repository.softDelete(id);
+}

--- a/lib/features/budgets/domain/use_cases/save_budget_use_case.dart
+++ b/lib/features/budgets/domain/use_cases/save_budget_use_case.dart
@@ -1,0 +1,11 @@
+import 'package:kopim/features/budgets/domain/entities/budget.dart';
+import 'package:kopim/features/budgets/domain/repositories/budget_repository.dart';
+
+class SaveBudgetUseCase {
+  SaveBudgetUseCase({required BudgetRepository repository})
+    : _repository = repository;
+
+  final BudgetRepository _repository;
+
+  Future<void> call(Budget budget) => _repository.upsert(budget);
+}

--- a/lib/features/budgets/domain/use_cases/watch_budgets_use_case.dart
+++ b/lib/features/budgets/domain/use_cases/watch_budgets_use_case.dart
@@ -1,0 +1,11 @@
+import 'package:kopim/features/budgets/domain/entities/budget.dart';
+import 'package:kopim/features/budgets/domain/repositories/budget_repository.dart';
+
+class WatchBudgetsUseCase {
+  WatchBudgetsUseCase({required BudgetRepository repository})
+    : _repository = repository;
+
+  final BudgetRepository _repository;
+
+  Stream<List<Budget>> call() => _repository.watchBudgets();
+}

--- a/lib/features/budgets/presentation/budget_detail_screen.dart
+++ b/lib/features/budgets/presentation/budget_detail_screen.dart
@@ -1,0 +1,211 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+
+import 'package:kopim/core/di/injectors.dart';
+import 'package:kopim/features/budgets/domain/entities/budget_progress.dart';
+import 'package:kopim/features/budgets/presentation/budget_form_screen.dart';
+import 'package:kopim/features/budgets/presentation/controllers/budgets_providers.dart';
+import 'package:kopim/features/budgets/presentation/widgets/budget_card.dart';
+import 'package:kopim/features/transactions/domain/entities/transaction.dart';
+import 'package:kopim/l10n/app_localizations.dart';
+
+class BudgetDetailScreen extends ConsumerWidget {
+  const BudgetDetailScreen({required this.budgetId, super.key});
+
+  final String budgetId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final AppLocalizations strings = AppLocalizations.of(context)!;
+    final AsyncValue<BudgetProgress> progressAsync = ref.watch(
+      budgetProgressByIdProvider(budgetId),
+    );
+    final AsyncValue<List<TransactionEntity>> transactionsAsync = ref.watch(
+      budgetTransactionsByIdProvider(budgetId),
+    );
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(strings.budgetDetailTitle),
+        actions: <Widget>[
+          IconButton(
+            icon: const Icon(Icons.edit),
+            tooltip: strings.editButtonLabel,
+            onPressed: progressAsync.maybeWhen(
+              data: (BudgetProgress progress) => () async {
+                await Navigator.of(context).push(
+                  MaterialPageRoute<void>(
+                    builder: (BuildContext context) =>
+                        BudgetFormScreen(initialBudget: progress.budget),
+                  ),
+                );
+              },
+              orElse: () => null,
+            ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.delete),
+            tooltip: strings.deleteButtonLabel,
+            onPressed: progressAsync.maybeWhen(
+              data: (BudgetProgress progress) => () async {
+                final bool? confirmed = await showDialog<bool>(
+                  context: context,
+                  builder: (BuildContext context) {
+                    return AlertDialog(
+                      title: Text(strings.budgetDeleteTitle),
+                      content: Text(strings.budgetDeleteMessage),
+                      actions: <Widget>[
+                        TextButton(
+                          onPressed: () => Navigator.of(context).pop(false),
+                          child: Text(strings.cancelButtonLabel),
+                        ),
+                        TextButton(
+                          onPressed: () => Navigator.of(context).pop(true),
+                          child: Text(strings.deleteButtonLabel),
+                        ),
+                      ],
+                    );
+                  },
+                );
+                if (confirmed != true) return;
+                await ref
+                    .read(deleteBudgetUseCaseProvider)
+                    .call(progress.budget.id);
+                if (context.mounted) {
+                  Navigator.of(context).pop();
+                }
+              },
+              orElse: () => null,
+            ),
+          ),
+        ],
+      ),
+      body: progressAsync.when(
+        data: (BudgetProgress progress) {
+          return _BudgetDetailBody(
+            progress: progress,
+            transactionsAsync: transactionsAsync,
+          );
+        },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (Object error, StackTrace stackTrace) {
+          return Center(
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Text(error.toString()),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _BudgetDetailBody extends StatelessWidget {
+  const _BudgetDetailBody({
+    required this.progress,
+    required this.transactionsAsync,
+  });
+
+  final BudgetProgress progress;
+  final AsyncValue<List<TransactionEntity>> transactionsAsync;
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations strings = AppLocalizations.of(context)!;
+    final ThemeData theme = Theme.of(context);
+    final NumberFormat currencyFormat = NumberFormat.simpleCurrency(
+      locale: strings.localeName,
+    );
+    final DateFormat dateFormat = DateFormat.yMMMMd(strings.localeName);
+    final DateTime start = progress.instance.periodStart;
+    final DateTime end = progress.instance.periodEnd;
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          BudgetCard(progress: progress),
+          const SizedBox(height: 16),
+          Text(
+            strings.budgetPeriodLabel(
+              dateFormat.format(start),
+              dateFormat.format(end.subtract(const Duration(minutes: 1))),
+            ),
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 24),
+          Text(
+            strings.budgetTransactionsTitle,
+            style: theme.textTheme.titleMedium,
+          ),
+          const SizedBox(height: 12),
+          transactionsAsync.when(
+            data: (List<TransactionEntity> transactions) {
+              if (transactions.isEmpty) {
+                return Text(
+                  strings.budgetTransactionsEmpty,
+                  style: theme.textTheme.bodyMedium,
+                );
+              }
+              return ListView.separated(
+                shrinkWrap: true,
+                physics: const NeverScrollableScrollPhysics(),
+                itemCount: transactions.length,
+                itemBuilder: (BuildContext context, int index) {
+                  final TransactionEntity transaction = transactions[index];
+                  final bool isIncome =
+                      transaction.type.toLowerCase() == 'income';
+                  final double amount = transaction.amount.abs();
+                  return ListTile(
+                    contentPadding: EdgeInsets.zero,
+                    leading: CircleAvatar(
+                      backgroundColor: theme.colorScheme.primaryContainer,
+                      child: Icon(
+                        isIncome ? Icons.arrow_upward : Icons.arrow_downward,
+                        color: theme.colorScheme.onPrimaryContainer,
+                      ),
+                    ),
+                    title: Text(
+                      transaction.note?.isNotEmpty == true
+                          ? transaction.note!
+                          : strings.transactionDefaultTitle,
+                    ),
+                    subtitle: Text(dateFormat.format(transaction.date)),
+                    trailing: Text(
+                      currencyFormat.format(amount),
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: isIncome
+                            ? theme.colorScheme.primary
+                            : theme.colorScheme.error,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  );
+                },
+                separatorBuilder: (BuildContext context, int index) =>
+                    const Divider(height: 1),
+              );
+            },
+            loading: () => const Padding(
+              padding: EdgeInsets.symmetric(vertical: 24),
+              child: Center(child: CircularProgressIndicator()),
+            ),
+            error: (Object error, StackTrace stackTrace) => Padding(
+              padding: const EdgeInsets.symmetric(vertical: 16),
+              child: Text(
+                error.toString(),
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.error,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/budgets/presentation/budget_form_screen.dart
+++ b/lib/features/budgets/presentation/budget_form_screen.dart
@@ -1,0 +1,376 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+
+import 'package:kopim/features/accounts/domain/entities/account_entity.dart';
+import 'package:kopim/features/budgets/domain/entities/budget.dart';
+import 'package:kopim/features/budgets/domain/entities/budget_period.dart';
+import 'package:kopim/features/budgets/domain/entities/budget_scope.dart';
+import 'package:kopim/features/budgets/presentation/controllers/budget_form_controller.dart';
+import 'package:kopim/features/budgets/presentation/controllers/budgets_providers.dart';
+import 'package:kopim/features/categories/domain/entities/category.dart';
+import 'package:kopim/l10n/app_localizations.dart';
+
+class BudgetFormScreen extends ConsumerStatefulWidget {
+  const BudgetFormScreen({this.initialBudget, super.key});
+
+  final Budget? initialBudget;
+
+  @override
+  ConsumerState<BudgetFormScreen> createState() => _BudgetFormScreenState();
+}
+
+class _BudgetFormScreenState extends ConsumerState<BudgetFormScreen> {
+  late final TextEditingController _titleController;
+  late final TextEditingController _amountController;
+
+  @override
+  void initState() {
+    super.initState();
+    _titleController = TextEditingController();
+    _amountController = TextEditingController();
+    final BudgetFormParams params = BudgetFormParams(
+      initial: widget.initialBudget,
+    );
+    final BudgetFormState state = ref.read(
+      budgetFormControllerProvider(params: params),
+    );
+    _titleController.text = state.title;
+    _amountController.text = state.amountText;
+  }
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _amountController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final BudgetFormParams params = BudgetFormParams(
+      initial: widget.initialBudget,
+    );
+    final BudgetFormState state = ref.watch(
+      budgetFormControllerProvider(params: params),
+    );
+    final BudgetFormController controller = ref.watch(
+      budgetFormControllerProvider(params: params).notifier,
+    );
+    final AppLocalizations strings = AppLocalizations.of(context)!;
+    final NumberFormat currencyFormat = NumberFormat.simpleCurrency(
+      locale: strings.localeName,
+    );
+
+    ref.listen<BudgetFormState>(budgetFormControllerProvider(params: params), (
+      BudgetFormState? previous,
+      BudgetFormState next,
+    ) {
+      if (previous?.initialBudget != next.initialBudget) {
+        _titleController.text = next.title;
+        _amountController.text = next.amountText;
+      }
+    });
+
+    final AsyncValue<List<Category>> categoriesAsync = ref.watch(
+      budgetCategoriesStreamProvider,
+    );
+    final AsyncValue<List<AccountEntity>> accountsAsync = ref.watch(
+      budgetAccountsStreamProvider,
+    );
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          state.initialBudget == null
+              ? strings.budgetCreateTitle
+              : strings.budgetEditTitle,
+        ),
+      ),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              TextField(
+                controller: _titleController,
+                decoration: InputDecoration(
+                  labelText: strings.budgetTitleLabel,
+                ),
+                onChanged: controller.setTitle,
+              ),
+              const SizedBox(height: 16),
+              TextField(
+                controller: _amountController,
+                keyboardType: const TextInputType.numberWithOptions(
+                  decimal: true,
+                ),
+                decoration: InputDecoration(
+                  labelText: strings.budgetAmountLabel,
+                  helperText: currencyFormat.currencySymbol,
+                ),
+                onChanged: controller.setAmountText,
+              ),
+              const SizedBox(height: 16),
+              DropdownButtonFormField<BudgetPeriod>(
+                initialValue: state.period,
+                items: BudgetPeriod.values
+                    .map(
+                      (BudgetPeriod period) => DropdownMenuItem<BudgetPeriod>(
+                        value: period,
+                        child: Text(_periodLabel(strings, period)),
+                      ),
+                    )
+                    .toList(),
+                onChanged: (BudgetPeriod? value) {
+                  if (value != null) {
+                    controller.setPeriod(value);
+                  }
+                },
+                decoration: InputDecoration(
+                  labelText: strings.budgetPeriodLabelShort,
+                ),
+              ),
+              const SizedBox(height: 16),
+              DropdownButtonFormField<BudgetScope>(
+                initialValue: state.scope,
+                items: BudgetScope.values
+                    .map(
+                      (BudgetScope scope) => DropdownMenuItem<BudgetScope>(
+                        value: scope,
+                        child: Text(_scopeLabel(strings, scope)),
+                      ),
+                    )
+                    .toList(),
+                onChanged: (BudgetScope? value) {
+                  if (value != null) {
+                    controller.setScope(value);
+                  }
+                },
+                decoration: InputDecoration(
+                  labelText: strings.budgetScopeLabel,
+                ),
+              ),
+              const SizedBox(height: 16),
+              _DatePickerTile(
+                label: strings.budgetStartDateLabel,
+                value: state.startDate,
+                onSelected: (DateTime? date) {
+                  if (date != null) {
+                    controller.setStartDate(date);
+                  }
+                },
+              ),
+              if (state.period == BudgetPeriod.custom)
+                _DatePickerTile(
+                  label: strings.budgetEndDateLabel,
+                  value: state.endDate,
+                  onSelected: controller.setEndDate,
+                ),
+              const SizedBox(height: 16),
+              if (state.scope == BudgetScope.byCategory)
+                categoriesAsync.when(
+                  data: (List<Category> categories) {
+                    return _SelectionChips<Category>(
+                      title: strings.budgetCategoriesLabel,
+                      values: categories,
+                      selectedValues: state.categoryIds,
+                      labelBuilder: (Category category) => category.name,
+                      onToggle: (Category category) =>
+                          controller.toggleCategory(category.id),
+                    );
+                  },
+                  loading: () => const Center(
+                    child: Padding(
+                      padding: EdgeInsets.symmetric(vertical: 16),
+                      child: CircularProgressIndicator(),
+                    ),
+                  ),
+                  error: (Object error, StackTrace stackTrace) => Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 16),
+                    child: Text(error.toString()),
+                  ),
+                ),
+              if (state.scope == BudgetScope.byAccount)
+                accountsAsync.when(
+                  data: (List<AccountEntity> accounts) {
+                    return _SelectionChips<AccountEntity>(
+                      title: strings.budgetAccountsLabel,
+                      values: accounts,
+                      selectedValues: state.accountIds,
+                      labelBuilder: (AccountEntity account) => account.name,
+                      onToggle: (AccountEntity account) =>
+                          controller.toggleAccount(account.id),
+                    );
+                  },
+                  loading: () => const Center(
+                    child: Padding(
+                      padding: EdgeInsets.symmetric(vertical: 16),
+                      child: CircularProgressIndicator(),
+                    ),
+                  ),
+                  error: (Object error, StackTrace stackTrace) => Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 16),
+                    child: Text(error.toString()),
+                  ),
+                ),
+              if (state.errorMessage != null)
+                Padding(
+                  padding: const EdgeInsets.only(top: 16),
+                  child: Text(
+                    _mapError(strings, state.errorMessage!),
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.error,
+                    ),
+                  ),
+                ),
+              const SizedBox(height: 24),
+              SizedBox(
+                width: double.infinity,
+                child: FilledButton(
+                  onPressed: state.isSubmitting
+                      ? null
+                      : () async {
+                          final bool success = await controller.submit();
+                          if (success && context.mounted) {
+                            Navigator.of(context).pop();
+                          }
+                        },
+                  child: state.isSubmitting
+                      ? const SizedBox(
+                          width: 20,
+                          height: 20,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : Text(strings.saveButtonLabel),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _periodLabel(AppLocalizations strings, BudgetPeriod period) {
+    switch (period) {
+      case BudgetPeriod.monthly:
+        return strings.budgetPeriodMonthly;
+      case BudgetPeriod.weekly:
+        return strings.budgetPeriodWeekly;
+      case BudgetPeriod.custom:
+        return strings.budgetPeriodCustom;
+    }
+  }
+
+  String _scopeLabel(AppLocalizations strings, BudgetScope scope) {
+    switch (scope) {
+      case BudgetScope.all:
+        return strings.budgetScopeAll;
+      case BudgetScope.byCategory:
+        return strings.budgetScopeByCategory;
+      case BudgetScope.byAccount:
+        return strings.budgetScopeByAccount;
+    }
+  }
+
+  String _mapError(AppLocalizations strings, String code) {
+    switch (code) {
+      case 'invalid_amount':
+        return strings.budgetErrorInvalidAmount;
+      case 'missing_title':
+        return strings.budgetErrorMissingTitle;
+      default:
+        return strings.genericErrorMessage;
+    }
+  }
+}
+
+class _DatePickerTile extends StatelessWidget {
+  const _DatePickerTile({
+    required this.label,
+    required this.value,
+    required this.onSelected,
+  });
+
+  final String label;
+  final DateTime? value;
+  final ValueChanged<DateTime?> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations strings = AppLocalizations.of(context)!;
+    final DateFormat formatter = DateFormat.yMMMd(strings.localeName);
+    return ListTile(
+      contentPadding: EdgeInsets.zero,
+      title: Text(label),
+      subtitle: Text(
+        value != null ? formatter.format(value!) : strings.budgetNoEndDateLabel,
+      ),
+      trailing: const Icon(Icons.calendar_today),
+      onTap: () async {
+        final DateTime initial = value ?? DateTime.now();
+        final DateTime firstDate = DateTime(2000);
+        final DateTime lastDate = DateTime(2100);
+        final DateTime? picked = await showDatePicker(
+          context: context,
+          initialDate: initial,
+          firstDate: firstDate,
+          lastDate: lastDate,
+        );
+        onSelected(picked);
+      },
+    );
+  }
+}
+
+class _SelectionChips<T> extends StatelessWidget {
+  const _SelectionChips({
+    required this.title,
+    required this.values,
+    required this.selectedValues,
+    required this.labelBuilder,
+    required this.onToggle,
+  });
+
+  final String title;
+  final List<T> values;
+  final List<String> selectedValues;
+  final String Function(T value) labelBuilder;
+  final void Function(T value) onToggle;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text(title, style: theme.textTheme.titleSmall),
+        const SizedBox(height: 8),
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: <Widget>[
+            for (final T value in values)
+              FilterChip(
+                label: Text(labelBuilder(value)),
+                selected: selectedValues.contains(_extractId(value)),
+                onSelected: (_) => onToggle(value),
+              ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  String _extractId(T value) {
+    if (value is Category) {
+      return value.id;
+    }
+    if (value is AccountEntity) {
+      return value.id;
+    }
+    throw ArgumentError('Unsupported type $value');
+  }
+}

--- a/lib/features/budgets/presentation/budgets_screen.dart
+++ b/lib/features/budgets/presentation/budgets_screen.dart
@@ -1,0 +1,168 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:kopim/features/app_shell/presentation/models/navigation_tab_content.dart';
+import 'package:kopim/features/budgets/domain/entities/budget_progress.dart';
+import 'package:kopim/features/budgets/presentation/controllers/budgets_providers.dart';
+import 'package:kopim/features/budgets/presentation/widgets/budget_card.dart';
+import 'package:kopim/features/budgets/presentation/budget_detail_screen.dart';
+import 'package:kopim/features/budgets/presentation/budget_form_screen.dart';
+import 'package:kopim/l10n/app_localizations.dart';
+
+class BudgetsScreen extends ConsumerWidget {
+  const BudgetsScreen({super.key});
+
+  static const String routeName = '/budgets';
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final NavigationTabContent content = buildBudgetsTabContent(context, ref);
+    return Scaffold(
+      appBar: content.appBarBuilder?.call(context, ref),
+      body: content.bodyBuilder(context, ref),
+      floatingActionButton: content.floatingActionButtonBuilder?.call(
+        context,
+        ref,
+      ),
+    );
+  }
+}
+
+NavigationTabContent buildBudgetsTabContent(
+  BuildContext context,
+  WidgetRef ref,
+) {
+  final AppLocalizations strings = AppLocalizations.of(context)!;
+  return NavigationTabContent(
+    appBarBuilder: (BuildContext context, WidgetRef ref) =>
+        AppBar(title: Text(strings.budgetsTitle)),
+    floatingActionButtonBuilder: (BuildContext context, WidgetRef ref) {
+      return FloatingActionButton(
+        onPressed: () async {
+          await Navigator.of(context).push(
+            MaterialPageRoute<void>(
+              builder: (BuildContext context) => const BudgetFormScreen(),
+            ),
+          );
+        },
+        child: const Icon(Icons.add),
+      );
+    },
+    bodyBuilder: (BuildContext context, WidgetRef ref) {
+      final AsyncValue<List<BudgetProgress>> budgetsAsync = ref.watch(
+        budgetsWithProgressProvider,
+      );
+      return budgetsAsync.when(
+        data: (List<BudgetProgress> items) {
+          if (items.isEmpty) {
+            return _BudgetsEmptyState(strings: strings);
+          }
+          return ListView.separated(
+            padding: const EdgeInsets.all(16),
+            itemBuilder: (BuildContext context, int index) {
+              final BudgetProgress progress = items[index];
+              return BudgetCard(
+                progress: progress,
+                onTap: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (BuildContext context) =>
+                          BudgetDetailScreen(budgetId: progress.budget.id),
+                    ),
+                  );
+                },
+              );
+            },
+            separatorBuilder: (BuildContext context, int index) =>
+                const SizedBox(height: 12),
+            itemCount: items.length,
+          );
+        },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (Object error, StackTrace stackTrace) {
+          return _BudgetsErrorState(
+            message: error.toString(),
+            strings: strings,
+          );
+        },
+      );
+    },
+  );
+}
+
+class _BudgetsEmptyState extends StatelessWidget {
+  const _BudgetsEmptyState({required this.strings});
+
+  final AppLocalizations strings;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Icon(
+              Icons.pie_chart_outline,
+              size: 64,
+              color: theme.colorScheme.primary,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              strings.budgetsEmptyTitle,
+              style: theme.textTheme.titleMedium,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              strings.budgetsEmptyMessage,
+              style: theme.textTheme.bodyMedium,
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _BudgetsErrorState extends StatelessWidget {
+  const _BudgetsErrorState({required this.message, required this.strings});
+
+  final String message;
+  final AppLocalizations strings;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Icon(
+              Icons.warning_amber_rounded,
+              size: 48,
+              color: theme.colorScheme.error,
+            ),
+            const SizedBox(height: 12),
+            Text(
+              strings.budgetsErrorTitle,
+              style: theme.textTheme.titleMedium,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              message,
+              style: theme.textTheme.bodySmall,
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/budgets/presentation/controllers/budget_form_controller.dart
+++ b/lib/features/budgets/presentation/controllers/budget_form_controller.dart
@@ -1,0 +1,202 @@
+import 'package:flutter/foundation.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:kopim/core/di/injectors.dart';
+import 'package:kopim/features/budgets/domain/entities/budget.dart';
+import 'package:kopim/features/budgets/domain/entities/budget_period.dart';
+import 'package:kopim/features/budgets/domain/entities/budget_scope.dart';
+import 'package:kopim/features/budgets/domain/use_cases/save_budget_use_case.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:uuid/uuid.dart';
+
+part 'budget_form_controller.freezed.dart';
+part 'budget_form_controller.g.dart';
+
+@immutable
+class BudgetFormParams {
+  const BudgetFormParams({this.initial});
+
+  final Budget? initial;
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is BudgetFormParams && other.initial == initial;
+  }
+
+  @override
+  int get hashCode => initial.hashCode;
+}
+
+@freezed
+abstract class BudgetFormState with _$BudgetFormState {
+  const factory BudgetFormState({
+    required String title,
+    required String amountText,
+    required BudgetPeriod period,
+    required BudgetScope scope,
+    required DateTime startDate,
+    DateTime? endDate,
+    @Default(<String>[]) List<String> categoryIds,
+    @Default(<String>[]) List<String> accountIds,
+    Budget? initialBudget,
+    @Default(false) bool isSubmitting,
+    String? errorMessage,
+  }) = _BudgetFormState;
+}
+
+@riverpod
+class BudgetFormController extends _$BudgetFormController {
+  @override
+  BudgetFormState build({BudgetFormParams params = const BudgetFormParams()}) {
+    final Budget? initial = params.initial;
+    if (initial != null) {
+      return BudgetFormState(
+        title: initial.title,
+        amountText: initial.amount.toStringAsFixed(2),
+        period: initial.period,
+        scope: initial.scope,
+        startDate: initial.startDate,
+        endDate: initial.endDate,
+        categoryIds: initial.categories,
+        accountIds: initial.accounts,
+        initialBudget: initial,
+      );
+    }
+    final DateTime now = DateTime.now();
+    return BudgetFormState(
+      title: '',
+      amountText: '0',
+      period: BudgetPeriod.monthly,
+      scope: BudgetScope.all,
+      startDate: DateTime(now.year, now.month, now.day, 0, 1),
+      endDate: null,
+      categoryIds: const <String>[],
+      accountIds: const <String>[],
+      initialBudget: null,
+    );
+  }
+
+  void setTitle(String value) {
+    state = state.copyWith(title: value);
+  }
+
+  void setAmountText(String value) {
+    state = state.copyWith(amountText: value);
+  }
+
+  void setPeriod(BudgetPeriod period) {
+    state = state.copyWith(period: period);
+  }
+
+  void setScope(BudgetScope scope) {
+    state = state.copyWith(scope: scope);
+  }
+
+  void setStartDate(DateTime date) {
+    state = state.copyWith(startDate: _normalizeStart(date));
+  }
+
+  void setEndDate(DateTime? date) {
+    state = state.copyWith(
+      endDate: date != null ? _normalizeStart(date) : null,
+    );
+  }
+
+  void toggleCategory(String categoryId) {
+    final List<String> categories = List<String>.from(state.categoryIds);
+    if (categories.contains(categoryId)) {
+      categories.remove(categoryId);
+    } else {
+      categories.add(categoryId);
+    }
+    state = state.copyWith(categoryIds: categories);
+  }
+
+  void toggleAccount(String accountId) {
+    final List<String> accounts = List<String>.from(state.accountIds);
+    if (accounts.contains(accountId)) {
+      accounts.remove(accountId);
+    } else {
+      accounts.add(accountId);
+    }
+    state = state.copyWith(accountIds: accounts);
+  }
+
+  void clearError() {
+    if (state.errorMessage != null) {
+      state = state.copyWith(errorMessage: null);
+    }
+  }
+
+  Future<bool> submit() async {
+    final double? amount = double.tryParse(
+      state.amountText.replaceAll(',', '.').trim(),
+    );
+    if (amount == null || amount <= 0) {
+      state = state.copyWith(errorMessage: 'invalid_amount');
+      return false;
+    }
+    if (state.title.trim().isEmpty) {
+      state = state.copyWith(errorMessage: 'missing_title');
+      return false;
+    }
+
+    state = state.copyWith(isSubmitting: true, errorMessage: null);
+    final SaveBudgetUseCase saveUseCase = ref.read(saveBudgetUseCaseProvider);
+    final Uuid uuid = ref.read(uuidGeneratorProvider);
+    final DateTime now = DateTime.now();
+
+    final List<String> categories = state.scope == BudgetScope.byCategory
+        ? state.categoryIds
+        : const <String>[];
+    final List<String> accounts = state.scope == BudgetScope.byAccount
+        ? state.accountIds
+        : const <String>[];
+
+    final Budget budget = state.initialBudget != null
+        ? state.initialBudget!.copyWith(
+            title: state.title.trim(),
+            period: state.period,
+            scope: state.scope,
+            startDate: _normalizeStart(state.startDate),
+            endDate: state.endDate != null
+                ? _normalizeStart(state.endDate!)
+                : null,
+            amount: amount,
+            categories: categories,
+            accounts: accounts,
+            updatedAt: now,
+          )
+        : Budget(
+            id: uuid.v4(),
+            title: state.title.trim(),
+            period: state.period,
+            startDate: _normalizeStart(state.startDate),
+            endDate: state.endDate != null
+                ? _normalizeStart(state.endDate!)
+                : null,
+            amount: amount,
+            scope: state.scope,
+            categories: categories,
+            accounts: accounts,
+            createdAt: now,
+            updatedAt: now,
+          );
+
+    try {
+      await saveUseCase(budget);
+      state = state.copyWith(isSubmitting: false, initialBudget: budget);
+      return true;
+    } catch (error) {
+      state = state.copyWith(
+        isSubmitting: false,
+        errorMessage: error.toString(),
+      );
+      return false;
+    }
+  }
+
+  DateTime _normalizeStart(DateTime date) {
+    return DateTime(date.year, date.month, date.day, 0, 1);
+  }
+}

--- a/lib/features/budgets/presentation/controllers/budget_form_controller.freezed.dart
+++ b/lib/features/budgets/presentation/controllers/budget_form_controller.freezed.dart
@@ -1,0 +1,349 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'budget_form_controller.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$BudgetFormState implements DiagnosticableTreeMixin {
+
+ String get title; String get amountText; BudgetPeriod get period; BudgetScope get scope; DateTime get startDate; DateTime? get endDate; List<String> get categoryIds; List<String> get accountIds; Budget? get initialBudget; bool get isSubmitting; String? get errorMessage;
+/// Create a copy of BudgetFormState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$BudgetFormStateCopyWith<BudgetFormState> get copyWith => _$BudgetFormStateCopyWithImpl<BudgetFormState>(this as BudgetFormState, _$identity);
+
+
+@override
+void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+  properties
+    ..add(DiagnosticsProperty('type', 'BudgetFormState'))
+    ..add(DiagnosticsProperty('title', title))..add(DiagnosticsProperty('amountText', amountText))..add(DiagnosticsProperty('period', period))..add(DiagnosticsProperty('scope', scope))..add(DiagnosticsProperty('startDate', startDate))..add(DiagnosticsProperty('endDate', endDate))..add(DiagnosticsProperty('categoryIds', categoryIds))..add(DiagnosticsProperty('accountIds', accountIds))..add(DiagnosticsProperty('initialBudget', initialBudget))..add(DiagnosticsProperty('isSubmitting', isSubmitting))..add(DiagnosticsProperty('errorMessage', errorMessage));
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is BudgetFormState&&(identical(other.title, title) || other.title == title)&&(identical(other.amountText, amountText) || other.amountText == amountText)&&(identical(other.period, period) || other.period == period)&&(identical(other.scope, scope) || other.scope == scope)&&(identical(other.startDate, startDate) || other.startDate == startDate)&&(identical(other.endDate, endDate) || other.endDate == endDate)&&const DeepCollectionEquality().equals(other.categoryIds, categoryIds)&&const DeepCollectionEquality().equals(other.accountIds, accountIds)&&(identical(other.initialBudget, initialBudget) || other.initialBudget == initialBudget)&&(identical(other.isSubmitting, isSubmitting) || other.isSubmitting == isSubmitting)&&(identical(other.errorMessage, errorMessage) || other.errorMessage == errorMessage));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,title,amountText,period,scope,startDate,endDate,const DeepCollectionEquality().hash(categoryIds),const DeepCollectionEquality().hash(accountIds),initialBudget,isSubmitting,errorMessage);
+
+@override
+String toString({ DiagnosticLevel minLevel = DiagnosticLevel.info }) {
+  return 'BudgetFormState(title: $title, amountText: $amountText, period: $period, scope: $scope, startDate: $startDate, endDate: $endDate, categoryIds: $categoryIds, accountIds: $accountIds, initialBudget: $initialBudget, isSubmitting: $isSubmitting, errorMessage: $errorMessage)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $BudgetFormStateCopyWith<$Res>  {
+  factory $BudgetFormStateCopyWith(BudgetFormState value, $Res Function(BudgetFormState) _then) = _$BudgetFormStateCopyWithImpl;
+@useResult
+$Res call({
+ String title, String amountText, BudgetPeriod period, BudgetScope scope, DateTime startDate, DateTime? endDate, List<String> categoryIds, List<String> accountIds, Budget? initialBudget, bool isSubmitting, String? errorMessage
+});
+
+
+$BudgetCopyWith<$Res>? get initialBudget;
+
+}
+/// @nodoc
+class _$BudgetFormStateCopyWithImpl<$Res>
+    implements $BudgetFormStateCopyWith<$Res> {
+  _$BudgetFormStateCopyWithImpl(this._self, this._then);
+
+  final BudgetFormState _self;
+  final $Res Function(BudgetFormState) _then;
+
+/// Create a copy of BudgetFormState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? title = null,Object? amountText = null,Object? period = null,Object? scope = null,Object? startDate = null,Object? endDate = freezed,Object? categoryIds = null,Object? accountIds = null,Object? initialBudget = freezed,Object? isSubmitting = null,Object? errorMessage = freezed,}) {
+  return _then(_self.copyWith(
+title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,amountText: null == amountText ? _self.amountText : amountText // ignore: cast_nullable_to_non_nullable
+as String,period: null == period ? _self.period : period // ignore: cast_nullable_to_non_nullable
+as BudgetPeriod,scope: null == scope ? _self.scope : scope // ignore: cast_nullable_to_non_nullable
+as BudgetScope,startDate: null == startDate ? _self.startDate : startDate // ignore: cast_nullable_to_non_nullable
+as DateTime,endDate: freezed == endDate ? _self.endDate : endDate // ignore: cast_nullable_to_non_nullable
+as DateTime?,categoryIds: null == categoryIds ? _self.categoryIds : categoryIds // ignore: cast_nullable_to_non_nullable
+as List<String>,accountIds: null == accountIds ? _self.accountIds : accountIds // ignore: cast_nullable_to_non_nullable
+as List<String>,initialBudget: freezed == initialBudget ? _self.initialBudget : initialBudget // ignore: cast_nullable_to_non_nullable
+as Budget?,isSubmitting: null == isSubmitting ? _self.isSubmitting : isSubmitting // ignore: cast_nullable_to_non_nullable
+as bool,errorMessage: freezed == errorMessage ? _self.errorMessage : errorMessage // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+/// Create a copy of BudgetFormState
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$BudgetCopyWith<$Res>? get initialBudget {
+    if (_self.initialBudget == null) {
+    return null;
+  }
+
+  return $BudgetCopyWith<$Res>(_self.initialBudget!, (value) {
+    return _then(_self.copyWith(initialBudget: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [BudgetFormState].
+extension BudgetFormStatePatterns on BudgetFormState {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _BudgetFormState value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _BudgetFormState() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _BudgetFormState value)  $default,){
+final _that = this;
+switch (_that) {
+case _BudgetFormState():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _BudgetFormState value)?  $default,){
+final _that = this;
+switch (_that) {
+case _BudgetFormState() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String title,  String amountText,  BudgetPeriod period,  BudgetScope scope,  DateTime startDate,  DateTime? endDate,  List<String> categoryIds,  List<String> accountIds,  Budget? initialBudget,  bool isSubmitting,  String? errorMessage)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _BudgetFormState() when $default != null:
+return $default(_that.title,_that.amountText,_that.period,_that.scope,_that.startDate,_that.endDate,_that.categoryIds,_that.accountIds,_that.initialBudget,_that.isSubmitting,_that.errorMessage);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String title,  String amountText,  BudgetPeriod period,  BudgetScope scope,  DateTime startDate,  DateTime? endDate,  List<String> categoryIds,  List<String> accountIds,  Budget? initialBudget,  bool isSubmitting,  String? errorMessage)  $default,) {final _that = this;
+switch (_that) {
+case _BudgetFormState():
+return $default(_that.title,_that.amountText,_that.period,_that.scope,_that.startDate,_that.endDate,_that.categoryIds,_that.accountIds,_that.initialBudget,_that.isSubmitting,_that.errorMessage);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String title,  String amountText,  BudgetPeriod period,  BudgetScope scope,  DateTime startDate,  DateTime? endDate,  List<String> categoryIds,  List<String> accountIds,  Budget? initialBudget,  bool isSubmitting,  String? errorMessage)?  $default,) {final _that = this;
+switch (_that) {
+case _BudgetFormState() when $default != null:
+return $default(_that.title,_that.amountText,_that.period,_that.scope,_that.startDate,_that.endDate,_that.categoryIds,_that.accountIds,_that.initialBudget,_that.isSubmitting,_that.errorMessage);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _BudgetFormState with DiagnosticableTreeMixin implements BudgetFormState {
+  const _BudgetFormState({required this.title, required this.amountText, required this.period, required this.scope, required this.startDate, this.endDate, final  List<String> categoryIds = const <String>[], final  List<String> accountIds = const <String>[], this.initialBudget, this.isSubmitting = false, this.errorMessage}): _categoryIds = categoryIds,_accountIds = accountIds;
+  
+
+@override final  String title;
+@override final  String amountText;
+@override final  BudgetPeriod period;
+@override final  BudgetScope scope;
+@override final  DateTime startDate;
+@override final  DateTime? endDate;
+ final  List<String> _categoryIds;
+@override@JsonKey() List<String> get categoryIds {
+  if (_categoryIds is EqualUnmodifiableListView) return _categoryIds;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_categoryIds);
+}
+
+ final  List<String> _accountIds;
+@override@JsonKey() List<String> get accountIds {
+  if (_accountIds is EqualUnmodifiableListView) return _accountIds;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_accountIds);
+}
+
+@override final  Budget? initialBudget;
+@override@JsonKey() final  bool isSubmitting;
+@override final  String? errorMessage;
+
+/// Create a copy of BudgetFormState
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$BudgetFormStateCopyWith<_BudgetFormState> get copyWith => __$BudgetFormStateCopyWithImpl<_BudgetFormState>(this, _$identity);
+
+
+@override
+void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+  properties
+    ..add(DiagnosticsProperty('type', 'BudgetFormState'))
+    ..add(DiagnosticsProperty('title', title))..add(DiagnosticsProperty('amountText', amountText))..add(DiagnosticsProperty('period', period))..add(DiagnosticsProperty('scope', scope))..add(DiagnosticsProperty('startDate', startDate))..add(DiagnosticsProperty('endDate', endDate))..add(DiagnosticsProperty('categoryIds', categoryIds))..add(DiagnosticsProperty('accountIds', accountIds))..add(DiagnosticsProperty('initialBudget', initialBudget))..add(DiagnosticsProperty('isSubmitting', isSubmitting))..add(DiagnosticsProperty('errorMessage', errorMessage));
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _BudgetFormState&&(identical(other.title, title) || other.title == title)&&(identical(other.amountText, amountText) || other.amountText == amountText)&&(identical(other.period, period) || other.period == period)&&(identical(other.scope, scope) || other.scope == scope)&&(identical(other.startDate, startDate) || other.startDate == startDate)&&(identical(other.endDate, endDate) || other.endDate == endDate)&&const DeepCollectionEquality().equals(other._categoryIds, _categoryIds)&&const DeepCollectionEquality().equals(other._accountIds, _accountIds)&&(identical(other.initialBudget, initialBudget) || other.initialBudget == initialBudget)&&(identical(other.isSubmitting, isSubmitting) || other.isSubmitting == isSubmitting)&&(identical(other.errorMessage, errorMessage) || other.errorMessage == errorMessage));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,title,amountText,period,scope,startDate,endDate,const DeepCollectionEquality().hash(_categoryIds),const DeepCollectionEquality().hash(_accountIds),initialBudget,isSubmitting,errorMessage);
+
+@override
+String toString({ DiagnosticLevel minLevel = DiagnosticLevel.info }) {
+  return 'BudgetFormState(title: $title, amountText: $amountText, period: $period, scope: $scope, startDate: $startDate, endDate: $endDate, categoryIds: $categoryIds, accountIds: $accountIds, initialBudget: $initialBudget, isSubmitting: $isSubmitting, errorMessage: $errorMessage)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$BudgetFormStateCopyWith<$Res> implements $BudgetFormStateCopyWith<$Res> {
+  factory _$BudgetFormStateCopyWith(_BudgetFormState value, $Res Function(_BudgetFormState) _then) = __$BudgetFormStateCopyWithImpl;
+@override @useResult
+$Res call({
+ String title, String amountText, BudgetPeriod period, BudgetScope scope, DateTime startDate, DateTime? endDate, List<String> categoryIds, List<String> accountIds, Budget? initialBudget, bool isSubmitting, String? errorMessage
+});
+
+
+@override $BudgetCopyWith<$Res>? get initialBudget;
+
+}
+/// @nodoc
+class __$BudgetFormStateCopyWithImpl<$Res>
+    implements _$BudgetFormStateCopyWith<$Res> {
+  __$BudgetFormStateCopyWithImpl(this._self, this._then);
+
+  final _BudgetFormState _self;
+  final $Res Function(_BudgetFormState) _then;
+
+/// Create a copy of BudgetFormState
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? title = null,Object? amountText = null,Object? period = null,Object? scope = null,Object? startDate = null,Object? endDate = freezed,Object? categoryIds = null,Object? accountIds = null,Object? initialBudget = freezed,Object? isSubmitting = null,Object? errorMessage = freezed,}) {
+  return _then(_BudgetFormState(
+title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,amountText: null == amountText ? _self.amountText : amountText // ignore: cast_nullable_to_non_nullable
+as String,period: null == period ? _self.period : period // ignore: cast_nullable_to_non_nullable
+as BudgetPeriod,scope: null == scope ? _self.scope : scope // ignore: cast_nullable_to_non_nullable
+as BudgetScope,startDate: null == startDate ? _self.startDate : startDate // ignore: cast_nullable_to_non_nullable
+as DateTime,endDate: freezed == endDate ? _self.endDate : endDate // ignore: cast_nullable_to_non_nullable
+as DateTime?,categoryIds: null == categoryIds ? _self._categoryIds : categoryIds // ignore: cast_nullable_to_non_nullable
+as List<String>,accountIds: null == accountIds ? _self._accountIds : accountIds // ignore: cast_nullable_to_non_nullable
+as List<String>,initialBudget: freezed == initialBudget ? _self.initialBudget : initialBudget // ignore: cast_nullable_to_non_nullable
+as Budget?,isSubmitting: null == isSubmitting ? _self.isSubmitting : isSubmitting // ignore: cast_nullable_to_non_nullable
+as bool,errorMessage: freezed == errorMessage ? _self.errorMessage : errorMessage // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+/// Create a copy of BudgetFormState
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$BudgetCopyWith<$Res>? get initialBudget {
+    if (_self.initialBudget == null) {
+    return null;
+  }
+
+  return $BudgetCopyWith<$Res>(_self.initialBudget!, (value) {
+    return _then(_self.copyWith(initialBudget: value));
+  });
+}
+}
+
+// dart format on

--- a/lib/features/budgets/presentation/controllers/budget_form_controller.g.dart
+++ b/lib/features/budgets/presentation/controllers/budget_form_controller.g.dart
@@ -1,0 +1,110 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'budget_form_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(BudgetFormController)
+const budgetFormControllerProvider = BudgetFormControllerFamily._();
+
+final class BudgetFormControllerProvider
+    extends $NotifierProvider<BudgetFormController, BudgetFormState> {
+  const BudgetFormControllerProvider._({
+    required BudgetFormControllerFamily super.from,
+    required BudgetFormParams super.argument,
+  }) : super(
+         retry: null,
+         name: r'budgetFormControllerProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$budgetFormControllerHash();
+
+  @override
+  String toString() {
+    return r'budgetFormControllerProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  BudgetFormController create() => BudgetFormController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(BudgetFormState value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<BudgetFormState>(value),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is BudgetFormControllerProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$budgetFormControllerHash() =>
+    r'e88b8615809778c33c119b827ec64a0f4cfcdc04';
+
+final class BudgetFormControllerFamily extends $Family
+    with
+        $ClassFamilyOverride<
+          BudgetFormController,
+          BudgetFormState,
+          BudgetFormState,
+          BudgetFormState,
+          BudgetFormParams
+        > {
+  const BudgetFormControllerFamily._()
+    : super(
+        retry: null,
+        name: r'budgetFormControllerProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  BudgetFormControllerProvider call({
+    BudgetFormParams params = const BudgetFormParams(),
+  }) => BudgetFormControllerProvider._(argument: params, from: this);
+
+  @override
+  String toString() => r'budgetFormControllerProvider';
+}
+
+abstract class _$BudgetFormController extends $Notifier<BudgetFormState> {
+  late final _$args = ref.$arg as BudgetFormParams;
+  BudgetFormParams get params => _$args;
+
+  BudgetFormState build({BudgetFormParams params = const BudgetFormParams()});
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build(params: _$args);
+    final ref = this.ref as $Ref<BudgetFormState, BudgetFormState>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<BudgetFormState, BudgetFormState>,
+              BudgetFormState,
+              Object?,
+              Object?
+            >;
+    element.handleValue(ref, created);
+  }
+}

--- a/lib/features/budgets/presentation/controllers/budgets_providers.dart
+++ b/lib/features/budgets/presentation/controllers/budgets_providers.dart
@@ -1,0 +1,140 @@
+import 'package:collection/collection.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'package:kopim/core/di/injectors.dart';
+import 'package:kopim/features/accounts/domain/entities/account_entity.dart';
+import 'package:kopim/features/budgets/domain/entities/budget.dart';
+import 'package:kopim/features/budgets/domain/entities/budget_instance.dart';
+import 'package:kopim/features/budgets/domain/entities/budget_progress.dart';
+import 'package:kopim/features/budgets/domain/repositories/budget_repository.dart';
+import 'package:kopim/features/budgets/domain/use_cases/compute_budget_progress_use_case.dart';
+import 'package:kopim/features/categories/domain/entities/category.dart';
+import 'package:kopim/features/transactions/domain/entities/transaction.dart';
+
+part 'budgets_providers.g.dart';
+
+@riverpod
+Stream<List<Budget>> budgetsStream(Ref ref) {
+  return ref.watch(watchBudgetsUseCaseProvider).call();
+}
+
+@riverpod
+Stream<List<TransactionEntity>> budgetTransactionsStream(Ref ref) {
+  return ref.watch(transactionRepositoryProvider).watchTransactions();
+}
+
+@riverpod
+Stream<List<AccountEntity>> budgetAccountsStream(Ref ref) {
+  return ref.watch(watchAccountsUseCaseProvider).call();
+}
+
+@riverpod
+Stream<List<Category>> budgetCategoriesStream(Ref ref) {
+  return ref.watch(watchCategoriesUseCaseProvider).call();
+}
+
+@riverpod
+AsyncValue<List<BudgetProgress>> budgetsWithProgress(Ref ref) {
+  final AsyncValue<List<Budget>> budgetsAsync = ref.watch(
+    budgetsStreamProvider,
+  );
+  final AsyncValue<List<TransactionEntity>> transactionsAsync = ref.watch(
+    budgetTransactionsStreamProvider,
+  );
+
+  if (budgetsAsync.isLoading || transactionsAsync.isLoading) {
+    return const AsyncValue<List<BudgetProgress>>.loading();
+  }
+
+  final Object? error = budgetsAsync.error ?? transactionsAsync.error;
+  if (error != null) {
+    return AsyncValue<List<BudgetProgress>>.error(
+      error,
+      budgetsAsync.stackTrace ??
+          transactionsAsync.stackTrace ??
+          StackTrace.empty,
+    );
+  }
+
+  final List<Budget> budgets = budgetsAsync.value ?? const <Budget>[];
+  final List<TransactionEntity> transactions =
+      transactionsAsync.value ?? const <TransactionEntity>[];
+  final ComputeBudgetProgressUseCase compute = ref.watch(
+    computeBudgetProgressUseCaseProvider,
+  );
+
+  final List<BudgetProgress> items = budgets
+      .map(
+        (Budget budget) => compute(budget: budget, transactions: transactions),
+      )
+      .sorted(
+        (BudgetProgress a, BudgetProgress b) =>
+            b.budget.updatedAt.compareTo(a.budget.updatedAt),
+      )
+      .toList(growable: false);
+
+  return AsyncValue<List<BudgetProgress>>.data(items);
+}
+
+@riverpod
+AsyncValue<BudgetProgress> budgetProgressById(Ref ref, String budgetId) {
+  final AsyncValue<List<BudgetProgress>> listAsync = ref.watch(
+    budgetsWithProgressProvider,
+  );
+  return listAsync.whenData(
+    (List<BudgetProgress> items) => items.firstWhere(
+      (BudgetProgress progress) => progress.budget.id == budgetId,
+      orElse: () => throw StateError('Budget $budgetId not found'),
+    ),
+  );
+}
+
+@riverpod
+AsyncValue<List<TransactionEntity>> budgetTransactionsById(
+  Ref ref,
+  String budgetId,
+) {
+  final AsyncValue<List<Budget>> budgetsAsync = ref.watch(
+    budgetsStreamProvider,
+  );
+  final AsyncValue<List<TransactionEntity>> transactionsAsync = ref.watch(
+    budgetTransactionsStreamProvider,
+  );
+  if (budgetsAsync.isLoading || transactionsAsync.isLoading) {
+    return const AsyncValue<List<TransactionEntity>>.loading();
+  }
+  final Object? error = budgetsAsync.error ?? transactionsAsync.error;
+  if (error != null) {
+    return AsyncValue<List<TransactionEntity>>.error(
+      error,
+      budgetsAsync.stackTrace ??
+          transactionsAsync.stackTrace ??
+          StackTrace.empty,
+    );
+  }
+  final Budget? budget = budgetsAsync.value?.firstWhereOrNull(
+    (Budget item) => item.id == budgetId,
+  );
+  if (budget == null) {
+    return const AsyncValue<List<TransactionEntity>>.data(
+      <TransactionEntity>[],
+    );
+  }
+  final ComputeBudgetProgressUseCase compute = ref.watch(
+    computeBudgetProgressUseCaseProvider,
+  );
+  final List<TransactionEntity> filtered = compute.filterTransactions(
+    budget: budget,
+    transactions: transactionsAsync.value ?? const <TransactionEntity>[],
+  );
+  return AsyncValue<List<TransactionEntity>>.data(filtered);
+}
+
+@riverpod
+Future<List<BudgetInstance>> budgetInstancesByBudget(
+  Ref ref,
+  String budgetId,
+) async {
+  final BudgetRepository repository = ref.watch(budgetRepositoryProvider);
+  return repository.loadInstances(budgetId);
+}

--- a/lib/features/budgets/presentation/controllers/budgets_providers.g.dart
+++ b/lib/features/budgets/presentation/controllers/budgets_providers.g.dart
@@ -1,0 +1,474 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'budgets_providers.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(budgetsStream)
+const budgetsStreamProvider = BudgetsStreamProvider._();
+
+final class BudgetsStreamProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<Budget>>,
+          List<Budget>,
+          Stream<List<Budget>>
+        >
+    with $FutureModifier<List<Budget>>, $StreamProvider<List<Budget>> {
+  const BudgetsStreamProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'budgetsStreamProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$budgetsStreamHash();
+
+  @$internal
+  @override
+  $StreamProviderElement<List<Budget>> $createElement(
+    $ProviderPointer pointer,
+  ) => $StreamProviderElement(pointer);
+
+  @override
+  Stream<List<Budget>> create(Ref ref) {
+    return budgetsStream(ref);
+  }
+}
+
+String _$budgetsStreamHash() => r'797212de1c19f0af950b15b3bbbdc429ac1d445d';
+
+@ProviderFor(budgetTransactionsStream)
+const budgetTransactionsStreamProvider = BudgetTransactionsStreamProvider._();
+
+final class BudgetTransactionsStreamProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<TransactionEntity>>,
+          List<TransactionEntity>,
+          Stream<List<TransactionEntity>>
+        >
+    with
+        $FutureModifier<List<TransactionEntity>>,
+        $StreamProvider<List<TransactionEntity>> {
+  const BudgetTransactionsStreamProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'budgetTransactionsStreamProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$budgetTransactionsStreamHash();
+
+  @$internal
+  @override
+  $StreamProviderElement<List<TransactionEntity>> $createElement(
+    $ProviderPointer pointer,
+  ) => $StreamProviderElement(pointer);
+
+  @override
+  Stream<List<TransactionEntity>> create(Ref ref) {
+    return budgetTransactionsStream(ref);
+  }
+}
+
+String _$budgetTransactionsStreamHash() =>
+    r'689adbc8b0d77aa1a6ef79d389160357a47b1ccd';
+
+@ProviderFor(budgetAccountsStream)
+const budgetAccountsStreamProvider = BudgetAccountsStreamProvider._();
+
+final class BudgetAccountsStreamProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<AccountEntity>>,
+          List<AccountEntity>,
+          Stream<List<AccountEntity>>
+        >
+    with
+        $FutureModifier<List<AccountEntity>>,
+        $StreamProvider<List<AccountEntity>> {
+  const BudgetAccountsStreamProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'budgetAccountsStreamProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$budgetAccountsStreamHash();
+
+  @$internal
+  @override
+  $StreamProviderElement<List<AccountEntity>> $createElement(
+    $ProviderPointer pointer,
+  ) => $StreamProviderElement(pointer);
+
+  @override
+  Stream<List<AccountEntity>> create(Ref ref) {
+    return budgetAccountsStream(ref);
+  }
+}
+
+String _$budgetAccountsStreamHash() =>
+    r'8884a5a979807f7ffc5021082793f15a1dced0ed';
+
+@ProviderFor(budgetCategoriesStream)
+const budgetCategoriesStreamProvider = BudgetCategoriesStreamProvider._();
+
+final class BudgetCategoriesStreamProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<Category>>,
+          List<Category>,
+          Stream<List<Category>>
+        >
+    with $FutureModifier<List<Category>>, $StreamProvider<List<Category>> {
+  const BudgetCategoriesStreamProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'budgetCategoriesStreamProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$budgetCategoriesStreamHash();
+
+  @$internal
+  @override
+  $StreamProviderElement<List<Category>> $createElement(
+    $ProviderPointer pointer,
+  ) => $StreamProviderElement(pointer);
+
+  @override
+  Stream<List<Category>> create(Ref ref) {
+    return budgetCategoriesStream(ref);
+  }
+}
+
+String _$budgetCategoriesStreamHash() =>
+    r'8389a92c1fdadf6a6f7e7820229683ca037a6dfb';
+
+@ProviderFor(budgetsWithProgress)
+const budgetsWithProgressProvider = BudgetsWithProgressProvider._();
+
+final class BudgetsWithProgressProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<BudgetProgress>>,
+          AsyncValue<List<BudgetProgress>>,
+          AsyncValue<List<BudgetProgress>>
+        >
+    with $Provider<AsyncValue<List<BudgetProgress>>> {
+  const BudgetsWithProgressProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'budgetsWithProgressProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$budgetsWithProgressHash();
+
+  @$internal
+  @override
+  $ProviderElement<AsyncValue<List<BudgetProgress>>> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  AsyncValue<List<BudgetProgress>> create(Ref ref) {
+    return budgetsWithProgress(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<List<BudgetProgress>> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AsyncValue<List<BudgetProgress>>>(
+        value,
+      ),
+    );
+  }
+}
+
+String _$budgetsWithProgressHash() =>
+    r'89904c6d80e517389af54ec72a7aca7833697ed3';
+
+@ProviderFor(budgetProgressById)
+const budgetProgressByIdProvider = BudgetProgressByIdFamily._();
+
+final class BudgetProgressByIdProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<BudgetProgress>,
+          AsyncValue<BudgetProgress>,
+          AsyncValue<BudgetProgress>
+        >
+    with $Provider<AsyncValue<BudgetProgress>> {
+  const BudgetProgressByIdProvider._({
+    required BudgetProgressByIdFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'budgetProgressByIdProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$budgetProgressByIdHash();
+
+  @override
+  String toString() {
+    return r'budgetProgressByIdProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $ProviderElement<AsyncValue<BudgetProgress>> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  AsyncValue<BudgetProgress> create(Ref ref) {
+    final argument = this.argument as String;
+    return budgetProgressById(ref, argument);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<BudgetProgress> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AsyncValue<BudgetProgress>>(value),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is BudgetProgressByIdProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$budgetProgressByIdHash() =>
+    r'98be397fb4e2bcc3eccd0b1156e268c66a63f52b';
+
+final class BudgetProgressByIdFamily extends $Family
+    with $FunctionalFamilyOverride<AsyncValue<BudgetProgress>, String> {
+  const BudgetProgressByIdFamily._()
+    : super(
+        retry: null,
+        name: r'budgetProgressByIdProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  BudgetProgressByIdProvider call(String budgetId) =>
+      BudgetProgressByIdProvider._(argument: budgetId, from: this);
+
+  @override
+  String toString() => r'budgetProgressByIdProvider';
+}
+
+@ProviderFor(budgetTransactionsById)
+const budgetTransactionsByIdProvider = BudgetTransactionsByIdFamily._();
+
+final class BudgetTransactionsByIdProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<TransactionEntity>>,
+          AsyncValue<List<TransactionEntity>>,
+          AsyncValue<List<TransactionEntity>>
+        >
+    with $Provider<AsyncValue<List<TransactionEntity>>> {
+  const BudgetTransactionsByIdProvider._({
+    required BudgetTransactionsByIdFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'budgetTransactionsByIdProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$budgetTransactionsByIdHash();
+
+  @override
+  String toString() {
+    return r'budgetTransactionsByIdProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $ProviderElement<AsyncValue<List<TransactionEntity>>> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  AsyncValue<List<TransactionEntity>> create(Ref ref) {
+    final argument = this.argument as String;
+    return budgetTransactionsById(ref, argument);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<List<TransactionEntity>> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AsyncValue<List<TransactionEntity>>>(
+        value,
+      ),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is BudgetTransactionsByIdProvider &&
+        other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$budgetTransactionsByIdHash() =>
+    r'abf328ad96ded79090fc64c79967638cd8e586ee';
+
+final class BudgetTransactionsByIdFamily extends $Family
+    with
+        $FunctionalFamilyOverride<AsyncValue<List<TransactionEntity>>, String> {
+  const BudgetTransactionsByIdFamily._()
+    : super(
+        retry: null,
+        name: r'budgetTransactionsByIdProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  BudgetTransactionsByIdProvider call(String budgetId) =>
+      BudgetTransactionsByIdProvider._(argument: budgetId, from: this);
+
+  @override
+  String toString() => r'budgetTransactionsByIdProvider';
+}
+
+@ProviderFor(budgetInstancesByBudget)
+const budgetInstancesByBudgetProvider = BudgetInstancesByBudgetFamily._();
+
+final class BudgetInstancesByBudgetProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<BudgetInstance>>,
+          List<BudgetInstance>,
+          FutureOr<List<BudgetInstance>>
+        >
+    with
+        $FutureModifier<List<BudgetInstance>>,
+        $FutureProvider<List<BudgetInstance>> {
+  const BudgetInstancesByBudgetProvider._({
+    required BudgetInstancesByBudgetFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'budgetInstancesByBudgetProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$budgetInstancesByBudgetHash();
+
+  @override
+  String toString() {
+    return r'budgetInstancesByBudgetProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $FutureProviderElement<List<BudgetInstance>> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<List<BudgetInstance>> create(Ref ref) {
+    final argument = this.argument as String;
+    return budgetInstancesByBudget(ref, argument);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is BudgetInstancesByBudgetProvider &&
+        other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$budgetInstancesByBudgetHash() =>
+    r'34b1e34789afb10dfe76892a7a3ccd6e56915370';
+
+final class BudgetInstancesByBudgetFamily extends $Family
+    with $FunctionalFamilyOverride<FutureOr<List<BudgetInstance>>, String> {
+  const BudgetInstancesByBudgetFamily._()
+    : super(
+        retry: null,
+        name: r'budgetInstancesByBudgetProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  BudgetInstancesByBudgetProvider call(String budgetId) =>
+      BudgetInstancesByBudgetProvider._(argument: budgetId, from: this);
+
+  @override
+  String toString() => r'budgetInstancesByBudgetProvider';
+}

--- a/lib/features/budgets/presentation/widgets/budget_card.dart
+++ b/lib/features/budgets/presentation/widgets/budget_card.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import 'package:kopim/features/budgets/domain/entities/budget_progress.dart';
+import 'package:kopim/features/budgets/presentation/widgets/budget_progress_indicator.dart';
+import 'package:kopim/l10n/app_localizations.dart';
+
+class BudgetCard extends StatelessWidget {
+  const BudgetCard({required this.progress, this.onTap, super.key});
+
+  final BudgetProgress progress;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final AppLocalizations strings = AppLocalizations.of(context)!;
+    final NumberFormat currencyFormat = NumberFormat.simpleCurrency(
+      locale: strings.localeName,
+    );
+    final double limit = progress.budget.amount;
+    final double spent = progress.spent;
+    final double remaining = progress.remaining;
+    final double ratio = progress.utilization.isFinite
+        ? progress.utilization.clamp(0, 2)
+        : 1.0;
+    final bool exceeded = progress.isExceeded;
+
+    return Material(
+      color: theme.colorScheme.surface,
+      borderRadius: BorderRadius.circular(16),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(16),
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Text(progress.budget.title, style: theme.textTheme.titleMedium),
+              const SizedBox(height: 12),
+              BudgetProgressIndicator(value: ratio, exceeded: exceeded),
+              const SizedBox(height: 12),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: <Widget>[
+                  _BudgetMetric(
+                    label: strings.budgetsSpentLabel,
+                    value: currencyFormat.format(spent),
+                  ),
+                  _BudgetMetric(
+                    label: strings.budgetsLimitLabel,
+                    value: currencyFormat.format(limit),
+                  ),
+                  _BudgetMetric(
+                    label: exceeded
+                        ? strings.budgetsExceededLabel
+                        : strings.budgetsRemainingLabel,
+                    value: currencyFormat.format(
+                      exceeded ? (spent - limit) : remaining,
+                    ),
+                    valueStyle: exceeded
+                        ? theme.textTheme.bodyMedium?.copyWith(
+                            color: theme.colorScheme.error,
+                            fontWeight: FontWeight.w600,
+                          )
+                        : null,
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _BudgetMetric extends StatelessWidget {
+  const _BudgetMetric({
+    required this.label,
+    required this.value,
+    this.valueStyle,
+  });
+
+  final String label;
+  final String value;
+  final TextStyle? valueStyle;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text(
+          label,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(value, style: valueStyle ?? theme.textTheme.bodyMedium),
+      ],
+    );
+  }
+}

--- a/lib/features/budgets/presentation/widgets/budget_progress_indicator.dart
+++ b/lib/features/budgets/presentation/widgets/budget_progress_indicator.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+
+class BudgetProgressIndicator extends StatelessWidget {
+  const BudgetProgressIndicator({
+    required this.value,
+    this.exceeded = false,
+    super.key,
+  });
+
+  final double value;
+  final bool exceeded;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final double clamped = value.isFinite ? value.clamp(0.0, 1.5) : 1.0;
+    final Color activeColor = exceeded
+        ? theme.colorScheme.error
+        : theme.colorScheme.primary;
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(12),
+      child: LinearProgressIndicator(
+        minHeight: 12,
+        value: clamped > 1 ? 1 : clamped,
+        backgroundColor: theme.colorScheme.surfaceContainerHighest,
+        valueColor: AlwaysStoppedAnimation<Color>(activeColor),
+      ),
+    );
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1084,5 +1084,169 @@
   "editAccountGenericError": "Could not update account. Please try again.",
   "@editAccountGenericError": {
     "description": "Generic error shown when updating the account fails"
+  },
+  "homeNavBudgets": "Budgets",
+  "@homeNavBudgets": {
+    "description": "Label for the budgets tab in the bottom navigation"
+  },
+  "budgetsTitle": "Budgets",
+  "@budgetsTitle": {
+    "description": "Title for the budgets list screen"
+  },
+  "budgetsEmptyTitle": "No budgets yet",
+  "@budgetsEmptyTitle": {
+    "description": "Headline shown when the user has not created budgets"
+  },
+  "budgetsEmptyMessage": "Create your first budget to track spending and stay on target.",
+  "@budgetsEmptyMessage": {
+    "description": "Supporting copy for the empty budgets state"
+  },
+  "budgetsErrorTitle": "Couldn't load budgets",
+  "@budgetsErrorTitle": {
+    "description": "Error headline shown when budgets stream fails"
+  },
+  "budgetsSpentLabel": "Spent",
+  "@budgetsSpentLabel": {
+    "description": "Label for the spent amount metric on a budget card"
+  },
+  "budgetsLimitLabel": "Limit",
+  "@budgetsLimitLabel": {
+    "description": "Label for the budget limit metric"
+  },
+  "budgetsRemainingLabel": "Remaining",
+  "@budgetsRemainingLabel": {
+    "description": "Label for the remaining amount metric"
+  },
+  "budgetsExceededLabel": "Over",
+  "@budgetsExceededLabel": {
+    "description": "Label used when a budget is exceeded"
+  },
+  "budgetDetailTitle": "Budget details",
+  "@budgetDetailTitle": {
+    "description": "Title for the budget detail screen"
+  },
+  "budgetDeleteTitle": "Delete budget?",
+  "@budgetDeleteTitle": {
+    "description": "Title for the delete budget confirmation dialog"
+  },
+  "budgetDeleteMessage": "This budget and its history will be removed. This action cannot be undone.",
+  "@budgetDeleteMessage": {
+    "description": "Body text for the delete budget confirmation dialog"
+  },
+  "budgetPeriodLabel": "Period: {start} – {end}",
+  "@budgetPeriodLabel": {
+    "description": "Label describing the time range covered by a budget instance",
+    "placeholders": {
+      "start": {
+        "type": "String"
+      },
+      "end": {
+        "type": "String"
+      }
+    }
+  },
+  "budgetTransactionsTitle": "Transactions",
+  "@budgetTransactionsTitle": {
+    "description": "Section title for transactions inside the budget detail screen"
+  },
+  "budgetTransactionsEmpty": "No transactions match this budget yet.",
+  "@budgetTransactionsEmpty": {
+    "description": "Message shown when no transactions are associated with the budget"
+  },
+  "budgetCreateTitle": "Create budget",
+  "@budgetCreateTitle": {
+    "description": "Title for the budget creation screen"
+  },
+  "budgetEditTitle": "Edit budget",
+  "@budgetEditTitle": {
+    "description": "Title for the budget editing screen"
+  },
+  "budgetTitleLabel": "Budget title",
+  "@budgetTitleLabel": {
+    "description": "Label for the budget title text field"
+  },
+  "budgetAmountLabel": "Limit amount",
+  "@budgetAmountLabel": {
+    "description": "Label for the budget amount input"
+  },
+  "budgetPeriodLabelShort": "Period",
+  "@budgetPeriodLabelShort": {
+    "description": "Label for the budget period dropdown"
+  },
+  "budgetScopeLabel": "Scope",
+  "@budgetScopeLabel": {
+    "description": "Label for the budget scope dropdown"
+  },
+  "budgetStartDateLabel": "Start date",
+  "@budgetStartDateLabel": {
+    "description": "Label for the start date picker"
+  },
+  "budgetEndDateLabel": "End date",
+  "@budgetEndDateLabel": {
+    "description": "Label for the end date picker"
+  },
+  "budgetCategoriesLabel": "Categories",
+  "@budgetCategoriesLabel": {
+    "description": "Label for the selected categories chips"
+  },
+  "budgetAccountsLabel": "Accounts",
+  "@budgetAccountsLabel": {
+    "description": "Label for the selected accounts chips"
+  },
+  "budgetPeriodMonthly": "Monthly",
+  "@budgetPeriodMonthly": {
+    "description": "Option label for monthly budgets"
+  },
+  "budgetPeriodWeekly": "Weekly",
+  "@budgetPeriodWeekly": {
+    "description": "Option label for weekly budgets"
+  },
+  "budgetPeriodCustom": "Custom range",
+  "@budgetPeriodCustom": {
+    "description": "Option label for custom budgets"
+  },
+  "budgetScopeAll": "All transactions",
+  "@budgetScopeAll": {
+    "description": "Option label for a budget covering all transactions"
+  },
+  "budgetScopeByCategory": "Selected categories",
+  "@budgetScopeByCategory": {
+    "description": "Option label for category-scoped budgets"
+  },
+  "budgetScopeByAccount": "Selected accounts",
+  "@budgetScopeByAccount": {
+    "description": "Option label for account-scoped budgets"
+  },
+  "budgetErrorInvalidAmount": "Enter a positive amount.",
+  "@budgetErrorInvalidAmount": {
+    "description": "Validation error shown when the amount is invalid"
+  },
+  "budgetErrorMissingTitle": "Enter a title for the budget.",
+  "@budgetErrorMissingTitle": {
+    "description": "Validation error shown when the title is missing"
+  },
+  "budgetNoEndDateLabel": "No end date",
+  "@budgetNoEndDateLabel": {
+    "description": "Placeholder shown when no end date is selected"
+  },
+  "editButtonLabel": "Edit",
+  "@editButtonLabel": {
+    "description": "Generic label for edit actions"
+  },
+  "deleteButtonLabel": "Delete",
+  "@deleteButtonLabel": {
+    "description": "Generic label for delete actions"
+  },
+  "cancelButtonLabel": "Cancel",
+  "@cancelButtonLabel": {
+    "description": "Generic label for cancel actions"
+  },
+  "saveButtonLabel": "Save",
+  "@saveButtonLabel": {
+    "description": "Generic label for save buttons"
+  },
+  "transactionDefaultTitle": "Transaction",
+  "@transactionDefaultTitle": {
+    "description": "Fallback title for transactions without a note"
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1519,6 +1519,240 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Could not update account. Please try again.'**
   String get editAccountGenericError;
+
+  /// Label for the budgets tab in the bottom navigation
+  ///
+  /// In en, this message translates to:
+  /// **'Budgets'**
+  String get homeNavBudgets;
+
+  /// Title for the budgets list screen
+  ///
+  /// In en, this message translates to:
+  /// **'Budgets'**
+  String get budgetsTitle;
+
+  /// Headline shown when the user has not created budgets
+  ///
+  /// In en, this message translates to:
+  /// **'No budgets yet'**
+  String get budgetsEmptyTitle;
+
+  /// Supporting copy for the empty budgets state
+  ///
+  /// In en, this message translates to:
+  /// **'Create your first budget to track spending and stay on target.'**
+  String get budgetsEmptyMessage;
+
+  /// Error headline shown when budgets stream fails
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t load budgets'**
+  String get budgetsErrorTitle;
+
+  /// Label for the spent amount metric on a budget card
+  ///
+  /// In en, this message translates to:
+  /// **'Spent'**
+  String get budgetsSpentLabel;
+
+  /// Label for the budget limit metric
+  ///
+  /// In en, this message translates to:
+  /// **'Limit'**
+  String get budgetsLimitLabel;
+
+  /// Label for the remaining amount metric
+  ///
+  /// In en, this message translates to:
+  /// **'Remaining'**
+  String get budgetsRemainingLabel;
+
+  /// Label used when a budget is exceeded
+  ///
+  /// In en, this message translates to:
+  /// **'Over'**
+  String get budgetsExceededLabel;
+
+  /// Title for the budget detail screen
+  ///
+  /// In en, this message translates to:
+  /// **'Budget details'**
+  String get budgetDetailTitle;
+
+  /// Title for the delete budget confirmation dialog
+  ///
+  /// In en, this message translates to:
+  /// **'Delete budget?'**
+  String get budgetDeleteTitle;
+
+  /// Body text for the delete budget confirmation dialog
+  ///
+  /// In en, this message translates to:
+  /// **'This budget and its history will be removed. This action cannot be undone.'**
+  String get budgetDeleteMessage;
+
+  /// Label describing the time range covered by a budget instance
+  ///
+  /// In en, this message translates to:
+  /// **'Period: {start} – {end}'**
+  String budgetPeriodLabel(String start, String end);
+
+  /// Section title for transactions inside the budget detail screen
+  ///
+  /// In en, this message translates to:
+  /// **'Transactions'**
+  String get budgetTransactionsTitle;
+
+  /// Message shown when no transactions are associated with the budget
+  ///
+  /// In en, this message translates to:
+  /// **'No transactions match this budget yet.'**
+  String get budgetTransactionsEmpty;
+
+  /// Title for the budget creation screen
+  ///
+  /// In en, this message translates to:
+  /// **'Create budget'**
+  String get budgetCreateTitle;
+
+  /// Title for the budget editing screen
+  ///
+  /// In en, this message translates to:
+  /// **'Edit budget'**
+  String get budgetEditTitle;
+
+  /// Label for the budget title text field
+  ///
+  /// In en, this message translates to:
+  /// **'Budget title'**
+  String get budgetTitleLabel;
+
+  /// Label for the budget amount input
+  ///
+  /// In en, this message translates to:
+  /// **'Limit amount'**
+  String get budgetAmountLabel;
+
+  /// Label for the budget period dropdown
+  ///
+  /// In en, this message translates to:
+  /// **'Period'**
+  String get budgetPeriodLabelShort;
+
+  /// Label for the budget scope dropdown
+  ///
+  /// In en, this message translates to:
+  /// **'Scope'**
+  String get budgetScopeLabel;
+
+  /// Label for the start date picker
+  ///
+  /// In en, this message translates to:
+  /// **'Start date'**
+  String get budgetStartDateLabel;
+
+  /// Label for the end date picker
+  ///
+  /// In en, this message translates to:
+  /// **'End date'**
+  String get budgetEndDateLabel;
+
+  /// Label for the selected categories chips
+  ///
+  /// In en, this message translates to:
+  /// **'Categories'**
+  String get budgetCategoriesLabel;
+
+  /// Label for the selected accounts chips
+  ///
+  /// In en, this message translates to:
+  /// **'Accounts'**
+  String get budgetAccountsLabel;
+
+  /// Option label for monthly budgets
+  ///
+  /// In en, this message translates to:
+  /// **'Monthly'**
+  String get budgetPeriodMonthly;
+
+  /// Option label for weekly budgets
+  ///
+  /// In en, this message translates to:
+  /// **'Weekly'**
+  String get budgetPeriodWeekly;
+
+  /// Option label for custom budgets
+  ///
+  /// In en, this message translates to:
+  /// **'Custom range'**
+  String get budgetPeriodCustom;
+
+  /// Option label for a budget covering all transactions
+  ///
+  /// In en, this message translates to:
+  /// **'All transactions'**
+  String get budgetScopeAll;
+
+  /// Option label for category-scoped budgets
+  ///
+  /// In en, this message translates to:
+  /// **'Selected categories'**
+  String get budgetScopeByCategory;
+
+  /// Option label for account-scoped budgets
+  ///
+  /// In en, this message translates to:
+  /// **'Selected accounts'**
+  String get budgetScopeByAccount;
+
+  /// Validation error shown when the amount is invalid
+  ///
+  /// In en, this message translates to:
+  /// **'Enter a positive amount.'**
+  String get budgetErrorInvalidAmount;
+
+  /// Validation error shown when the title is missing
+  ///
+  /// In en, this message translates to:
+  /// **'Enter a title for the budget.'**
+  String get budgetErrorMissingTitle;
+
+  /// Placeholder shown when no end date is selected
+  ///
+  /// In en, this message translates to:
+  /// **'No end date'**
+  String get budgetNoEndDateLabel;
+
+  /// Generic label for edit actions
+  ///
+  /// In en, this message translates to:
+  /// **'Edit'**
+  String get editButtonLabel;
+
+  /// Generic label for delete actions
+  ///
+  /// In en, this message translates to:
+  /// **'Delete'**
+  String get deleteButtonLabel;
+
+  /// Generic label for cancel actions
+  ///
+  /// In en, this message translates to:
+  /// **'Cancel'**
+  String get cancelButtonLabel;
+
+  /// Generic label for save buttons
+  ///
+  /// In en, this message translates to:
+  /// **'Save'**
+  String get saveButtonLabel;
+
+  /// Fallback title for transactions without a note
+  ///
+  /// In en, this message translates to:
+  /// **'Transaction'**
+  String get transactionDefaultTitle;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -804,4 +804,126 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get editAccountGenericError =>
       'Could not update account. Please try again.';
+
+  @override
+  String get homeNavBudgets => 'Budgets';
+
+  @override
+  String get budgetsTitle => 'Budgets';
+
+  @override
+  String get budgetsEmptyTitle => 'No budgets yet';
+
+  @override
+  String get budgetsEmptyMessage =>
+      'Create your first budget to track spending and stay on target.';
+
+  @override
+  String get budgetsErrorTitle => 'Couldn\'t load budgets';
+
+  @override
+  String get budgetsSpentLabel => 'Spent';
+
+  @override
+  String get budgetsLimitLabel => 'Limit';
+
+  @override
+  String get budgetsRemainingLabel => 'Remaining';
+
+  @override
+  String get budgetsExceededLabel => 'Over';
+
+  @override
+  String get budgetDetailTitle => 'Budget details';
+
+  @override
+  String get budgetDeleteTitle => 'Delete budget?';
+
+  @override
+  String get budgetDeleteMessage =>
+      'This budget and its history will be removed. This action cannot be undone.';
+
+  @override
+  String budgetPeriodLabel(String start, String end) {
+    return 'Period: $start – $end';
+  }
+
+  @override
+  String get budgetTransactionsTitle => 'Transactions';
+
+  @override
+  String get budgetTransactionsEmpty =>
+      'No transactions match this budget yet.';
+
+  @override
+  String get budgetCreateTitle => 'Create budget';
+
+  @override
+  String get budgetEditTitle => 'Edit budget';
+
+  @override
+  String get budgetTitleLabel => 'Budget title';
+
+  @override
+  String get budgetAmountLabel => 'Limit amount';
+
+  @override
+  String get budgetPeriodLabelShort => 'Period';
+
+  @override
+  String get budgetScopeLabel => 'Scope';
+
+  @override
+  String get budgetStartDateLabel => 'Start date';
+
+  @override
+  String get budgetEndDateLabel => 'End date';
+
+  @override
+  String get budgetCategoriesLabel => 'Categories';
+
+  @override
+  String get budgetAccountsLabel => 'Accounts';
+
+  @override
+  String get budgetPeriodMonthly => 'Monthly';
+
+  @override
+  String get budgetPeriodWeekly => 'Weekly';
+
+  @override
+  String get budgetPeriodCustom => 'Custom range';
+
+  @override
+  String get budgetScopeAll => 'All transactions';
+
+  @override
+  String get budgetScopeByCategory => 'Selected categories';
+
+  @override
+  String get budgetScopeByAccount => 'Selected accounts';
+
+  @override
+  String get budgetErrorInvalidAmount => 'Enter a positive amount.';
+
+  @override
+  String get budgetErrorMissingTitle => 'Enter a title for the budget.';
+
+  @override
+  String get budgetNoEndDateLabel => 'No end date';
+
+  @override
+  String get editButtonLabel => 'Edit';
+
+  @override
+  String get deleteButtonLabel => 'Delete';
+
+  @override
+  String get cancelButtonLabel => 'Cancel';
+
+  @override
+  String get saveButtonLabel => 'Save';
+
+  @override
+  String get transactionDefaultTitle => 'Transaction';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -807,4 +807,126 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String get editAccountGenericError =>
       'Не удалось обновить счёт. Повторите попытку.';
+
+  @override
+  String get homeNavBudgets => 'Бюджеты';
+
+  @override
+  String get budgetsTitle => 'Бюджеты';
+
+  @override
+  String get budgetsEmptyTitle => 'Пока нет бюджетов';
+
+  @override
+  String get budgetsEmptyMessage =>
+      'Создайте первый бюджет, чтобы контролировать расходы.';
+
+  @override
+  String get budgetsErrorTitle => 'Не удалось загрузить бюджеты';
+
+  @override
+  String get budgetsSpentLabel => 'Потрачено';
+
+  @override
+  String get budgetsLimitLabel => 'Лимит';
+
+  @override
+  String get budgetsRemainingLabel => 'Осталось';
+
+  @override
+  String get budgetsExceededLabel => 'Перерасход';
+
+  @override
+  String get budgetDetailTitle => 'Детали бюджета';
+
+  @override
+  String get budgetDeleteTitle => 'Удалить бюджет?';
+
+  @override
+  String get budgetDeleteMessage =>
+      'Бюджет и его история будут удалены. Отменить действие нельзя.';
+
+  @override
+  String budgetPeriodLabel(String start, String end) {
+    return 'Период: $start – $end';
+  }
+
+  @override
+  String get budgetTransactionsTitle => 'Транзакции';
+
+  @override
+  String get budgetTransactionsEmpty =>
+      'Для этого бюджета пока нет транзакций.';
+
+  @override
+  String get budgetCreateTitle => 'Новый бюджет';
+
+  @override
+  String get budgetEditTitle => 'Редактирование бюджета';
+
+  @override
+  String get budgetTitleLabel => 'Название бюджета';
+
+  @override
+  String get budgetAmountLabel => 'Сумма лимита';
+
+  @override
+  String get budgetPeriodLabelShort => 'Период';
+
+  @override
+  String get budgetScopeLabel => 'Область';
+
+  @override
+  String get budgetStartDateLabel => 'Дата начала';
+
+  @override
+  String get budgetEndDateLabel => 'Дата окончания';
+
+  @override
+  String get budgetCategoriesLabel => 'Категории';
+
+  @override
+  String get budgetAccountsLabel => 'Счета';
+
+  @override
+  String get budgetPeriodMonthly => 'Ежемесячно';
+
+  @override
+  String get budgetPeriodWeekly => 'Еженедельно';
+
+  @override
+  String get budgetPeriodCustom => 'Произвольный период';
+
+  @override
+  String get budgetScopeAll => 'Все транзакции';
+
+  @override
+  String get budgetScopeByCategory => 'Выбранные категории';
+
+  @override
+  String get budgetScopeByAccount => 'Выбранные счета';
+
+  @override
+  String get budgetErrorInvalidAmount => 'Введите положительную сумму.';
+
+  @override
+  String get budgetErrorMissingTitle => 'Введите название бюджета.';
+
+  @override
+  String get budgetNoEndDateLabel => 'Без даты окончания';
+
+  @override
+  String get editButtonLabel => 'Редактировать';
+
+  @override
+  String get deleteButtonLabel => 'Удалить';
+
+  @override
+  String get cancelButtonLabel => 'Отмена';
+
+  @override
+  String get saveButtonLabel => 'Сохранить';
+
+  @override
+  String get transactionDefaultTitle => 'Транзакция';
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1084,5 +1084,169 @@
   "editAccountGenericError": "Не удалось обновить счёт. Повторите попытку.",
   "@editAccountGenericError": {
     "description": "Общее сообщение об ошибке при обновлении счёта"
+  },
+  "homeNavBudgets": "Бюджеты",
+  "@homeNavBudgets": {
+    "description": "Подпись вкладки бюджетов в нижней навигации"
+  },
+  "budgetsTitle": "Бюджеты",
+  "@budgetsTitle": {
+    "description": "Заголовок экрана списка бюджетов"
+  },
+  "budgetsEmptyTitle": "Пока нет бюджетов",
+  "@budgetsEmptyTitle": {
+    "description": "Заголовок пустого состояния списков бюджетов"
+  },
+  "budgetsEmptyMessage": "Создайте первый бюджет, чтобы контролировать расходы.",
+  "@budgetsEmptyMessage": {
+    "description": "Сообщение пустого состояния для экранов бюджетов"
+  },
+  "budgetsErrorTitle": "Не удалось загрузить бюджеты",
+  "@budgetsErrorTitle": {
+    "description": "Сообщение об ошибке при загрузке бюджетов"
+  },
+  "budgetsSpentLabel": "Потрачено",
+  "@budgetsSpentLabel": {
+    "description": "Подпись метрики потраченной суммы"
+  },
+  "budgetsLimitLabel": "Лимит",
+  "@budgetsLimitLabel": {
+    "description": "Подпись метрики лимита бюджета"
+  },
+  "budgetsRemainingLabel": "Осталось",
+  "@budgetsRemainingLabel": {
+    "description": "Подпись метрики оставшейся суммы"
+  },
+  "budgetsExceededLabel": "Перерасход",
+  "@budgetsExceededLabel": {
+    "description": "Подпись метрики при превышении бюджета"
+  },
+  "budgetDetailTitle": "Детали бюджета",
+  "@budgetDetailTitle": {
+    "description": "Заголовок экрана деталей бюджета"
+  },
+  "budgetDeleteTitle": "Удалить бюджет?",
+  "@budgetDeleteTitle": {
+    "description": "Заголовок диалога подтверждения удаления бюджета"
+  },
+  "budgetDeleteMessage": "Бюджет и его история будут удалены. Отменить действие нельзя.",
+  "@budgetDeleteMessage": {
+    "description": "Сообщение в диалоге удаления бюджета"
+  },
+  "budgetPeriodLabel": "Период: {start} – {end}",
+  "@budgetPeriodLabel": {
+    "description": "Подпись диапазона дат экземпляра бюджета",
+    "placeholders": {
+      "start": {
+        "type": "String"
+      },
+      "end": {
+        "type": "String"
+      }
+    }
+  },
+  "budgetTransactionsTitle": "Транзакции",
+  "@budgetTransactionsTitle": {
+    "description": "Заголовок списка транзакций в деталях бюджета"
+  },
+  "budgetTransactionsEmpty": "Для этого бюджета пока нет транзакций.",
+  "@budgetTransactionsEmpty": {
+    "description": "Сообщение при отсутствии транзакций в бюджете"
+  },
+  "budgetCreateTitle": "Новый бюджет",
+  "@budgetCreateTitle": {
+    "description": "Заголовок экрана создания бюджета"
+  },
+  "budgetEditTitle": "Редактирование бюджета",
+  "@budgetEditTitle": {
+    "description": "Заголовок экрана редактирования бюджета"
+  },
+  "budgetTitleLabel": "Название бюджета",
+  "@budgetTitleLabel": {
+    "description": "Подпись поля названия бюджета"
+  },
+  "budgetAmountLabel": "Сумма лимита",
+  "@budgetAmountLabel": {
+    "description": "Подпись поля суммы бюджета"
+  },
+  "budgetPeriodLabelShort": "Период",
+  "@budgetPeriodLabelShort": {
+    "description": "Подпись выбора периода бюджета"
+  },
+  "budgetScopeLabel": "Область",
+  "@budgetScopeLabel": {
+    "description": "Подпись выбора области бюджета"
+  },
+  "budgetStartDateLabel": "Дата начала",
+  "@budgetStartDateLabel": {
+    "description": "Подпись выбора даты начала"
+  },
+  "budgetEndDateLabel": "Дата окончания",
+  "@budgetEndDateLabel": {
+    "description": "Подпись выбора даты окончания"
+  },
+  "budgetCategoriesLabel": "Категории",
+  "@budgetCategoriesLabel": {
+    "description": "Подпись списка выбранных категорий"
+  },
+  "budgetAccountsLabel": "Счета",
+  "@budgetAccountsLabel": {
+    "description": "Подпись списка выбранных счетов"
+  },
+  "budgetPeriodMonthly": "Ежемесячно",
+  "@budgetPeriodMonthly": {
+    "description": "Вариант для ежемесячного бюджета"
+  },
+  "budgetPeriodWeekly": "Еженедельно",
+  "@budgetPeriodWeekly": {
+    "description": "Вариант для еженедельного бюджета"
+  },
+  "budgetPeriodCustom": "Произвольный период",
+  "@budgetPeriodCustom": {
+    "description": "Вариант для пользовательского бюджета"
+  },
+  "budgetScopeAll": "Все транзакции",
+  "@budgetScopeAll": {
+    "description": "Вариант бюджета со всеми транзакциями"
+  },
+  "budgetScopeByCategory": "Выбранные категории",
+  "@budgetScopeByCategory": {
+    "description": "Вариант бюджета по категориям"
+  },
+  "budgetScopeByAccount": "Выбранные счета",
+  "@budgetScopeByAccount": {
+    "description": "Вариант бюджета по счетам"
+  },
+  "budgetErrorInvalidAmount": "Введите положительную сумму.",
+  "@budgetErrorInvalidAmount": {
+    "description": "Ошибка валидации при неверной сумме"
+  },
+  "budgetErrorMissingTitle": "Введите название бюджета.",
+  "@budgetErrorMissingTitle": {
+    "description": "Ошибка валидации при пустом названии"
+  },
+  "budgetNoEndDateLabel": "Без даты окончания",
+  "@budgetNoEndDateLabel": {
+    "description": "Подпись при отсутствии даты окончания"
+  },
+  "editButtonLabel": "Редактировать",
+  "@editButtonLabel": {
+    "description": "Общая подпись для действий редактирования"
+  },
+  "deleteButtonLabel": "Удалить",
+  "@deleteButtonLabel": {
+    "description": "Общая подпись для действий удаления"
+  },
+  "cancelButtonLabel": "Отмена",
+  "@cancelButtonLabel": {
+    "description": "Общая подпись кнопки отмены"
+  },
+  "saveButtonLabel": "Сохранить",
+  "@saveButtonLabel": {
+    "description": "Общая подпись кнопки сохранения"
+  },
+  "transactionDefaultTitle": "Транзакция",
+  "@transactionDefaultTitle": {
+    "description": "Резервный заголовок транзакции без примечания"
   }
 }

--- a/test/core/services/sync_service_profile_test.dart
+++ b/test/core/services/sync_service_profile_test.dart
@@ -12,6 +12,8 @@ import 'package:kopim/core/data/database.dart' as db;
 import 'package:kopim/core/data/outbox/outbox_dao.dart';
 import 'package:kopim/core/services/sync_service.dart';
 import 'package:kopim/features/accounts/data/sources/remote/account_remote_data_source.dart';
+import 'package:kopim/features/budgets/data/sources/remote/budget_instance_remote_data_source.dart';
+import 'package:kopim/features/budgets/data/sources/remote/budget_remote_data_source.dart';
 import 'package:kopim/features/categories/data/sources/remote/category_remote_data_source.dart';
 import 'package:kopim/features/profile/data/local/profile_dao.dart';
 import 'package:kopim/features/profile/data/profile_repository_impl.dart';
@@ -80,6 +82,8 @@ void main() {
       accountRemoteDataSource: AccountRemoteDataSource(firestore),
       categoryRemoteDataSource: CategoryRemoteDataSource(firestore),
       transactionRemoteDataSource: TransactionRemoteDataSource(firestore),
+      budgetRemoteDataSource: BudgetRemoteDataSource(firestore),
+      budgetInstanceRemoteDataSource: BudgetInstanceRemoteDataSource(firestore),
       profileRemoteDataSource: profileRemote,
       firebaseAuth: firebaseAuth,
       connectivity: connectivity,

--- a/test/features/analytics/presentation/analytics_screen_test.dart
+++ b/test/features/analytics/presentation/analytics_screen_test.dart
@@ -1,0 +1,147 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart' show Override;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
+import 'package:kopim/features/accounts/domain/entities/account_entity.dart';
+import 'package:kopim/features/analytics/domain/models/analytics_category_breakdown.dart';
+import 'package:kopim/features/analytics/domain/models/analytics_overview.dart';
+import 'package:kopim/features/analytics/presentation/analytics_screen.dart';
+import 'package:kopim/features/analytics/presentation/controllers/analytics_filter_controller.dart';
+import 'package:kopim/features/analytics/presentation/controllers/analytics_providers.dart';
+import 'package:kopim/features/categories/domain/entities/category.dart';
+import 'package:kopim/l10n/app_localizations.dart';
+
+class _FakeAnalyticsFilterController extends AnalyticsFilterController {
+  _FakeAnalyticsFilterController(this._state);
+
+  final AnalyticsFilterState _state;
+
+  @override
+  AnalyticsFilterState build() => _state;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('AnalyticsScreen', () {
+    testWidgets(
+      'renders header with titleLarge typography and legend entries',
+      (WidgetTester tester) async {
+        final AnalyticsFilterState filterState = AnalyticsFilterState(
+          dateRange: DateTimeRange(
+            start: DateTime(2024, 1, 1),
+            end: DateTime(2024, 1, 31),
+          ),
+        );
+
+        const AnalyticsOverview overview = AnalyticsOverview(
+          totalIncome: 0.0,
+          totalExpense: 100.0,
+          netBalance: -100.0,
+          topExpenseCategories: <AnalyticsCategoryBreakdown>[
+            AnalyticsCategoryBreakdown(categoryId: 'food', amount: 60.0),
+            AnalyticsCategoryBreakdown(categoryId: 'transport', amount: 40.0),
+          ],
+          topIncomeCategories: <AnalyticsCategoryBreakdown>[],
+        );
+
+        final Category foodCategory = Category(
+          id: 'food',
+          name: 'Groceries',
+          type: 'expense',
+          color: '#FF5722',
+          icon: null,
+          parentId: null,
+          createdAt: DateTime(2023, 1, 1),
+          updatedAt: DateTime(2023, 1, 1),
+        );
+        final Category transportCategory = Category(
+          id: 'transport',
+          name: 'Transport',
+          type: 'expense',
+          color: '#03A9F4',
+          icon: null,
+          parentId: null,
+          createdAt: DateTime(2023, 1, 1),
+          updatedAt: DateTime(2023, 1, 1),
+        );
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: <Override>[
+              analyticsFilterControllerProvider.overrideWith(
+                () => _FakeAnalyticsFilterController(filterState),
+              ),
+              analyticsFilteredStatsProvider(
+                topCategoriesLimit: 5,
+              ).overrideWith(
+                (Ref ref) => Stream<AnalyticsOverview>.value(overview),
+              ),
+              analyticsCategoriesProvider.overrideWith(
+                (Ref ref) => Stream<List<Category>>.value(<Category>[
+                  foodCategory,
+                  transportCategory,
+                ]),
+              ),
+              analyticsAccountsProvider.overrideWith(
+                (Ref ref) => Stream<List<AccountEntity>>.value(<AccountEntity>[
+                  AccountEntity(
+                    id: 'acc',
+                    name: 'Main',
+                    balance: 0,
+                    currency: 'USD',
+                    type: 'checking',
+                    createdAt: DateTime(2023, 1, 1),
+                    updatedAt: DateTime(2023, 1, 1),
+                    isDeleted: false,
+                  ),
+                ]),
+              ),
+            ],
+            // ignore: prefer_const_constructors
+            child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: const AnalyticsScreen(),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        final BuildContext context = tester.element(
+          find.byType(AnalyticsScreen),
+        );
+        final AppLocalizations strings = AppLocalizations.of(context)!;
+        final ThemeData theme = Theme.of(context);
+        final DateFormat rangeFormat = DateFormat.yMMMMd(strings.localeName);
+        final String start = rangeFormat.format(filterState.dateRange.start);
+        final String end = rangeFormat.format(filterState.dateRange.end);
+        final String rangeLabel = start == end
+            ? start
+            : strings.analyticsFilterDateValue(start, end);
+        final String expectedHeader = strings.analyticsOverviewRangeTitle(
+          rangeLabel,
+        );
+
+        final Text headerText = tester.widget<Text>(find.text(expectedHeader));
+        expect(headerText.style, theme.textTheme.titleLarge);
+
+        final Iterable<Card> cards = tester.widgetList<Card>(find.byType(Card));
+        for (final Card card in cards) {
+          expect(card.elevation, 0);
+          expect(card.surfaceTintColor, Colors.transparent);
+        }
+
+        expect(find.text('Groceries'), findsOneWidget);
+        expect(find.text('Transport'), findsOneWidget);
+
+        final NumberFormat currencyFormat = NumberFormat.simpleCurrency(
+          locale: strings.localeName,
+        );
+        expect(find.text(currencyFormat.format(60)), findsWidgets);
+      },
+    );
+  });
+}

--- a/test/features/analytics/presentation/widgets/analytics_chart_test.dart
+++ b/test/features/analytics/presentation/widgets/analytics_chart_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kopim/features/analytics/presentation/widgets/analytics_chart.dart';
+
+void main() {
+  testWidgets('AnalyticsDonutChart renders percentage labels for segments', (
+    WidgetTester tester,
+  ) async {
+    final List<AnalyticsChartItem> items = <AnalyticsChartItem>[
+      const AnalyticsChartItem(title: 'A', amount: 60, color: Colors.red),
+      const AnalyticsChartItem(title: 'B', amount: 40, color: Colors.blue),
+    ];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: SizedBox(
+              width: 240,
+              height: 240,
+              child: AnalyticsDonutChart(
+                items: items,
+                backgroundColor: Colors.grey.shade200,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('60%'), findsOneWidget);
+    expect(find.text('40%'), findsOneWidget);
+  });
+}

--- a/test/features/app_shell/presentation/main_navigation_shell_test.dart
+++ b/test/features/app_shell/presentation/main_navigation_shell_test.dart
@@ -9,6 +9,11 @@ import 'package:kopim/features/accounts/domain/repositories/account_repository.d
 import 'package:kopim/features/accounts/domain/use_cases/watch_accounts_use_case.dart';
 import 'package:kopim/features/analytics/domain/use_cases/watch_monthly_analytics_use_case.dart';
 import 'package:kopim/features/app_shell/presentation/widgets/main_navigation_shell.dart';
+import 'package:kopim/features/budgets/domain/entities/budget.dart';
+import 'package:kopim/features/budgets/domain/entities/budget_instance.dart';
+import 'package:kopim/features/budgets/domain/entities/budget_progress.dart';
+import 'package:kopim/features/budgets/domain/use_cases/compute_budget_progress_use_case.dart';
+import 'package:kopim/features/budgets/presentation/controllers/budgets_providers.dart';
 import 'package:kopim/features/categories/domain/entities/category.dart';
 import 'package:kopim/features/categories/domain/entities/category_tree_node.dart';
 import 'package:kopim/features/categories/domain/repositories/category_repository.dart';
@@ -178,6 +183,39 @@ void main() {
           (Ref ref) =>
               Stream<List<UpcomingPayment>>.value(const <UpcomingPayment>[]),
         ),
+        budgetsStreamProvider.overrideWith(
+          (Ref ref) => Stream<List<Budget>>.value(const <Budget>[]),
+        ),
+        budgetTransactionsStreamProvider.overrideWith(
+          (Ref ref) => Stream<List<TransactionEntity>>.value(
+            const <TransactionEntity>[],
+          ),
+        ),
+        budgetAccountsStreamProvider.overrideWith(
+          (Ref ref) =>
+              Stream<List<AccountEntity>>.value(const <AccountEntity>[]),
+        ),
+        budgetCategoriesStreamProvider.overrideWith(
+          (Ref ref) => Stream<List<Category>>.value(const <Category>[]),
+        ),
+        computeBudgetProgressUseCaseProvider.overrideWithValue(
+          ComputeBudgetProgressUseCase(),
+        ),
+        budgetsWithProgressProvider.overrideWith(
+          (Ref ref) =>
+              const AsyncValue<List<BudgetProgress>>.data(<BudgetProgress>[]),
+        ),
+        budgetProgressByIdProvider.overrideWith(
+          (Ref ref, String _) => const AsyncValue<BudgetProgress>.loading(),
+        ),
+        budgetTransactionsByIdProvider.overrideWith(
+          (Ref ref, String _) => const AsyncValue<List<TransactionEntity>>.data(
+            <TransactionEntity>[],
+          ),
+        ),
+        budgetInstancesByBudgetProvider.overrideWith(
+          (Ref ref, String _) async => const <BudgetInstance>[],
+        ),
       ],
       child: child,
     );
@@ -197,29 +235,17 @@ void main() {
       ),
     );
 
-    await tester.pumpAndSettle(
-      const Duration(milliseconds: 16),
-      EnginePhase.sendSemanticsUpdate,
-      const Duration(seconds: 2),
-    );
+    await tester.pumpAndSettle();
 
     final Finder bottomNavFinder = find.byType(BottomNavigationBar);
     expect(bottomNavFinder, findsOneWidget);
 
     await tester.tap(find.text('Analytics'));
-    await tester.pumpAndSettle(
-      const Duration(milliseconds: 16),
-      EnginePhase.sendSemanticsUpdate,
-      const Duration(seconds: 2),
-    );
+    await tester.pumpAndSettle();
     expect(bottomNavFinder, findsOneWidget);
 
     await tester.tap(find.text('Settings'));
-    await tester.pumpAndSettle(
-      const Duration(milliseconds: 16),
-      EnginePhase.sendSemanticsUpdate,
-      const Duration(seconds: 2),
-    );
+    await tester.pumpAndSettle();
     expect(bottomNavFinder, findsOneWidget);
   });
 
@@ -237,11 +263,7 @@ void main() {
       ),
     );
 
-    await tester.pumpAndSettle(
-      const Duration(milliseconds: 16),
-      EnginePhase.sendSemanticsUpdate,
-      const Duration(seconds: 2),
-    );
+    await tester.pumpAndSettle();
 
     navigatorKey.currentState!.push(
       MaterialPageRoute<void>(
@@ -250,20 +272,12 @@ void main() {
       ),
     );
 
-    await tester.pumpAndSettle(
-      const Duration(milliseconds: 16),
-      EnginePhase.sendSemanticsUpdate,
-      const Duration(seconds: 2),
-    );
+    await tester.pumpAndSettle();
 
     expect(find.byType(BottomNavigationBar), findsNothing);
 
     navigatorKey.currentState!.pop();
-    await tester.pumpAndSettle(
-      const Duration(milliseconds: 16),
-      EnginePhase.sendSemanticsUpdate,
-      const Duration(seconds: 2),
-    );
+    await tester.pumpAndSettle();
 
     expect(find.byType(BottomNavigationBar), findsOneWidget);
   });

--- a/test/features/budgets/domain/services/budget_schedule_test.dart
+++ b/test/features/budgets/domain/services/budget_schedule_test.dart
@@ -1,0 +1,143 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kopim/features/budgets/domain/entities/budget.dart';
+import 'package:kopim/features/budgets/domain/entities/budget_instance.dart';
+import 'package:kopim/features/budgets/domain/entities/budget_instance_status.dart';
+import 'package:kopim/features/budgets/domain/entities/budget_period.dart';
+import 'package:kopim/features/budgets/domain/entities/budget_scope.dart';
+import 'package:kopim/features/budgets/domain/services/budget_schedule.dart';
+
+void main() {
+  const BudgetSchedule schedule = BudgetSchedule();
+
+  Budget buildBudget({
+    required DateTime start,
+    DateTime? end,
+    BudgetPeriod period = BudgetPeriod.monthly,
+  }) {
+    return Budget(
+      id: 'budget',
+      title: 'Test',
+      period: period,
+      startDate: start,
+      endDate: end,
+      amount: 1000,
+      scope: BudgetScope.all,
+      categories: const <String>[],
+      accounts: const <String>[],
+      createdAt: start,
+      updatedAt: start,
+    );
+  }
+
+  group('BudgetSchedule.periodFor', () {
+    test('returns normalized monthly window based on reference', () {
+      final DateTime initial = DateTime.utc(2024, 1, 15, 13, 45);
+      final Budget budget = buildBudget(start: initial);
+      final ({DateTime start, DateTime end}) period = schedule.periodFor(
+        budget: budget,
+        reference: DateTime.utc(2024, 3, 5),
+      );
+
+      expect(
+        period.start.isAtSameMomentAs(DateTime.utc(2024, 2, 15, 0, 1)),
+        isTrue,
+      );
+      expect(
+        period.end.isAtSameMomentAs(DateTime.utc(2024, 3, 15, 0, 1)),
+        isTrue,
+      );
+    });
+
+    test('uses normalized bounds for custom budgets with invalid end', () {
+      final DateTime start = DateTime.utc(2024, 4, 20, 18);
+      final Budget budget = buildBudget(
+        start: start,
+        end: DateTime.utc(2024, 4, 19),
+        period: BudgetPeriod.custom,
+      );
+
+      final ({DateTime start, DateTime end}) period = schedule.periodFor(
+        budget: budget,
+      );
+
+      expect(
+        period.start.isAtSameMomentAs(DateTime.utc(2024, 4, 20, 0, 1)),
+        isTrue,
+      );
+      expect(
+        period.end.isAtSameMomentAs(DateTime.utc(2024, 4, 21, 0, 1)),
+        isTrue,
+      );
+    });
+  });
+
+  group('BudgetSchedule.generateUpcomingInstances', () {
+    test('produces instances aligned to 00:01 and sequential periods', () {
+      final Budget budget = buildBudget(start: DateTime.utc(2024, 6, 30, 12));
+      final Iterable<BudgetInstance> instances = schedule
+          .generateUpcomingInstances(
+            budget: budget,
+            from: DateTime.utc(2024, 6, 30, 12),
+            count: 2,
+            idBuilder: (DateTime start) =>
+                'instance-${start.toIso8601String()}',
+          );
+
+      final List<BudgetInstance> list = instances.toList();
+      expect(list, hasLength(2));
+      expect(
+        list.first.periodStart.isAtSameMomentAs(
+          DateTime.utc(2024, 6, 30, 0, 1),
+        ),
+        isTrue,
+      );
+      expect(
+        list.first.periodEnd.isAtSameMomentAs(DateTime.utc(2024, 7, 30, 0, 1)),
+        isTrue,
+      );
+      expect(list.first.status, BudgetInstanceStatus.active);
+      expect(
+        list.last.periodStart.isAtSameMomentAs(DateTime.utc(2024, 7, 30, 0, 1)),
+        isTrue,
+      );
+      expect(
+        list.last.periodEnd.isAtSameMomentAs(DateTime.utc(2024, 8, 30, 0, 1)),
+        isTrue,
+      );
+    });
+  });
+
+  group('BudgetSchedule.statusFor', () {
+    test('returns pending before start and active within window', () {
+      final DateTime start = DateTime.utc(2024, 5, 1, 0, 1);
+      final DateTime end = DateTime.utc(2024, 6, 1, 0, 1);
+
+      expect(
+        schedule.statusFor(
+          clock: DateTime.utc(2024, 4, 30, 23, 59),
+          start: start,
+          end: end,
+        ),
+        BudgetInstanceStatus.pending,
+      );
+
+      expect(
+        schedule.statusFor(
+          clock: DateTime.utc(2024, 5, 15),
+          start: start,
+          end: end,
+        ),
+        BudgetInstanceStatus.active,
+      );
+
+      expect(
+        schedule.statusFor(
+          clock: DateTime.utc(2024, 6, 1, 0, 1),
+          start: start,
+          end: end,
+        ),
+        BudgetInstanceStatus.closed,
+      );
+    });
+  });
+}

--- a/test/features/budgets/domain/use_cases/compute_budget_progress_use_case_test.dart
+++ b/test/features/budgets/domain/use_cases/compute_budget_progress_use_case_test.dart
@@ -1,0 +1,144 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kopim/features/budgets/domain/entities/budget.dart';
+import 'package:kopim/features/budgets/domain/entities/budget_instance.dart';
+import 'package:kopim/features/budgets/domain/entities/budget_instance_status.dart';
+import 'package:kopim/features/budgets/domain/entities/budget_progress.dart';
+import 'package:kopim/features/budgets/domain/entities/budget_period.dart';
+import 'package:kopim/features/budgets/domain/entities/budget_scope.dart';
+import 'package:kopim/features/budgets/domain/services/budget_schedule.dart';
+import 'package:kopim/features/budgets/domain/use_cases/compute_budget_progress_use_case.dart';
+import 'package:kopim/features/transactions/domain/entities/transaction.dart';
+
+void main() {
+  final ComputeBudgetProgressUseCase useCase = ComputeBudgetProgressUseCase(
+    schedule: const BudgetSchedule(),
+  );
+
+  Budget buildBudget({
+    BudgetScope scope = BudgetScope.all,
+    List<String> categories = const <String>[],
+    List<String> accounts = const <String>[],
+    double amount = 100,
+    DateTime? start,
+  }) {
+    final DateTime startDate = start ?? DateTime.utc(2024, 1, 1, 0, 1);
+    return Budget(
+      id: 'budget',
+      title: 'Budget',
+      period: BudgetPeriod.monthly,
+      startDate: startDate,
+      endDate: null,
+      amount: amount,
+      scope: scope,
+      categories: categories,
+      accounts: accounts,
+      createdAt: startDate,
+      updatedAt: startDate,
+    );
+  }
+
+  TransactionEntity tx({
+    required String id,
+    required double amount,
+    required DateTime date,
+    String accountId = 'acc',
+    String? categoryId,
+    String type = 'expense',
+  }) {
+    return TransactionEntity(
+      id: id,
+      accountId: accountId,
+      categoryId: categoryId,
+      amount: amount,
+      date: date,
+      note: null,
+      type: type,
+      createdAt: date,
+      updatedAt: date,
+    );
+  }
+
+  group('ComputeBudgetProgressUseCase', () {
+    test('computes utilization and exceeded flag for overspent budget', () {
+      final Budget budget = buildBudget(amount: 100);
+      final List<TransactionEntity> transactions = <TransactionEntity>[
+        tx(id: 't1', amount: -70, date: DateTime.utc(2024, 1, 10)),
+        tx(id: 't2', amount: -50, date: DateTime.utc(2024, 1, 20)),
+      ];
+
+      final BudgetProgress progress = useCase(
+        budget: budget,
+        transactions: transactions,
+        reference: DateTime.utc(2024, 1, 25),
+      );
+
+      expect(progress.spent, closeTo(120, 0.0001));
+      expect(progress.remaining, closeTo(-20, 0.0001));
+      expect(progress.utilization, closeTo(1.2, 0.0001));
+      expect(progress.isExceeded, isTrue);
+    });
+
+    test('filters transactions by category scope', () {
+      final Budget budget = buildBudget(
+        scope: BudgetScope.byCategory,
+        categories: <String>['food'],
+      );
+      final List<TransactionEntity> transactions = <TransactionEntity>[
+        tx(
+          id: 't1',
+          amount: -25,
+          categoryId: 'food',
+          date: DateTime.utc(2024, 1, 5),
+        ),
+        tx(
+          id: 't2',
+          amount: -30,
+          categoryId: 'transport',
+          date: DateTime.utc(2024, 1, 6),
+        ),
+      ];
+
+      final List<TransactionEntity> filtered = useCase.filterTransactions(
+        budget: budget,
+        transactions: transactions,
+        reference: DateTime.utc(2024, 1, 10),
+      );
+
+      expect(filtered, hasLength(1));
+      expect(filtered.single.id, 't1');
+    });
+
+    test('reuses existing instance when period matches', () {
+      final DateTime periodStart = DateTime.utc(2024, 2, 1, 0, 1);
+      final Budget budget = buildBudget(start: periodStart);
+      final BudgetInstance existing = BudgetInstance(
+        id: 'instance',
+        budgetId: budget.id,
+        periodStart: periodStart,
+        periodEnd: DateTime.utc(2024, 3, 1, 0, 1),
+        amount: 80,
+        spent: 10,
+        status: BudgetInstanceStatus.pending,
+        createdAt: periodStart,
+        updatedAt: periodStart,
+      );
+
+      final TransactionEntity transaction = tx(
+        id: 't1',
+        amount: -40,
+        date: DateTime.utc(2024, 2, 10),
+      );
+
+      final BudgetProgress progress = useCase(
+        budget: budget,
+        transactions: <TransactionEntity>[transaction],
+        reference: DateTime.utc(2024, 2, 15),
+        existingInstance: existing,
+      );
+
+      expect(progress.instance.id, existing.id);
+      expect(progress.instance.spent, closeTo(40, 0.0001));
+      expect(progress.instance.status, BudgetInstanceStatus.active);
+    });
+  });
+}


### PR DESCRIPTION
## Описание
- добавлена вкладка «Бюджеты» в нижней навигации и экран списка с деталями и формой
- реализован доменный и дата-слой бюджетов с синхронизацией и преобразователем списков строк
- расширены локализации и покрытие тестами для бюджетов и аналитики

## Тесты
- dart format --set-exit-if-changed .
- flutter analyze
- dart run build_runner build --delete-conflicting-outputs
- flutter test --reporter expanded
- flutter pub outdated

------
https://chatgpt.com/codex/tasks/task_e_68e13499e840832eabdf7515031e0905