### PR TITLE
feat: обновить UI аналитики и вынести общий экран настроек

### DIFF
--- a/lib/features/analytics/presentation/analytics_screen.dart
+++ b/lib/features/analytics/presentation/analytics_screen.dart
@@ -383,7 +383,14 @@ class _AnalyticsFilterBar extends ConsumerWidget {
             children: <Widget>[
               const Icon(Icons.calendar_today_outlined, size: 18),
               const SizedBox(width: 8),
-              Text('${strings.analyticsFilterDateLabel}: $dateValue'),
+              Flexible(
+                child: Text(
+                  '${strings.analyticsFilterDateLabel}: $dateValue',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  softWrap: false,
+                ),
+              ),
             ],
           ),
         ),
@@ -664,6 +671,11 @@ class _TopCategoriesPagerState extends State<_TopCategoriesPager> {
                   curve: Curves.easeInOut,
                 );
               },
+              style: const ButtonStyle(
+                side: WidgetStatePropertyAll<BorderSide>(
+                  BorderSide(style: BorderStyle.none),
+                ),
+              ),
             ),
             const SizedBox(height: 16),
             SizedBox(

--- a/lib/features/analytics/presentation/widgets/analytics_chart.dart
+++ b/lib/features/analytics/presentation/widgets/analytics_chart.dart
@@ -32,55 +32,60 @@ class AnalyticsDonutChart extends StatelessWidget {
       return const SizedBox.shrink();
     }
 
-    return AspectRatio(
-      aspectRatio: 1,
-      child: LayoutBuilder(
-        builder: (BuildContext context, BoxConstraints constraints) {
-          final Size biggest = constraints.biggest;
-          double size = biggest.shortestSide;
-          if (!size.isFinite || size <= 0) {
-            size = biggest.longestSide;
-          }
-          if (!size.isFinite || size <= 0) {
-            size = 200;
-          }
-          final double strokeWidth = math.max(size * 0.18, 12);
-          final List<_DonutSegment> segments = _buildSegments();
-          final double radius = size / 2;
-          final double labelRadius = radius + strokeWidth * 0.4;
-          final double alignmentFactor = radius == 0 ? 0 : labelRadius / radius;
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: AspectRatio(
+        aspectRatio: 1,
+        child: LayoutBuilder(
+          builder: (BuildContext context, BoxConstraints constraints) {
+            final Size biggest = constraints.biggest;
+            double size = biggest.shortestSide;
+            if (!size.isFinite || size <= 0) {
+              size = biggest.longestSide;
+            }
+            if (!size.isFinite || size <= 0) {
+              size = 200;
+            }
+            final double strokeWidth = math.max(size * 0.18, 12);
+            final List<_DonutSegment> segments = _buildSegments();
+            final double radius = size / 2;
+            final double labelRadius = radius + strokeWidth * 0.4;
+            final double alignmentFactor = radius == 0
+                ? 0
+                : labelRadius / radius;
 
-          return Center(
-            child: SizedBox(
-              width: size,
-              height: size,
-              child: Stack(
-                clipBehavior: Clip.none,
-                alignment: Alignment.center,
-                children: <Widget>[
-                  CustomPaint(
-                    size: Size.square(size),
-                    painter: _DonutChartPainter(
-                      segments: segments,
-                      strokeWidth: strokeWidth,
-                      backgroundColor: backgroundColor,
-                    ),
-                  ),
-                  for (final _DonutSegment segment in segments)
-                    Align(
-                      alignment: Alignment(
-                        math.cos(segment.midAngle) * alignmentFactor,
-                        math.sin(segment.midAngle) * alignmentFactor,
-                      ),
-                      child: _DonutPercentageLabel(
-                        percentage: segment.percentage,
+            return Center(
+              child: SizedBox(
+                width: size,
+                height: size,
+                child: Stack(
+                  clipBehavior: Clip.none,
+                  alignment: Alignment.center,
+                  children: <Widget>[
+                    CustomPaint(
+                      size: Size.square(size),
+                      painter: _DonutChartPainter(
+                        segments: segments,
+                        strokeWidth: strokeWidth,
+                        backgroundColor: backgroundColor,
                       ),
                     ),
-                ],
+                    for (final _DonutSegment segment in segments)
+                      Align(
+                        alignment: Alignment(
+                          math.cos(segment.midAngle) * alignmentFactor,
+                          math.sin(segment.midAngle) * alignmentFactor,
+                        ),
+                        child: _DonutPercentageLabel(
+                          percentage: segment.percentage,
+                        ),
+                      ),
+                  ],
+                ),
               ),
-            ),
-          );
-        },
+            );
+          },
+        ),
       ),
     );
   }

--- a/lib/features/profile/presentation/screens/general_settings_screen.dart
+++ b/lib/features/profile/presentation/screens/general_settings_screen.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+
+import 'package:kopim/features/categories/presentation/screens/manage_categories_screen.dart';
+import 'package:kopim/features/profile/presentation/widgets/settings_button_theme.dart';
+import 'package:kopim/features/recurring_transactions/presentation/screens/recurring_transactions_screen.dart';
+import 'package:kopim/l10n/app_localizations.dart';
+
+class GeneralSettingsScreen extends StatelessWidget {
+  const GeneralSettingsScreen({super.key});
+
+  static const String routeName = '/settings/general';
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations strings = AppLocalizations.of(context)!;
+    final ThemeData theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(title: Text(strings.profileGeneralSettingsTitle)),
+      body: Theme(
+        data: buildSettingsButtonTheme(theme),
+        child: ListView(
+          key: const PageStorageKey<String>('general-settings-sections'),
+          padding: const EdgeInsets.all(24),
+          children: <Widget>[
+            _SettingsSection(
+              title: strings.profileGeneralSettingsManagementSection,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: <Widget>[
+                  FilledButton.icon(
+                    onPressed: () {
+                      Navigator.of(
+                        context,
+                      ).pushNamed(ManageCategoriesScreen.routeName);
+                    },
+                    icon: const Icon(Icons.category_outlined),
+                    label: Text(strings.profileManageCategoriesCta),
+                  ),
+                  const SizedBox(height: 12),
+                  FilledButton.icon(
+                    onPressed: () {
+                      Navigator.of(
+                        context,
+                      ).pushNamed(RecurringTransactionsScreen.routeName);
+                    },
+                    icon: const Icon(Icons.repeat),
+                    label: Text(strings.profileRecurringTransactionsCta),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SettingsSection extends StatelessWidget {
+  const _SettingsSection({required this.title, required this.child});
+
+  final String title;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Card(
+      margin: EdgeInsets.zero,
+      child: Theme(
+        data: theme.copyWith(dividerColor: Colors.transparent),
+        child: ExpansionTile(
+          key: PageStorageKey<String>('general-settings-$title'),
+          tilePadding: const EdgeInsets.symmetric(horizontal: 16),
+          childrenPadding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+          initiallyExpanded: true,
+          title: Text(title, style: theme.textTheme.titleMedium),
+          children: <Widget>[child],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:kopim/features/app_shell/presentation/models/navigation_tab_content.dart';
+import 'package:kopim/features/profile/presentation/screens/general_settings_screen.dart';
 import 'package:kopim/features/profile/presentation/widgets/profile_management_body.dart';
 import 'package:kopim/l10n/app_localizations.dart';
 
@@ -30,8 +31,21 @@ NavigationTabContent buildProfileTabContent(
   WidgetRef ref,
 ) {
   return NavigationTabContent(
-    appBarBuilder: (BuildContext context, WidgetRef ref) =>
-        AppBar(title: Text(AppLocalizations.of(context)!.profileTitle)),
+    appBarBuilder: (BuildContext context, WidgetRef ref) {
+      final AppLocalizations strings = AppLocalizations.of(context)!;
+      return AppBar(
+        title: Text(strings.profileTitle),
+        actions: <Widget>[
+          IconButton(
+            tooltip: strings.profileGeneralSettingsTooltip,
+            icon: const Icon(Icons.tune),
+            onPressed: () {
+              Navigator.of(context).pushNamed(GeneralSettingsScreen.routeName);
+            },
+          ),
+        ],
+      );
+    },
     bodyBuilder: (BuildContext context, WidgetRef ref) =>
         const ProfileManagementBody(),
   );

--- a/lib/features/profile/presentation/widgets/profile_management_body.dart
+++ b/lib/features/profile/presentation/widgets/profile_management_body.dart
@@ -6,14 +6,13 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:kopim/core/theme/application/theme_mode_controller.dart';
 import 'package:kopim/core/theme/domain/app_theme_mode.dart';
-import 'package:kopim/features/categories/presentation/screens/manage_categories_screen.dart';
-import 'package:kopim/features/recurring_transactions/presentation/screens/recurring_transactions_screen.dart';
 import 'package:kopim/features/profile/domain/entities/auth_user.dart';
 import 'package:kopim/features/profile/domain/entities/profile.dart';
 import 'package:kopim/features/profile/presentation/controllers/auth_controller.dart';
 import 'package:kopim/features/profile/presentation/controllers/profile_controller.dart';
 import 'package:kopim/features/profile/presentation/controllers/profile_form_controller.dart';
 import 'package:kopim/l10n/app_localizations.dart';
+import 'package:kopim/features/profile/presentation/widgets/settings_button_theme.dart';
 
 class ProfileManagementBody extends ConsumerWidget {
   const ProfileManagementBody({super.key});
@@ -115,139 +114,127 @@ class _ProfileForm extends ConsumerWidget {
 
     final ThemeData theme = Theme.of(context);
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: <Widget>[
-        _CollapsibleSection(
-          title: strings.profileSectionAccount,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: <Widget>[
-              TextFormField(
-                key: ValueKey<String>('name-$initialKey'),
-                initialValue: name,
-                onChanged: formController.updateName,
-                decoration: InputDecoration(
-                  labelText: strings.profileNameLabel,
-                  border: const OutlineInputBorder(),
-                ),
-                textInputAction: TextInputAction.next,
-              ),
-              const SizedBox(height: 16),
-              DropdownButtonFormField<ProfileCurrency>(
-                key: ValueKey<String>('currency-$initialKey-${currency.name}'),
-                initialValue: currency,
-                decoration: InputDecoration(
-                  labelText: strings.profileCurrencyLabel,
-                  border: const OutlineInputBorder(),
-                ),
-                items: ProfileCurrency.values
-                    .map(
-                      (ProfileCurrency value) =>
-                          DropdownMenuItem<ProfileCurrency>(
-                            value: value,
-                            child: Text(value.name.toUpperCase()),
-                          ),
-                    )
-                    .toList(growable: false),
-                onChanged: (ProfileCurrency? value) {
-                  if (value != null) {
-                    formController.updateCurrency(value);
-                  }
-                },
-              ),
-              const SizedBox(height: 16),
-              DropdownButtonFormField<String>(
-                key: ValueKey<String>('locale-$initialKey-$locale'),
-                initialValue: locale,
-                decoration: InputDecoration(
-                  labelText: strings.profileLocaleLabel,
-                  border: const OutlineInputBorder(),
-                ),
-                items: locales
-                    .map(
-                      (String code) => DropdownMenuItem<String>(
-                        value: code,
-                        child: Text(code.toUpperCase()),
-                      ),
-                    )
-                    .toList(growable: false),
-                onChanged: (String? value) {
-                  if (value != null) {
-                    formController.updateLocale(value);
-                  }
-                },
-              ),
-              if (profileAsync.hasError) ...<Widget>[
-                const SizedBox(height: 12),
-                Text(
-                  strings.profileLoadError(profileAsync.error.toString()),
-                  style: theme.textTheme.bodySmall?.copyWith(
-                    color: theme.colorScheme.error,
+    return Theme(
+      data: buildSettingsButtonTheme(theme),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          _CollapsibleSection(
+            title: strings.profileSectionAccount,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: <Widget>[
+                TextFormField(
+                  key: ValueKey<String>('name-$initialKey'),
+                  initialValue: name,
+                  onChanged: formController.updateName,
+                  decoration: InputDecoration(
+                    labelText: strings.profileNameLabel,
+                    border: const OutlineInputBorder(),
                   ),
+                  textInputAction: TextInputAction.next,
                 ),
-              ],
-              if (errorMessage != null) ...<Widget>[
-                const SizedBox(height: 12),
-                Text(
-                  errorMessage,
-                  style: theme.textTheme.bodySmall?.copyWith(
-                    color: theme.colorScheme.error,
+                const SizedBox(height: 16),
+                DropdownButtonFormField<ProfileCurrency>(
+                  key: ValueKey<String>(
+                    'currency-$initialKey-${currency.name}',
                   ),
+                  initialValue: currency,
+                  decoration: InputDecoration(
+                    labelText: strings.profileCurrencyLabel,
+                    border: const OutlineInputBorder(),
+                  ),
+                  items: ProfileCurrency.values
+                      .map(
+                        (ProfileCurrency value) =>
+                            DropdownMenuItem<ProfileCurrency>(
+                              value: value,
+                              child: Text(value.name.toUpperCase()),
+                            ),
+                      )
+                      .toList(growable: false),
+                  onChanged: (ProfileCurrency? value) {
+                    if (value != null) {
+                      formController.updateCurrency(value);
+                    }
+                  },
                 ),
-              ],
-              const SizedBox(height: 24),
-              Row(
-                children: <Widget>[
-                  ElevatedButton.icon(
-                    onPressed: !isSaving && hasChanges
-                        ? () => formController.submit()
-                        : null,
-                    icon: isSaving
-                        ? const SizedBox(
-                            width: 16,
-                            height: 16,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          )
-                        : const Icon(Icons.save),
-                    label: Text(strings.profileSaveCta),
+                const SizedBox(height: 16),
+                DropdownButtonFormField<String>(
+                  key: ValueKey<String>('locale-$initialKey-$locale'),
+                  initialValue: locale,
+                  decoration: InputDecoration(
+                    labelText: strings.profileLocaleLabel,
+                    border: const OutlineInputBorder(),
                   ),
-                  const SizedBox(width: 16),
-                  if (profileAsync.isLoading) const _CenteredProgress(size: 20),
+                  items: locales
+                      .map(
+                        (String code) => DropdownMenuItem<String>(
+                          value: code,
+                          child: Text(code.toUpperCase()),
+                        ),
+                      )
+                      .toList(growable: false),
+                  onChanged: (String? value) {
+                    if (value != null) {
+                      formController.updateLocale(value);
+                    }
+                  },
+                ),
+                if (profileAsync.hasError) ...<Widget>[
+                  const SizedBox(height: 12),
+                  Text(
+                    strings.profileLoadError(profileAsync.error.toString()),
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.error,
+                    ),
+                  ),
                 ],
-              ),
-              const SizedBox(height: 16),
-              TextButton.icon(
-                onPressed: () {
-                  ref.read(authControllerProvider.notifier).signOut();
-                },
-                icon: const Icon(Icons.logout),
-                label: Text(strings.profileSignOutCta),
-              ),
-            ],
+                if (errorMessage != null) ...<Widget>[
+                  const SizedBox(height: 12),
+                  Text(
+                    errorMessage,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.error,
+                    ),
+                  ),
+                ],
+                const SizedBox(height: 24),
+                Row(
+                  children: <Widget>[
+                    FilledButton.icon(
+                      onPressed: !isSaving && hasChanges
+                          ? () => formController.submit()
+                          : null,
+                      icon: isSaving
+                          ? const SizedBox(
+                              width: 16,
+                              height: 16,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : const Icon(Icons.save),
+                      label: Text(strings.profileSaveCta),
+                    ),
+                    const SizedBox(width: 16),
+                    if (profileAsync.isLoading)
+                      const _CenteredProgress(size: 20),
+                  ],
+                ),
+                const SizedBox(height: 16),
+                FilledButton.icon(
+                  onPressed: () {
+                    ref.read(authControllerProvider.notifier).signOut();
+                  },
+                  icon: const Icon(Icons.logout),
+                  label: Text(strings.profileSignOutCta),
+                ),
+              ],
+            ),
           ),
-        ),
-        const SizedBox(height: 24),
-        const ProfileThemePreferencesCard(),
-        const SizedBox(height: 24),
-        OutlinedButton.icon(
-          onPressed: () {
-            Navigator.of(context).pushNamed(ManageCategoriesScreen.routeName);
-          },
-          icon: const Icon(Icons.category_outlined),
-          label: Text(strings.profileManageCategoriesCta),
-        ),
-        const SizedBox(height: 12),
-        OutlinedButton.icon(
-          onPressed: () {
-            Navigator.of(
-              context,
-            ).pushNamed(RecurringTransactionsScreen.routeName);
-          },
-          icon: const Icon(Icons.repeat),
-          label: Text(strings.profileRecurringTransactionsCta),
-        ),
-      ],
+          const SizedBox(height: 24),
+          const ProfileThemePreferencesCard(),
+        ],
+      ),
     );
   }
 
@@ -310,7 +297,7 @@ class ProfileThemePreferencesCard extends ConsumerWidget {
             alignment: Alignment.centerRight,
             child: Padding(
               padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
-              child: TextButton.icon(
+              child: FilledButton.icon(
                 onPressed: isSystem
                     ? null
                     : () => unawaited(
@@ -341,10 +328,13 @@ class _CollapsibleSection extends StatelessWidget {
       child: Theme(
         data: theme.copyWith(dividerColor: Colors.transparent),
         child: ExpansionTile(
+          key: PageStorageKey<String>('profile-section-$title'),
           tilePadding: const EdgeInsets.symmetric(horizontal: 16),
           childrenPadding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
           title: Text(title, style: theme.textTheme.titleMedium),
-          children: <Widget>[child],
+          children: <Widget>[
+            PageStorage(bucket: PageStorageBucket(), child: child),
+          ],
         ),
       ),
     );

--- a/lib/features/profile/presentation/widgets/settings_button_theme.dart
+++ b/lib/features/profile/presentation/widgets/settings_button_theme.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+ThemeData buildSettingsButtonTheme(ThemeData base) {
+  final ButtonStyle resolvedStyle =
+      FilledButton.styleFrom(
+        elevation: 0,
+        shadowColor: Colors.transparent,
+        shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.all(Radius.circular(12)),
+        ),
+      ).copyWith(
+        side: const WidgetStatePropertyAll<BorderSide>(
+          BorderSide(style: BorderStyle.none),
+        ),
+      );
+
+  return base.copyWith(
+    filledButtonTheme: FilledButtonThemeData(style: resolvedStyle),
+  );
+}

--- a/lib/features/transactions/presentation/widgets/transaction_form_view.dart
+++ b/lib/features/transactions/presentation/widgets/transaction_form_view.dart
@@ -209,6 +209,11 @@ class _TransactionForm extends ConsumerWidget {
                       .read(transactionProvider.notifier)
                       .updateType(values.first);
                 },
+                style: const ButtonStyle(
+                  side: WidgetStatePropertyAll<BorderSide>(
+                    BorderSide(style: BorderStyle.none),
+                  ),
+                ),
               ),
             ),
           ),
@@ -388,6 +393,12 @@ class _AmountFieldState extends ConsumerState<_AmountField> {
       decoration: InputDecoration(
         labelText: widget.strings.addTransactionAmountLabel,
         hintText: widget.strings.addTransactionAmountHint,
+        filled: true,
+        fillColor: Theme.of(context).colorScheme.surfaceContainerHighest,
+        border: const OutlineInputBorder(
+          borderSide: BorderSide(style: BorderStyle.none),
+          borderRadius: BorderRadius.all(Radius.circular(12)),
+        ),
       ),
       onChanged: _handleChanged,
       onEditingComplete: () {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -13,6 +13,18 @@
   "@profileAppearanceSection": {
     "description": "Section title for appearance settings in profile management"
   },
+  "profileGeneralSettingsTitle": "General settings",
+  "@profileGeneralSettingsTitle": {
+    "description": "Title for the general settings screen"
+  },
+  "profileGeneralSettingsTooltip": "General settings",
+  "@profileGeneralSettingsTooltip": {
+    "description": "Tooltip for opening the general settings screen"
+  },
+  "profileGeneralSettingsManagementSection": "Data management",
+  "@profileGeneralSettingsManagementSection": {
+    "description": "Section title for category and recurring actions on general settings"
+  },
   "profileManageCategoriesCta": "Manage categories",
   "@profileManageCategoriesCta": {
     "description": "Button label that opens the category management screen from the profile settings"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -122,6 +122,24 @@ abstract class AppLocalizations {
   /// **'Appearance'**
   String get profileAppearanceSection;
 
+  /// Title for the general settings screen
+  ///
+  /// In en, this message translates to:
+  /// **'General settings'**
+  String get profileGeneralSettingsTitle;
+
+  /// Tooltip for opening the general settings screen
+  ///
+  /// In en, this message translates to:
+  /// **'General settings'**
+  String get profileGeneralSettingsTooltip;
+
+  /// Section title for category and recurring actions on general settings
+  ///
+  /// In en, this message translates to:
+  /// **'Data management'**
+  String get profileGeneralSettingsManagementSection;
+
   /// Button label that opens the category management screen from the profile settings
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -21,6 +21,15 @@ class AppLocalizationsEn extends AppLocalizations {
   String get profileAppearanceSection => 'Appearance';
 
   @override
+  String get profileGeneralSettingsTitle => 'General settings';
+
+  @override
+  String get profileGeneralSettingsTooltip => 'General settings';
+
+  @override
+  String get profileGeneralSettingsManagementSection => 'Data management';
+
+  @override
   String get profileManageCategoriesCta => 'Manage categories';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -22,6 +22,15 @@ class AppLocalizationsRu extends AppLocalizations {
   String get profileAppearanceSection => 'Внешний вид';
 
   @override
+  String get profileGeneralSettingsTitle => 'Общие настройки';
+
+  @override
+  String get profileGeneralSettingsTooltip => 'Общие настройки';
+
+  @override
+  String get profileGeneralSettingsManagementSection => 'Управление данными';
+
+  @override
   String get profileManageCategoriesCta => 'Управлять категориями';
 
   @override

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -13,6 +13,18 @@
   "@profileAppearanceSection": {
     "description": "Заголовок секции настроек внешнего вида на экране профиля"
   },
+  "profileGeneralSettingsTitle": "Общие настройки",
+  "@profileGeneralSettingsTitle": {
+    "description": "Заголовок экрана общих настроек"
+  },
+  "profileGeneralSettingsTooltip": "Общие настройки",
+  "@profileGeneralSettingsTooltip": {
+    "description": "Подсказка для перехода на экран общих настроек"
+  },
+  "profileGeneralSettingsManagementSection": "Управление данными",
+  "@profileGeneralSettingsManagementSection": {
+    "description": "Заголовок секции с действиями для категорий и повторяющихся операций"
+  },
   "profileManageCategoriesCta": "Управлять категориями",
   "@profileManageCategoriesCta": {
     "description": "Подпись кнопки, открывающей экран управления категориями из настроек профиля"

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,7 @@ import 'features/accounts/presentation/accounts_add_screen.dart';
 import 'features/accounts/presentation/edit_account_screen.dart';
 import 'features/app_shell/presentation/widgets/main_navigation_shell.dart';
 import 'features/categories/presentation/screens/manage_categories_screen.dart';
+import 'features/profile/presentation/screens/general_settings_screen.dart';
 import 'features/profile/presentation/screens/profile_management_screen.dart';
 import 'features/profile/presentation/screens/profile_screen.dart';
 import 'features/profile/presentation/screens/sign_in_screen.dart';
@@ -81,6 +82,7 @@ class _MyAppState extends ConsumerState<MyApp> {
         },
         AddTransactionScreen.routeName: (_) => const AddTransactionScreen(),
         ProfileScreen.routeName: (_) => const ProfileScreen(),
+        GeneralSettingsScreen.routeName: (_) => const GeneralSettingsScreen(),
         ProfileManagementScreen.routeName: (_) =>
             const ProfileManagementScreen(),
         ManageCategoriesScreen.routeName: (_) => const ManageCategoriesScreen(),

--- a/test/features/analytics/presentation/analytics_screen_test.dart
+++ b/test/features/analytics/presentation/analytics_screen_test.dart
@@ -143,5 +143,189 @@ void main() {
         expect(find.text(currencyFormat.format(60)), findsWidgets);
       },
     );
+
+    testWidgets('date filter button handles narrow layouts without overflow', (
+      WidgetTester tester,
+    ) async {
+      final AnalyticsFilterState filterState = AnalyticsFilterState(
+        dateRange: DateTimeRange(
+          start: DateTime(2024, 10, 10),
+          end: DateTime(2024, 10, 21),
+        ),
+      );
+
+      const AnalyticsOverview overview = AnalyticsOverview(
+        totalIncome: 50.0,
+        totalExpense: 120.0,
+        netBalance: -70.0,
+        topExpenseCategories: <AnalyticsCategoryBreakdown>[
+          AnalyticsCategoryBreakdown(categoryId: 'food', amount: 80.0),
+        ],
+        topIncomeCategories: <AnalyticsCategoryBreakdown>[
+          AnalyticsCategoryBreakdown(categoryId: 'salary', amount: 50.0),
+        ],
+      );
+
+      final Category foodCategory = Category(
+        id: 'food',
+        name: 'Food',
+        type: 'expense',
+        color: '#FF9800',
+        icon: null,
+        parentId: null,
+        createdAt: DateTime(2023, 1, 1),
+        updatedAt: DateTime(2023, 1, 1),
+      );
+      final Category salaryCategory = Category(
+        id: 'salary',
+        name: 'Salary',
+        type: 'income',
+        color: '#4CAF50',
+        icon: null,
+        parentId: null,
+        createdAt: DateTime(2023, 1, 1),
+        updatedAt: DateTime(2023, 1, 1),
+      );
+
+      tester.view.physicalSize = const Size(320, 720);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: <Override>[
+            analyticsFilterControllerProvider.overrideWith(
+              () => _FakeAnalyticsFilterController(filterState),
+            ),
+            analyticsFilteredStatsProvider(topCategoriesLimit: 5).overrideWith(
+              (Ref ref) => Stream<AnalyticsOverview>.value(overview),
+            ),
+            analyticsCategoriesProvider.overrideWith(
+              (Ref ref) => Stream<List<Category>>.value(<Category>[
+                foodCategory,
+                salaryCategory,
+              ]),
+            ),
+            analyticsAccountsProvider.overrideWith(
+              (Ref ref) => Stream<List<AccountEntity>>.value(<AccountEntity>[
+                AccountEntity(
+                  id: 'acc',
+                  name: 'Main',
+                  balance: 0,
+                  currency: 'USD',
+                  type: 'checking',
+                  createdAt: DateTime(2023, 1, 1),
+                  updatedAt: DateTime(2023, 1, 1),
+                  isDeleted: false,
+                ),
+              ]),
+            ),
+          ],
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: AnalyticsScreen(),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('top categories segmented button renders without outline', (
+      WidgetTester tester,
+    ) async {
+      final AnalyticsFilterState filterState = AnalyticsFilterState(
+        dateRange: DateTimeRange(
+          start: DateTime(2024, 1, 1),
+          end: DateTime(2024, 1, 31),
+        ),
+      );
+
+      const AnalyticsOverview overview = AnalyticsOverview(
+        totalIncome: 80.0,
+        totalExpense: 120.0,
+        netBalance: -40.0,
+        topExpenseCategories: <AnalyticsCategoryBreakdown>[
+          AnalyticsCategoryBreakdown(categoryId: 'food', amount: 120.0),
+        ],
+        topIncomeCategories: <AnalyticsCategoryBreakdown>[
+          AnalyticsCategoryBreakdown(categoryId: 'salary', amount: 80.0),
+        ],
+      );
+
+      final Category foodCategory = Category(
+        id: 'food',
+        name: 'Food',
+        type: 'expense',
+        color: '#FF9800',
+        icon: null,
+        parentId: null,
+        createdAt: DateTime(2023, 1, 1),
+        updatedAt: DateTime(2023, 1, 1),
+      );
+      final Category salaryCategory = Category(
+        id: 'salary',
+        name: 'Salary',
+        type: 'income',
+        color: '#4CAF50',
+        icon: null,
+        parentId: null,
+        createdAt: DateTime(2023, 1, 1),
+        updatedAt: DateTime(2023, 1, 1),
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: <Override>[
+            analyticsFilterControllerProvider.overrideWith(
+              () => _FakeAnalyticsFilterController(filterState),
+            ),
+            analyticsFilteredStatsProvider(topCategoriesLimit: 5).overrideWith(
+              (Ref ref) => Stream<AnalyticsOverview>.value(overview),
+            ),
+            analyticsCategoriesProvider.overrideWith(
+              (Ref ref) => Stream<List<Category>>.value(<Category>[
+                foodCategory,
+                salaryCategory,
+              ]),
+            ),
+            analyticsAccountsProvider.overrideWith(
+              (Ref ref) => Stream<List<AccountEntity>>.value(<AccountEntity>[
+                AccountEntity(
+                  id: 'acc',
+                  name: 'Main',
+                  balance: 0,
+                  currency: 'USD',
+                  type: 'checking',
+                  createdAt: DateTime(2023, 1, 1),
+                  updatedAt: DateTime(2023, 1, 1),
+                  isDeleted: false,
+                ),
+              ]),
+            ),
+          ],
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: AnalyticsScreen(),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      final SegmentedButton<int> segmentedButton = tester
+          .widget<SegmentedButton<int>>(find.byType(SegmentedButton<int>));
+      final BorderSide? resolvedSide = segmentedButton.style?.side?.resolve(
+        <WidgetState>{},
+      );
+      expect(resolvedSide?.style, BorderStyle.none);
+    });
   });
 }

--- a/test/features/profile/presentation/general_settings_screen_test.dart
+++ b/test/features/profile/presentation/general_settings_screen_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kopim/features/categories/presentation/screens/manage_categories_screen.dart';
+import 'package:kopim/features/profile/presentation/screens/general_settings_screen.dart';
+import 'package:kopim/features/recurring_transactions/presentation/screens/recurring_transactions_screen.dart';
+import 'package:kopim/l10n/app_localizations.dart';
+
+class _RecordingNavigatorObserver extends NavigatorObserver {
+  _RecordingNavigatorObserver(this.pushedRoutes);
+
+  final List<Route<dynamic>> pushedRoutes;
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    pushedRoutes.add(route);
+    super.didPush(route, previousRoute);
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('displays management actions', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: GeneralSettingsScreen(),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    final BuildContext context = tester.element(
+      find.byType(GeneralSettingsScreen),
+    );
+    final AppLocalizations strings = AppLocalizations.of(context)!;
+
+    expect(find.text(strings.profileManageCategoriesCta), findsOneWidget);
+    expect(find.text(strings.profileRecurringTransactionsCta), findsOneWidget);
+  });
+
+  testWidgets('navigates to management screens', (WidgetTester tester) async {
+    final List<Route<dynamic>> pushedRoutes = <Route<dynamic>>[];
+    final NavigatorObserver observer = _RecordingNavigatorObserver(
+      pushedRoutes,
+    );
+    final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        navigatorKey: navigatorKey,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: const GeneralSettingsScreen(),
+        routes: <String, WidgetBuilder>{
+          ManageCategoriesScreen.routeName: (_) =>
+              const _StubDestination(label: 'manage-categories-destination'),
+          RecurringTransactionsScreen.routeName: (_) =>
+              const _StubDestination(label: 'recurring-destination'),
+        },
+        navigatorObservers: <NavigatorObserver>[observer],
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    final BuildContext context = tester.element(
+      find.byType(GeneralSettingsScreen),
+    );
+    final AppLocalizations strings = AppLocalizations.of(context)!;
+
+    await tester.tap(find.text(strings.profileManageCategoriesCta));
+    await tester.pumpAndSettle();
+
+    expect(
+      pushedRoutes.map((Route<dynamic> route) => route.settings.name),
+      contains(ManageCategoriesScreen.routeName),
+    );
+    expect(find.text('manage-categories-destination'), findsOneWidget);
+
+    navigatorKey.currentState!.pop();
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text(strings.profileRecurringTransactionsCta));
+    await tester.pumpAndSettle();
+
+    expect(
+      pushedRoutes.map((Route<dynamic> route) => route.settings.name),
+      contains(RecurringTransactionsScreen.routeName),
+    );
+    expect(find.text('recurring-destination'), findsOneWidget);
+  });
+}
+
+class _StubDestination extends StatelessWidget {
+  const _StubDestination({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(body: Center(child: Text(label)));
+  }
+}

--- a/test/features/transactions/presentation/transaction_form_view_test.dart
+++ b/test/features/transactions/presentation/transaction_form_view_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart' show Override;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kopim/features/accounts/domain/entities/account_entity.dart';
+import 'package:kopim/features/categories/domain/entities/category.dart';
+import 'package:kopim/features/transactions/presentation/add_transaction_screen.dart';
+import 'package:kopim/features/transactions/presentation/controllers/transaction_form_controller.dart';
+import 'package:kopim/l10n/app_localizations.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('amount field uses filled decoration', (
+    WidgetTester tester,
+  ) async {
+    final AccountEntity account = AccountEntity(
+      id: 'acc-1',
+      name: 'Cash',
+      balance: 1200,
+      currency: 'USD',
+      type: 'wallet',
+      createdAt: DateTime(2023, 1, 1),
+      updatedAt: DateTime(2023, 1, 1),
+      isDeleted: false,
+    );
+    final Category category = Category(
+      id: 'groceries',
+      name: 'Groceries',
+      type: 'expense',
+      color: '#FF5722',
+      icon: null,
+      parentId: null,
+      createdAt: DateTime(2023, 1, 1),
+      updatedAt: DateTime(2023, 1, 1),
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          transactionFormAccountsProvider.overrideWith(
+            (Ref ref) =>
+                Stream<List<AccountEntity>>.value(<AccountEntity>[account]),
+          ),
+          transactionFormCategoriesProvider.overrideWith(
+            (Ref ref) => Stream<List<Category>>.value(<Category>[category]),
+          ),
+        ],
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: AddTransactionScreen(),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    final BuildContext context = tester.element(
+      find.byType(AddTransactionScreen),
+    );
+    final AppLocalizations strings = AppLocalizations.of(context)!;
+
+    final Finder decoratorFinder = find.descendant(
+      of: find.bySemanticsLabel(strings.addTransactionAmountLabel),
+      matching: find.byType(InputDecorator),
+    );
+    final InputDecorator decorator = tester.widget<InputDecorator>(
+      decoratorFinder,
+    );
+    final InputDecoration decoration = decorator.decoration;
+
+    expect(decoration.filled, isTrue);
+    expect(decoration.fillColor, isNotNull);
+    final OutlineInputBorder border = decoration.border! as OutlineInputBorder;
+    expect(border.borderSide.style, BorderStyle.none);
+  });
+}


### PR DESCRIPTION
## Summary
- расширил отступы диаграмм аналитики и убрал обводку с переключателей
- вынес управление категориями и повторениями на новый экран общих настроек
- унифицировал стили кнопок и заливку поля суммы, обновил локализации и тесты

## Testing
- dart format --set-exit-if-changed .
- flutter analyze
- dart run build_runner build --delete-conflicting-outputs
- flutter test --reporter expanded
- flutter pub outdated

------
https://chatgpt.com/codex/tasks/task_e_68e17cb8063c832ea1a15eccf0390d98