### PR TITLE
Добавить кэш форматтеров дат и тест профиля

### DIFF
--- a/lib/core/formatting/date_format_providers.dart
+++ b/lib/core/formatting/date_format_providers.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/widgets.dart';
+import 'package:intl/intl.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Ключевой формат даты, используемый в приложении.
+enum AppDateFormat {
+  /// Полное название месяца и день, например «24 сентября 2024 г.».
+  longMonthDay,
+}
+
+/// Параметры для получения форматтера даты.
+typedef DateFormatRequest = ({Locale locale, AppDateFormat format});
+
+/// Провайдер, кэширующий [`DateFormat`] для заданной локали и паттерна.
+final Provider<DateFormat> Function(DateFormatRequest request)
+dateFormatProvider = Provider.family<DateFormat, DateFormatRequest>((
+  Ref ref,
+  DateFormatRequest request,
+) {
+  final String localeTag = request.locale.toLanguageTag();
+  switch (request.format) {
+    case AppDateFormat.longMonthDay:
+      return DateFormat.yMMMMd(localeTag);
+  }
+});

--- a/lib/features/recurring_transactions/presentation/screens/recurring_transactions_screen.dart
+++ b/lib/features/recurring_transactions/presentation/screens/recurring_transactions_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:kopim/core/di/injectors.dart';
+import 'package:kopim/core/formatting/date_format_providers.dart';
 import 'package:kopim/features/recurring_transactions/domain/entities/recurring_rule.dart';
 import 'package:kopim/features/recurring_transactions/presentation/controllers/recurring_transactions_providers.dart';
 import 'package:kopim/features/recurring_transactions/presentation/models/recurring_rule_form_result.dart';
@@ -193,7 +194,7 @@ class RecurringTransactionsScreen extends ConsumerWidget {
   }
 }
 
-class _RecurringRuleTile extends StatelessWidget {
+class _RecurringRuleTile extends ConsumerWidget {
   const _RecurringRuleTile({
     required this.rule,
     required this.nextDue,
@@ -209,13 +210,17 @@ class _RecurringRuleTile extends StatelessWidget {
   final VoidCallback onDelete;
 
   @override
-  Widget build(BuildContext context) {
-    final DateFormat dateFormat = DateFormat.yMMMMd();
+  Widget build(BuildContext context, WidgetRef ref) {
+    final Locale locale = Localizations.localeOf(context);
+    final DateFormat dateFormat = ref.watch(
+      dateFormatProvider((locale: locale, format: AppDateFormat.longMonthDay)),
+    );
     final String subtitle = nextDue == null
         ? AppLocalizations.of(context)!.recurringTransactionsNoUpcoming
         : '${AppLocalizations.of(context)!.recurringTransactionsNextDue}: '
               '${dateFormat.format(nextDue!.toLocal())}';
     return Material(
+      key: ValueKey<String>(rule.id),
       elevation: 1,
       borderRadius: BorderRadius.circular(12),
       child: ListTile(

--- a/test/core/config/theme_test.dart
+++ b/test/core/config/theme_test.dart
@@ -1,114 +1,41 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
 import 'package:kopim/core/config/theme.dart';
 
 void main() {
-  group('Bottom navigation theming', () {
-    testWidgets('uses onSurface colors in light theme', (
-      WidgetTester tester,
-    ) async {
+  group('buildAppTheme', () {
+    test('использует Material 3 и ColorScheme.fromSeed', () {
+      const Color seedColor = Color(0xFF8AEDAB);
+      final ColorScheme expectedScheme = ColorScheme.fromSeed(
+        seedColor: seedColor,
+        brightness: Brightness.light,
+      );
       final ThemeData theme = buildAppTheme(brightness: Brightness.light);
 
-      await tester.pumpWidget(
-        MaterialApp(
-          theme: theme,
-          home: Scaffold(
-            bottomNavigationBar: BottomNavigationBar(
-              currentIndex: 0,
-              items: const <BottomNavigationBarItem>[
-                BottomNavigationBarItem(
-                  icon: Icon(Icons.home_outlined),
-                  label: 'Home',
-                ),
-                BottomNavigationBarItem(
-                  icon: Icon(Icons.bar_chart_outlined),
-                  label: 'Analytics',
-                ),
-              ],
-            ),
-          ),
-        ),
-      );
-
-      await tester.pumpAndSettle();
-
-      final BuildContext context = tester.element(
-        find.byType(BottomNavigationBar),
-      );
-      final ColorScheme colorScheme = Theme.of(context).colorScheme;
-      final Iterable<IconTheme> iconThemes = tester.widgetList<IconTheme>(
-        find.descendant(
-          of: find.byType(BottomNavigationBar),
-          matching: find.byType(IconTheme),
-        ),
-      );
-
+      expect(theme.useMaterial3, isTrue);
+      expect(theme.colorScheme.primary, expectedScheme.primary);
+      expect(theme.colorScheme.secondary, expectedScheme.secondary);
       expect(
-        iconThemes.any(
-          (IconTheme theme) => theme.data.color == colorScheme.onSurface,
-        ),
-        isTrue,
+        theme.bottomNavigationBarTheme.selectedItemColor,
+        theme.colorScheme.onSurface,
       );
       expect(
-        iconThemes.any(
-          (IconTheme theme) => theme.data.color == colorScheme.onSurfaceVariant,
-        ),
-        isTrue,
+        theme.bottomNavigationBarTheme.unselectedItemColor,
+        theme.colorScheme.onSurfaceVariant,
       );
     });
 
-    testWidgets('uses onSurface roles in dark theme', (
-      WidgetTester tester,
-    ) async {
+    test('поддерживает тёмную тему', () {
+      const Color seedColor = Color(0xFF8AEDAB);
+      final ColorScheme expectedScheme = ColorScheme.fromSeed(
+        seedColor: seedColor,
+        brightness: Brightness.dark,
+      );
       final ThemeData theme = buildAppTheme(brightness: Brightness.dark);
 
-      await tester.pumpWidget(
-        MaterialApp(
-          theme: theme,
-          home: Scaffold(
-            bottomNavigationBar: BottomNavigationBar(
-              currentIndex: 0,
-              items: const <BottomNavigationBarItem>[
-                BottomNavigationBarItem(
-                  icon: Icon(Icons.home_outlined),
-                  label: 'Home',
-                ),
-                BottomNavigationBarItem(
-                  icon: Icon(Icons.bar_chart_outlined),
-                  label: 'Analytics',
-                ),
-              ],
-            ),
-          ),
-        ),
-      );
-
-      await tester.pumpAndSettle();
-
-      final BuildContext context = tester.element(
-        find.byType(BottomNavigationBar),
-      );
-      final ColorScheme colorScheme = Theme.of(context).colorScheme;
-      final Iterable<IconTheme> iconThemes = tester.widgetList<IconTheme>(
-        find.descendant(
-          of: find.byType(BottomNavigationBar),
-          matching: find.byType(IconTheme),
-        ),
-      );
-
-      expect(
-        iconThemes.any(
-          (IconTheme theme) => theme.data.color == colorScheme.onSurface,
-        ),
-        isTrue,
-      );
-      expect(
-        iconThemes.any(
-          (IconTheme theme) => theme.data.color == colorScheme.onSurfaceVariant,
-        ),
-        isTrue,
-      );
+      expect(theme.brightness, Brightness.dark);
+      expect(theme.colorScheme.brightness, Brightness.dark);
+      expect(theme.colorScheme.primary, expectedScheme.primary);
     });
   });
 }

--- a/test/core/formatting/date_format_providers_test.dart
+++ b/test/core/formatting/date_format_providers_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:intl/intl.dart';
+import 'package:kopim/core/formatting/date_format_providers.dart';
+import 'package:riverpod/riverpod.dart';
+
+void main() {
+  setUpAll(() async {
+    await initializeDateFormatting('ru');
+    await initializeDateFormatting('en');
+  });
+
+  group('dateFormatProvider', () {
+    test('возвращает один и тот же экземпляр для одинаковых параметров', () {
+      final ProviderContainer container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      const DateFormatRequest request = (
+        locale: Locale('ru'),
+        format: AppDateFormat.longMonthDay,
+      );
+
+      final DateFormat first = container.read(dateFormatProvider(request));
+      final DateFormat second = container.read(dateFormatProvider(request));
+
+      expect(identical(first, second), isTrue);
+    });
+
+    test('форматирует дату в соответствии с локалью', () {
+      final ProviderContainer container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      const DateFormatRequest request = (
+        locale: Locale('en'),
+        format: AppDateFormat.longMonthDay,
+      );
+
+      final DateFormat format = container.read(dateFormatProvider(request));
+      final DateTime date = DateTime(2024, 9, 24);
+
+      expect(format.format(date), 'September 24, 2024');
+    });
+  });
+}

--- a/test/features/profile/presentation/screens/profile_screen_test.dart
+++ b/test/features/profile/presentation/screens/profile_screen_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kopim/features/app_shell/presentation/models/navigation_tab_content.dart';
+import 'package:kopim/features/profile/presentation/screens/general_settings_screen.dart';
+import 'package:kopim/features/profile/presentation/screens/profile_screen.dart'
+    show buildProfileTabContent;
+import 'package:kopim/l10n/app_localizations.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class _MockNavigatorObserver extends Mock implements NavigatorObserver {}
+
+class _ProfileAppBarHarness extends ConsumerWidget {
+  const _ProfileAppBarHarness();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final NavigationTabContent content = buildProfileTabContent(context, ref);
+    final PreferredSizeWidget? appBar = content.appBarBuilder?.call(
+      context,
+      ref,
+    );
+
+    return Scaffold(appBar: appBar, body: const SizedBox.shrink());
+  }
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(FakeRoute());
+  });
+
+  testWidgets('иконка настроек открывает экран общих настроек', (
+    WidgetTester tester,
+  ) async {
+    final _MockNavigatorObserver observer = _MockNavigatorObserver();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          navigatorObservers: <NavigatorObserver>[observer],
+          routes: <String, WidgetBuilder>{
+            GeneralSettingsScreen.routeName: (_) => const Scaffold(),
+          },
+          home: const _ProfileAppBarHarness(),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byIcon(Icons.tune));
+    await tester.pumpAndSettle();
+
+    verify(
+      () => observer.didPush(
+        any(
+          that: isA<Route<dynamic>>().having(
+            (Route<dynamic> route) => route.settings.name,
+            'name',
+            GeneralSettingsScreen.routeName,
+          ),
+        ),
+        any(),
+      ),
+    ).called(1);
+  });
+}
+
+class FakeRoute extends Fake implements Route<dynamic> {}


### PR DESCRIPTION
## Изменения
- добавлен провайдер `date_format_providers.dart` с кэшированием `DateFormat` и интеграция его в экран повторяющихся операций
- актуализированы модульные тесты темы и добавлены новые тесты для форматтеров и навигации профиля

## Тесты
- dart format --set-exit-if-changed .
- flutter analyze
- dart run build_runner build --delete-conflicting-outputs
- flutter test --reporter expanded
- flutter pub outdated

------
https://chatgpt.com/codex/tasks/task_e_68e193c7d848832eb1c9e8ed18acf72d