### PR TITLE
Добавлена поддержка целей накоплений с офлайн-синком

### DIFF
--- a/lib/core/data/database.dart
+++ b/lib/core/data/database.dart
@@ -203,6 +203,23 @@ class BudgetInstances extends Table {
   Set<Column<Object>> get primaryKey => <Column<Object>>{id};
 }
 
+@DataClassName('SavingGoalRow')
+class SavingGoals extends Table {
+  TextColumn get id => text().withLength(min: 1, max: 50)();
+  TextColumn get userId => text().withLength(min: 1, max: 64)();
+  TextColumn get name => text().withLength(min: 1, max: 120)();
+  IntColumn get targetAmount => integer()();
+  IntColumn get currentAmount =>
+      integer().withDefault(const Constant<int>(0))();
+  TextColumn get note => text().nullable()();
+  DateTimeColumn get createdAt => dateTime().withDefault(currentDateAndTime)();
+  DateTimeColumn get updatedAt => dateTime().withDefault(currentDateAndTime)();
+  DateTimeColumn get archivedAt => dateTime().nullable()();
+
+  @override
+  Set<Column<Object>> get primaryKey => <Column<Object>>{id};
+}
+
 @DataClassName('JobQueueRow')
 class JobQueue extends Table {
   IntColumn get id => integer().autoIncrement()();
@@ -227,6 +244,7 @@ class JobQueue extends Table {
     JobQueue,
     Budgets,
     BudgetInstances,
+    SavingGoals,
   ],
 )
 class AppDatabase extends _$AppDatabase {
@@ -235,7 +253,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.connect(DatabaseConnection super.connection);
 
   @override
-  int get schemaVersion => 8;
+  int get schemaVersion => 9;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -255,6 +273,13 @@ class AppDatabase extends _$AppDatabase {
           'budget_instances_budget_period_idx',
           'CREATE INDEX IF NOT EXISTS budget_instances_budget_period_idx '
               'ON budget_instances(budget_id, period_start)',
+        ),
+      );
+      await m.createIndex(
+        Index(
+          'saving_goals_status_updated_idx',
+          'CREATE INDEX IF NOT EXISTS saving_goals_status_updated_idx '
+              'ON saving_goals(archived_at, updated_at DESC)',
         ),
       );
     },
@@ -360,6 +385,16 @@ class AppDatabase extends _$AppDatabase {
             'budget_instances_budget_period_idx',
             'CREATE INDEX IF NOT EXISTS budget_instances_budget_period_idx '
                 'ON budget_instances(budget_id, period_start)',
+          ),
+        );
+      }
+      if (from < 9) {
+        await m.createTable(savingGoals);
+        await m.createIndex(
+          Index(
+            'saving_goals_status_updated_idx',
+            'CREATE INDEX IF NOT EXISTS saving_goals_status_updated_idx '
+                'ON saving_goals(archived_at, updated_at DESC)',
           ),
         );
       }

--- a/lib/core/data/database.g.dart
+++ b/lib/core/data/database.g.dart
@@ -6744,6 +6744,578 @@ class BudgetInstancesCompanion extends UpdateCompanion<BudgetInstanceRow> {
   }
 }
 
+class $SavingGoalsTable extends SavingGoals
+    with TableInfo<$SavingGoalsTable, SavingGoalRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $SavingGoalsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<String> id = GeneratedColumn<String>(
+    'id',
+    aliasedName,
+    false,
+    additionalChecks: GeneratedColumn.checkTextLength(
+      minTextLength: 1,
+      maxTextLength: 50,
+    ),
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _userIdMeta = const VerificationMeta('userId');
+  @override
+  late final GeneratedColumn<String> userId = GeneratedColumn<String>(
+    'user_id',
+    aliasedName,
+    false,
+    additionalChecks: GeneratedColumn.checkTextLength(
+      minTextLength: 1,
+      maxTextLength: 64,
+    ),
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _nameMeta = const VerificationMeta('name');
+  @override
+  late final GeneratedColumn<String> name = GeneratedColumn<String>(
+    'name',
+    aliasedName,
+    false,
+    additionalChecks: GeneratedColumn.checkTextLength(
+      minTextLength: 1,
+      maxTextLength: 120,
+    ),
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _targetAmountMeta = const VerificationMeta(
+    'targetAmount',
+  );
+  @override
+  late final GeneratedColumn<int> targetAmount = GeneratedColumn<int>(
+    'target_amount',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _currentAmountMeta = const VerificationMeta(
+    'currentAmount',
+  );
+  @override
+  late final GeneratedColumn<int> currentAmount = GeneratedColumn<int>(
+    'current_amount',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultValue: const Constant<int>(0),
+  );
+  static const VerificationMeta _noteMeta = const VerificationMeta('note');
+  @override
+  late final GeneratedColumn<String> note = GeneratedColumn<String>(
+    'note',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _createdAtMeta = const VerificationMeta(
+    'createdAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
+    'created_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+    defaultValue: currentDateAndTime,
+  );
+  static const VerificationMeta _updatedAtMeta = const VerificationMeta(
+    'updatedAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> updatedAt = GeneratedColumn<DateTime>(
+    'updated_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+    defaultValue: currentDateAndTime,
+  );
+  static const VerificationMeta _archivedAtMeta = const VerificationMeta(
+    'archivedAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> archivedAt = GeneratedColumn<DateTime>(
+    'archived_at',
+    aliasedName,
+    true,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    userId,
+    name,
+    targetAmount,
+    currentAmount,
+    note,
+    createdAt,
+    updatedAt,
+    archivedAt,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'saving_goals';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<SavingGoalRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    } else if (isInserting) {
+      context.missing(_idMeta);
+    }
+    if (data.containsKey('user_id')) {
+      context.handle(
+        _userIdMeta,
+        userId.isAcceptableOrUnknown(data['user_id']!, _userIdMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_userIdMeta);
+    }
+    if (data.containsKey('name')) {
+      context.handle(
+        _nameMeta,
+        name.isAcceptableOrUnknown(data['name']!, _nameMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_nameMeta);
+    }
+    if (data.containsKey('target_amount')) {
+      context.handle(
+        _targetAmountMeta,
+        targetAmount.isAcceptableOrUnknown(
+          data['target_amount']!,
+          _targetAmountMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_targetAmountMeta);
+    }
+    if (data.containsKey('current_amount')) {
+      context.handle(
+        _currentAmountMeta,
+        currentAmount.isAcceptableOrUnknown(
+          data['current_amount']!,
+          _currentAmountMeta,
+        ),
+      );
+    }
+    if (data.containsKey('note')) {
+      context.handle(
+        _noteMeta,
+        note.isAcceptableOrUnknown(data['note']!, _noteMeta),
+      );
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(
+        _createdAtMeta,
+        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
+      );
+    }
+    if (data.containsKey('updated_at')) {
+      context.handle(
+        _updatedAtMeta,
+        updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta),
+      );
+    }
+    if (data.containsKey('archived_at')) {
+      context.handle(
+        _archivedAtMeta,
+        archivedAt.isAcceptableOrUnknown(data['archived_at']!, _archivedAtMeta),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  SavingGoalRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return SavingGoalRow(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}id'],
+      )!,
+      userId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}user_id'],
+      )!,
+      name: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}name'],
+      )!,
+      targetAmount: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}target_amount'],
+      )!,
+      currentAmount: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}current_amount'],
+      )!,
+      note: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}note'],
+      ),
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}created_at'],
+      )!,
+      updatedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}updated_at'],
+      )!,
+      archivedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}archived_at'],
+      ),
+    );
+  }
+
+  @override
+  $SavingGoalsTable createAlias(String alias) {
+    return $SavingGoalsTable(attachedDatabase, alias);
+  }
+}
+
+class SavingGoalRow extends DataClass implements Insertable<SavingGoalRow> {
+  final String id;
+  final String userId;
+  final String name;
+  final int targetAmount;
+  final int currentAmount;
+  final String? note;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final DateTime? archivedAt;
+  const SavingGoalRow({
+    required this.id,
+    required this.userId,
+    required this.name,
+    required this.targetAmount,
+    required this.currentAmount,
+    this.note,
+    required this.createdAt,
+    required this.updatedAt,
+    this.archivedAt,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<String>(id);
+    map['user_id'] = Variable<String>(userId);
+    map['name'] = Variable<String>(name);
+    map['target_amount'] = Variable<int>(targetAmount);
+    map['current_amount'] = Variable<int>(currentAmount);
+    if (!nullToAbsent || note != null) {
+      map['note'] = Variable<String>(note);
+    }
+    map['created_at'] = Variable<DateTime>(createdAt);
+    map['updated_at'] = Variable<DateTime>(updatedAt);
+    if (!nullToAbsent || archivedAt != null) {
+      map['archived_at'] = Variable<DateTime>(archivedAt);
+    }
+    return map;
+  }
+
+  SavingGoalsCompanion toCompanion(bool nullToAbsent) {
+    return SavingGoalsCompanion(
+      id: Value(id),
+      userId: Value(userId),
+      name: Value(name),
+      targetAmount: Value(targetAmount),
+      currentAmount: Value(currentAmount),
+      note: note == null && nullToAbsent ? const Value.absent() : Value(note),
+      createdAt: Value(createdAt),
+      updatedAt: Value(updatedAt),
+      archivedAt: archivedAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(archivedAt),
+    );
+  }
+
+  factory SavingGoalRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return SavingGoalRow(
+      id: serializer.fromJson<String>(json['id']),
+      userId: serializer.fromJson<String>(json['userId']),
+      name: serializer.fromJson<String>(json['name']),
+      targetAmount: serializer.fromJson<int>(json['targetAmount']),
+      currentAmount: serializer.fromJson<int>(json['currentAmount']),
+      note: serializer.fromJson<String?>(json['note']),
+      createdAt: serializer.fromJson<DateTime>(json['createdAt']),
+      updatedAt: serializer.fromJson<DateTime>(json['updatedAt']),
+      archivedAt: serializer.fromJson<DateTime?>(json['archivedAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<String>(id),
+      'userId': serializer.toJson<String>(userId),
+      'name': serializer.toJson<String>(name),
+      'targetAmount': serializer.toJson<int>(targetAmount),
+      'currentAmount': serializer.toJson<int>(currentAmount),
+      'note': serializer.toJson<String?>(note),
+      'createdAt': serializer.toJson<DateTime>(createdAt),
+      'updatedAt': serializer.toJson<DateTime>(updatedAt),
+      'archivedAt': serializer.toJson<DateTime?>(archivedAt),
+    };
+  }
+
+  SavingGoalRow copyWith({
+    String? id,
+    String? userId,
+    String? name,
+    int? targetAmount,
+    int? currentAmount,
+    Value<String?> note = const Value.absent(),
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    Value<DateTime?> archivedAt = const Value.absent(),
+  }) => SavingGoalRow(
+    id: id ?? this.id,
+    userId: userId ?? this.userId,
+    name: name ?? this.name,
+    targetAmount: targetAmount ?? this.targetAmount,
+    currentAmount: currentAmount ?? this.currentAmount,
+    note: note.present ? note.value : this.note,
+    createdAt: createdAt ?? this.createdAt,
+    updatedAt: updatedAt ?? this.updatedAt,
+    archivedAt: archivedAt.present ? archivedAt.value : this.archivedAt,
+  );
+  SavingGoalRow copyWithCompanion(SavingGoalsCompanion data) {
+    return SavingGoalRow(
+      id: data.id.present ? data.id.value : this.id,
+      userId: data.userId.present ? data.userId.value : this.userId,
+      name: data.name.present ? data.name.value : this.name,
+      targetAmount: data.targetAmount.present
+          ? data.targetAmount.value
+          : this.targetAmount,
+      currentAmount: data.currentAmount.present
+          ? data.currentAmount.value
+          : this.currentAmount,
+      note: data.note.present ? data.note.value : this.note,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+      updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
+      archivedAt: data.archivedAt.present
+          ? data.archivedAt.value
+          : this.archivedAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('SavingGoalRow(')
+          ..write('id: $id, ')
+          ..write('userId: $userId, ')
+          ..write('name: $name, ')
+          ..write('targetAmount: $targetAmount, ')
+          ..write('currentAmount: $currentAmount, ')
+          ..write('note: $note, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('archivedAt: $archivedAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    userId,
+    name,
+    targetAmount,
+    currentAmount,
+    note,
+    createdAt,
+    updatedAt,
+    archivedAt,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is SavingGoalRow &&
+          other.id == this.id &&
+          other.userId == this.userId &&
+          other.name == this.name &&
+          other.targetAmount == this.targetAmount &&
+          other.currentAmount == this.currentAmount &&
+          other.note == this.note &&
+          other.createdAt == this.createdAt &&
+          other.updatedAt == this.updatedAt &&
+          other.archivedAt == this.archivedAt);
+}
+
+class SavingGoalsCompanion extends UpdateCompanion<SavingGoalRow> {
+  final Value<String> id;
+  final Value<String> userId;
+  final Value<String> name;
+  final Value<int> targetAmount;
+  final Value<int> currentAmount;
+  final Value<String?> note;
+  final Value<DateTime> createdAt;
+  final Value<DateTime> updatedAt;
+  final Value<DateTime?> archivedAt;
+  final Value<int> rowid;
+  const SavingGoalsCompanion({
+    this.id = const Value.absent(),
+    this.userId = const Value.absent(),
+    this.name = const Value.absent(),
+    this.targetAmount = const Value.absent(),
+    this.currentAmount = const Value.absent(),
+    this.note = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+    this.archivedAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  SavingGoalsCompanion.insert({
+    required String id,
+    required String userId,
+    required String name,
+    required int targetAmount,
+    this.currentAmount = const Value.absent(),
+    this.note = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+    this.archivedAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  }) : id = Value(id),
+       userId = Value(userId),
+       name = Value(name),
+       targetAmount = Value(targetAmount);
+  static Insertable<SavingGoalRow> custom({
+    Expression<String>? id,
+    Expression<String>? userId,
+    Expression<String>? name,
+    Expression<int>? targetAmount,
+    Expression<int>? currentAmount,
+    Expression<String>? note,
+    Expression<DateTime>? createdAt,
+    Expression<DateTime>? updatedAt,
+    Expression<DateTime>? archivedAt,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (userId != null) 'user_id': userId,
+      if (name != null) 'name': name,
+      if (targetAmount != null) 'target_amount': targetAmount,
+      if (currentAmount != null) 'current_amount': currentAmount,
+      if (note != null) 'note': note,
+      if (createdAt != null) 'created_at': createdAt,
+      if (updatedAt != null) 'updated_at': updatedAt,
+      if (archivedAt != null) 'archived_at': archivedAt,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  SavingGoalsCompanion copyWith({
+    Value<String>? id,
+    Value<String>? userId,
+    Value<String>? name,
+    Value<int>? targetAmount,
+    Value<int>? currentAmount,
+    Value<String?>? note,
+    Value<DateTime>? createdAt,
+    Value<DateTime>? updatedAt,
+    Value<DateTime?>? archivedAt,
+    Value<int>? rowid,
+  }) {
+    return SavingGoalsCompanion(
+      id: id ?? this.id,
+      userId: userId ?? this.userId,
+      name: name ?? this.name,
+      targetAmount: targetAmount ?? this.targetAmount,
+      currentAmount: currentAmount ?? this.currentAmount,
+      note: note ?? this.note,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      archivedAt: archivedAt ?? this.archivedAt,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<String>(id.value);
+    }
+    if (userId.present) {
+      map['user_id'] = Variable<String>(userId.value);
+    }
+    if (name.present) {
+      map['name'] = Variable<String>(name.value);
+    }
+    if (targetAmount.present) {
+      map['target_amount'] = Variable<int>(targetAmount.value);
+    }
+    if (currentAmount.present) {
+      map['current_amount'] = Variable<int>(currentAmount.value);
+    }
+    if (note.present) {
+      map['note'] = Variable<String>(note.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<DateTime>(createdAt.value);
+    }
+    if (updatedAt.present) {
+      map['updated_at'] = Variable<DateTime>(updatedAt.value);
+    }
+    if (archivedAt.present) {
+      map['archived_at'] = Variable<DateTime>(archivedAt.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('SavingGoalsCompanion(')
+          ..write('id: $id, ')
+          ..write('userId: $userId, ')
+          ..write('name: $name, ')
+          ..write('targetAmount: $targetAmount, ')
+          ..write('currentAmount: $currentAmount, ')
+          ..write('note: $note, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('archivedAt: $archivedAt, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$AppDatabase extends GeneratedDatabase {
   _$AppDatabase(QueryExecutor e) : super(e);
   $AppDatabaseManager get managers => $AppDatabaseManager(this);
@@ -6762,6 +7334,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final $BudgetInstancesTable budgetInstances = $BudgetInstancesTable(
     this,
   );
+  late final $SavingGoalsTable savingGoals = $SavingGoalsTable(this);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
@@ -6778,6 +7351,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     jobQueue,
     budgets,
     budgetInstances,
+    savingGoals,
   ];
   @override
   StreamQueryUpdateRules get streamUpdateRules => const StreamQueryUpdateRules([
@@ -11647,6 +12221,288 @@ typedef $$BudgetInstancesTableProcessedTableManager =
       BudgetInstanceRow,
       PrefetchHooks Function({bool budgetId})
     >;
+typedef $$SavingGoalsTableCreateCompanionBuilder =
+    SavingGoalsCompanion Function({
+      required String id,
+      required String userId,
+      required String name,
+      required int targetAmount,
+      Value<int> currentAmount,
+      Value<String?> note,
+      Value<DateTime> createdAt,
+      Value<DateTime> updatedAt,
+      Value<DateTime?> archivedAt,
+      Value<int> rowid,
+    });
+typedef $$SavingGoalsTableUpdateCompanionBuilder =
+    SavingGoalsCompanion Function({
+      Value<String> id,
+      Value<String> userId,
+      Value<String> name,
+      Value<int> targetAmount,
+      Value<int> currentAmount,
+      Value<String?> note,
+      Value<DateTime> createdAt,
+      Value<DateTime> updatedAt,
+      Value<DateTime?> archivedAt,
+      Value<int> rowid,
+    });
+
+class $$SavingGoalsTableFilterComposer
+    extends Composer<_$AppDatabase, $SavingGoalsTable> {
+  $$SavingGoalsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get userId => $composableBuilder(
+    column: $table.userId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get name => $composableBuilder(
+    column: $table.name,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get targetAmount => $composableBuilder(
+    column: $table.targetAmount,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get currentAmount => $composableBuilder(
+    column: $table.currentAmount,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get note => $composableBuilder(
+    column: $table.note,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get archivedAt => $composableBuilder(
+    column: $table.archivedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$SavingGoalsTableOrderingComposer
+    extends Composer<_$AppDatabase, $SavingGoalsTable> {
+  $$SavingGoalsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get userId => $composableBuilder(
+    column: $table.userId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get name => $composableBuilder(
+    column: $table.name,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get targetAmount => $composableBuilder(
+    column: $table.targetAmount,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get currentAmount => $composableBuilder(
+    column: $table.currentAmount,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get note => $composableBuilder(
+    column: $table.note,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get archivedAt => $composableBuilder(
+    column: $table.archivedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$SavingGoalsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $SavingGoalsTable> {
+  $$SavingGoalsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get userId =>
+      $composableBuilder(column: $table.userId, builder: (column) => column);
+
+  GeneratedColumn<String> get name =>
+      $composableBuilder(column: $table.name, builder: (column) => column);
+
+  GeneratedColumn<int> get targetAmount => $composableBuilder(
+    column: $table.targetAmount,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get currentAmount => $composableBuilder(
+    column: $table.currentAmount,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get note =>
+      $composableBuilder(column: $table.note, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get updatedAt =>
+      $composableBuilder(column: $table.updatedAt, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get archivedAt => $composableBuilder(
+    column: $table.archivedAt,
+    builder: (column) => column,
+  );
+}
+
+class $$SavingGoalsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $SavingGoalsTable,
+          SavingGoalRow,
+          $$SavingGoalsTableFilterComposer,
+          $$SavingGoalsTableOrderingComposer,
+          $$SavingGoalsTableAnnotationComposer,
+          $$SavingGoalsTableCreateCompanionBuilder,
+          $$SavingGoalsTableUpdateCompanionBuilder,
+          (
+            SavingGoalRow,
+            BaseReferences<_$AppDatabase, $SavingGoalsTable, SavingGoalRow>,
+          ),
+          SavingGoalRow,
+          PrefetchHooks Function()
+        > {
+  $$SavingGoalsTableTableManager(_$AppDatabase db, $SavingGoalsTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$SavingGoalsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$SavingGoalsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$SavingGoalsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<String> id = const Value.absent(),
+                Value<String> userId = const Value.absent(),
+                Value<String> name = const Value.absent(),
+                Value<int> targetAmount = const Value.absent(),
+                Value<int> currentAmount = const Value.absent(),
+                Value<String?> note = const Value.absent(),
+                Value<DateTime> createdAt = const Value.absent(),
+                Value<DateTime> updatedAt = const Value.absent(),
+                Value<DateTime?> archivedAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => SavingGoalsCompanion(
+                id: id,
+                userId: userId,
+                name: name,
+                targetAmount: targetAmount,
+                currentAmount: currentAmount,
+                note: note,
+                createdAt: createdAt,
+                updatedAt: updatedAt,
+                archivedAt: archivedAt,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String id,
+                required String userId,
+                required String name,
+                required int targetAmount,
+                Value<int> currentAmount = const Value.absent(),
+                Value<String?> note = const Value.absent(),
+                Value<DateTime> createdAt = const Value.absent(),
+                Value<DateTime> updatedAt = const Value.absent(),
+                Value<DateTime?> archivedAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => SavingGoalsCompanion.insert(
+                id: id,
+                userId: userId,
+                name: name,
+                targetAmount: targetAmount,
+                currentAmount: currentAmount,
+                note: note,
+                createdAt: createdAt,
+                updatedAt: updatedAt,
+                archivedAt: archivedAt,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$SavingGoalsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $SavingGoalsTable,
+      SavingGoalRow,
+      $$SavingGoalsTableFilterComposer,
+      $$SavingGoalsTableOrderingComposer,
+      $$SavingGoalsTableAnnotationComposer,
+      $$SavingGoalsTableCreateCompanionBuilder,
+      $$SavingGoalsTableUpdateCompanionBuilder,
+      (
+        SavingGoalRow,
+        BaseReferences<_$AppDatabase, $SavingGoalsTable, SavingGoalRow>,
+      ),
+      SavingGoalRow,
+      PrefetchHooks Function()
+    >;
 
 class $AppDatabaseManager {
   final _$AppDatabase _db;
@@ -11676,4 +12532,6 @@ class $AppDatabaseManager {
       $$BudgetsTableTableManager(_db, _db.budgets);
   $$BudgetInstancesTableTableManager get budgetInstances =>
       $$BudgetInstancesTableTableManager(_db, _db.budgetInstances);
+  $$SavingGoalsTableTableManager get savingGoals =>
+      $$SavingGoalsTableTableManager(_db, _db.savingGoals);
 }

--- a/lib/core/di/injectors.dart
+++ b/lib/core/di/injectors.dart
@@ -40,6 +40,16 @@ import 'package:kopim/features/categories/domain/use_cases/delete_category_use_c
 import 'package:kopim/features/categories/domain/use_cases/save_category_use_case.dart';
 import 'package:kopim/features/categories/domain/use_cases/watch_categories_use_case.dart';
 import 'package:kopim/features/categories/domain/use_cases/watch_category_tree_use_case.dart';
+import 'package:kopim/features/savings/data/repositories/saving_goal_repository_impl.dart';
+import 'package:kopim/features/savings/data/sources/local/saving_goal_dao.dart';
+import 'package:kopim/features/savings/data/sources/remote/saving_goal_remote_data_source.dart';
+import 'package:kopim/features/savings/domain/repositories/saving_goal_repository.dart';
+import 'package:kopim/features/savings/domain/use_cases/add_contribution_use_case.dart';
+import 'package:kopim/features/savings/domain/use_cases/archive_saving_goal_use_case.dart';
+import 'package:kopim/features/savings/domain/use_cases/create_saving_goal_use_case.dart';
+import 'package:kopim/features/savings/domain/use_cases/get_saving_goals_use_case.dart';
+import 'package:kopim/features/savings/domain/use_cases/update_saving_goal_use_case.dart';
+import 'package:kopim/features/savings/domain/use_cases/watch_saving_goals_use_case.dart';
 import 'package:kopim/features/profile/data/auth_repository_impl.dart';
 import 'package:kopim/features/profile/data/local/profile_dao.dart';
 import 'package:kopim/features/profile/data/profile_repository_impl.dart';
@@ -125,6 +135,10 @@ BudgetInstanceDao budgetInstanceDao(Ref ref) =>
     BudgetInstanceDao(ref.watch(appDatabaseProvider));
 
 @riverpod
+SavingGoalDao savingGoalDao(Ref ref) =>
+    SavingGoalDao(ref.watch(appDatabaseProvider));
+
+@riverpod
 ProfileDao profileDao(Ref ref) => ProfileDao(ref.watch(appDatabaseProvider));
 
 @riverpod
@@ -180,6 +194,10 @@ BudgetInstanceRemoteDataSource budgetInstanceRemoteDataSource(Ref ref) =>
     BudgetInstanceRemoteDataSource(ref.watch(firestoreProvider));
 
 @riverpod
+SavingGoalRemoteDataSource savingGoalRemoteDataSource(Ref ref) =>
+    SavingGoalRemoteDataSource(ref.watch(firestoreProvider));
+
+@riverpod
 RecurringNotificationService recurringNotificationService(Ref ref) =>
     RecurringNotificationService(
       ref.watch(flutterLocalNotificationsPluginProvider),
@@ -215,6 +233,43 @@ DeleteBudgetUseCase deleteBudgetUseCase(Ref ref) =>
 @riverpod
 ComputeBudgetProgressUseCase computeBudgetProgressUseCase(Ref ref) =>
     ComputeBudgetProgressUseCase(schedule: ref.watch(budgetScheduleProvider));
+
+@riverpod
+CreateSavingGoalUseCase createSavingGoalUseCase(Ref ref) =>
+    CreateSavingGoalUseCase(
+      repository: ref.watch(savingGoalRepositoryProvider),
+      authRepository: ref.watch(authRepositoryProvider),
+      uuidGenerator: ref.watch(uuidGeneratorProvider),
+    );
+
+@riverpod
+UpdateSavingGoalUseCase updateSavingGoalUseCase(Ref ref) =>
+    UpdateSavingGoalUseCase(
+      repository: ref.watch(savingGoalRepositoryProvider),
+    );
+
+@riverpod
+ArchiveSavingGoalUseCase archiveSavingGoalUseCase(Ref ref) =>
+    ArchiveSavingGoalUseCase(
+      repository: ref.watch(savingGoalRepositoryProvider),
+    );
+
+@riverpod
+WatchSavingGoalsUseCase watchSavingGoalsUseCase(Ref ref) =>
+    WatchSavingGoalsUseCase(
+      repository: ref.watch(savingGoalRepositoryProvider),
+    );
+
+@riverpod
+GetSavingGoalsUseCase getSavingGoalsUseCase(Ref ref) =>
+    GetSavingGoalsUseCase(repository: ref.watch(savingGoalRepositoryProvider));
+
+@riverpod
+AddContributionUseCase addContributionUseCase(Ref ref) =>
+    AddContributionUseCase(
+      repository: ref.watch(savingGoalRepositoryProvider),
+      addTransactionUseCase: ref.watch(addTransactionUseCaseProvider),
+    );
 
 @riverpod
 CategoryRepository categoryRepository(Ref ref) => CategoryRepositoryImpl(
@@ -255,6 +310,15 @@ BudgetRepository budgetRepository(Ref ref) => BudgetRepositoryImpl(
   budgetDao: ref.watch(budgetDaoProvider),
   budgetInstanceDao: ref.watch(budgetInstanceDaoProvider),
   outboxDao: ref.watch(outboxDaoProvider),
+);
+
+@riverpod
+SavingGoalRepository savingGoalRepository(Ref ref) => SavingGoalRepositoryImpl(
+  database: ref.watch(appDatabaseProvider),
+  savingGoalDao: ref.watch(savingGoalDaoProvider),
+  outboxDao: ref.watch(outboxDaoProvider),
+  analyticsService: ref.watch(analyticsServiceProvider),
+  loggerService: ref.watch(loggerServiceProvider),
 );
 
 @riverpod
@@ -393,6 +457,7 @@ SyncService syncService(Ref ref) {
     budgetInstanceRemoteDataSource: ref.watch(
       budgetInstanceRemoteDataSourceProvider,
     ),
+    savingGoalRemoteDataSource: ref.watch(savingGoalRemoteDataSourceProvider),
     firebaseAuth: ref.watch(firebaseAuthProvider),
     connectivity: ref.watch(connectivityProvider),
   );
@@ -418,6 +483,7 @@ AuthSyncService authSyncService(Ref ref) => AuthSyncService(
   transactionDao: ref.watch(transactionDaoProvider),
   budgetDao: ref.watch(budgetDaoProvider),
   budgetInstanceDao: ref.watch(budgetInstanceDaoProvider),
+  savingGoalDao: ref.watch(savingGoalDaoProvider),
   profileDao: ref.watch(profileDaoProvider),
   accountRemoteDataSource: ref.watch(accountRemoteDataSourceProvider),
   categoryRemoteDataSource: ref.watch(categoryRemoteDataSourceProvider),
@@ -426,6 +492,7 @@ AuthSyncService authSyncService(Ref ref) => AuthSyncService(
   budgetInstanceRemoteDataSource: ref.watch(
     budgetInstanceRemoteDataSourceProvider,
   ),
+  savingGoalRemoteDataSource: ref.watch(savingGoalRemoteDataSourceProvider),
   profileRemoteDataSource: ref.watch(profileRemoteDataSourceProvider),
   firestore: ref.watch(firestoreProvider),
   loggerService: ref.watch(loggerServiceProvider),

--- a/lib/core/di/injectors.g.dart
+++ b/lib/core/di/injectors.g.dart
@@ -599,6 +599,47 @@ final class BudgetInstanceDaoProvider
 
 String _$budgetInstanceDaoHash() => r'f2ff161d2210b373bff95923b0810a8acb8f09bb';
 
+@ProviderFor(savingGoalDao)
+const savingGoalDaoProvider = SavingGoalDaoProvider._();
+
+final class SavingGoalDaoProvider
+    extends $FunctionalProvider<SavingGoalDao, SavingGoalDao, SavingGoalDao>
+    with $Provider<SavingGoalDao> {
+  const SavingGoalDaoProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'savingGoalDaoProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$savingGoalDaoHash();
+
+  @$internal
+  @override
+  $ProviderElement<SavingGoalDao> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  SavingGoalDao create(Ref ref) {
+    return savingGoalDao(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(SavingGoalDao value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<SavingGoalDao>(value),
+    );
+  }
+}
+
+String _$savingGoalDaoHash() => r'f486ee43a183e184c23f4137dcacb9c39c73aeb3';
+
 @ProviderFor(profileDao)
 const profileDaoProvider = ProfileDaoProvider._();
 
@@ -1296,6 +1337,55 @@ final class BudgetInstanceRemoteDataSourceProvider
 String _$budgetInstanceRemoteDataSourceHash() =>
     r'a020e9c9816dcaffaf93de641281dc389b6c4a5d';
 
+@ProviderFor(savingGoalRemoteDataSource)
+const savingGoalRemoteDataSourceProvider =
+    SavingGoalRemoteDataSourceProvider._();
+
+final class SavingGoalRemoteDataSourceProvider
+    extends
+        $FunctionalProvider<
+          SavingGoalRemoteDataSource,
+          SavingGoalRemoteDataSource,
+          SavingGoalRemoteDataSource
+        >
+    with $Provider<SavingGoalRemoteDataSource> {
+  const SavingGoalRemoteDataSourceProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'savingGoalRemoteDataSourceProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$savingGoalRemoteDataSourceHash();
+
+  @$internal
+  @override
+  $ProviderElement<SavingGoalRemoteDataSource> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  SavingGoalRemoteDataSource create(Ref ref) {
+    return savingGoalRemoteDataSource(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(SavingGoalRemoteDataSource value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<SavingGoalRemoteDataSource>(value),
+    );
+  }
+}
+
+String _$savingGoalRemoteDataSourceHash() =>
+    r'f92bab57e5d731e4d387077ea0733f42a2a95f56';
+
 @ProviderFor(recurringNotificationService)
 const recurringNotificationServiceProvider =
     RecurringNotificationServiceProvider._();
@@ -1679,6 +1769,294 @@ final class ComputeBudgetProgressUseCaseProvider
 String _$computeBudgetProgressUseCaseHash() =>
     r'6e959206f2a50fea51f6fda1927229c34dbd7a52';
 
+@ProviderFor(createSavingGoalUseCase)
+const createSavingGoalUseCaseProvider = CreateSavingGoalUseCaseProvider._();
+
+final class CreateSavingGoalUseCaseProvider
+    extends
+        $FunctionalProvider<
+          CreateSavingGoalUseCase,
+          CreateSavingGoalUseCase,
+          CreateSavingGoalUseCase
+        >
+    with $Provider<CreateSavingGoalUseCase> {
+  const CreateSavingGoalUseCaseProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'createSavingGoalUseCaseProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$createSavingGoalUseCaseHash();
+
+  @$internal
+  @override
+  $ProviderElement<CreateSavingGoalUseCase> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  CreateSavingGoalUseCase create(Ref ref) {
+    return createSavingGoalUseCase(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(CreateSavingGoalUseCase value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<CreateSavingGoalUseCase>(value),
+    );
+  }
+}
+
+String _$createSavingGoalUseCaseHash() =>
+    r'93b8c9b44deaa81ac2b26ea4867d468b914b873c';
+
+@ProviderFor(updateSavingGoalUseCase)
+const updateSavingGoalUseCaseProvider = UpdateSavingGoalUseCaseProvider._();
+
+final class UpdateSavingGoalUseCaseProvider
+    extends
+        $FunctionalProvider<
+          UpdateSavingGoalUseCase,
+          UpdateSavingGoalUseCase,
+          UpdateSavingGoalUseCase
+        >
+    with $Provider<UpdateSavingGoalUseCase> {
+  const UpdateSavingGoalUseCaseProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'updateSavingGoalUseCaseProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$updateSavingGoalUseCaseHash();
+
+  @$internal
+  @override
+  $ProviderElement<UpdateSavingGoalUseCase> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  UpdateSavingGoalUseCase create(Ref ref) {
+    return updateSavingGoalUseCase(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(UpdateSavingGoalUseCase value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<UpdateSavingGoalUseCase>(value),
+    );
+  }
+}
+
+String _$updateSavingGoalUseCaseHash() =>
+    r'de5d5f148e8edf98f06505044d1a305474246201';
+
+@ProviderFor(archiveSavingGoalUseCase)
+const archiveSavingGoalUseCaseProvider = ArchiveSavingGoalUseCaseProvider._();
+
+final class ArchiveSavingGoalUseCaseProvider
+    extends
+        $FunctionalProvider<
+          ArchiveSavingGoalUseCase,
+          ArchiveSavingGoalUseCase,
+          ArchiveSavingGoalUseCase
+        >
+    with $Provider<ArchiveSavingGoalUseCase> {
+  const ArchiveSavingGoalUseCaseProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'archiveSavingGoalUseCaseProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$archiveSavingGoalUseCaseHash();
+
+  @$internal
+  @override
+  $ProviderElement<ArchiveSavingGoalUseCase> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  ArchiveSavingGoalUseCase create(Ref ref) {
+    return archiveSavingGoalUseCase(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(ArchiveSavingGoalUseCase value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<ArchiveSavingGoalUseCase>(value),
+    );
+  }
+}
+
+String _$archiveSavingGoalUseCaseHash() =>
+    r'4494b09894ee7b6685f603152b70c3107634882b';
+
+@ProviderFor(watchSavingGoalsUseCase)
+const watchSavingGoalsUseCaseProvider = WatchSavingGoalsUseCaseProvider._();
+
+final class WatchSavingGoalsUseCaseProvider
+    extends
+        $FunctionalProvider<
+          WatchSavingGoalsUseCase,
+          WatchSavingGoalsUseCase,
+          WatchSavingGoalsUseCase
+        >
+    with $Provider<WatchSavingGoalsUseCase> {
+  const WatchSavingGoalsUseCaseProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'watchSavingGoalsUseCaseProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$watchSavingGoalsUseCaseHash();
+
+  @$internal
+  @override
+  $ProviderElement<WatchSavingGoalsUseCase> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  WatchSavingGoalsUseCase create(Ref ref) {
+    return watchSavingGoalsUseCase(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(WatchSavingGoalsUseCase value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<WatchSavingGoalsUseCase>(value),
+    );
+  }
+}
+
+String _$watchSavingGoalsUseCaseHash() =>
+    r'4594ab8a779349cd0948384eb9c72b1beea27747';
+
+@ProviderFor(getSavingGoalsUseCase)
+const getSavingGoalsUseCaseProvider = GetSavingGoalsUseCaseProvider._();
+
+final class GetSavingGoalsUseCaseProvider
+    extends
+        $FunctionalProvider<
+          GetSavingGoalsUseCase,
+          GetSavingGoalsUseCase,
+          GetSavingGoalsUseCase
+        >
+    with $Provider<GetSavingGoalsUseCase> {
+  const GetSavingGoalsUseCaseProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'getSavingGoalsUseCaseProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$getSavingGoalsUseCaseHash();
+
+  @$internal
+  @override
+  $ProviderElement<GetSavingGoalsUseCase> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  GetSavingGoalsUseCase create(Ref ref) {
+    return getSavingGoalsUseCase(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(GetSavingGoalsUseCase value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<GetSavingGoalsUseCase>(value),
+    );
+  }
+}
+
+String _$getSavingGoalsUseCaseHash() =>
+    r'0525aead0101084b70819efc8b58306fd06bd938';
+
+@ProviderFor(addContributionUseCase)
+const addContributionUseCaseProvider = AddContributionUseCaseProvider._();
+
+final class AddContributionUseCaseProvider
+    extends
+        $FunctionalProvider<
+          AddContributionUseCase,
+          AddContributionUseCase,
+          AddContributionUseCase
+        >
+    with $Provider<AddContributionUseCase> {
+  const AddContributionUseCaseProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'addContributionUseCaseProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$addContributionUseCaseHash();
+
+  @$internal
+  @override
+  $ProviderElement<AddContributionUseCase> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  AddContributionUseCase create(Ref ref) {
+    return addContributionUseCase(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AddContributionUseCase value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AddContributionUseCase>(value),
+    );
+  }
+}
+
+String _$addContributionUseCaseHash() =>
+    r'7be802062c76f10d1e5b2bf65b7f5098ebcd6203';
+
 @ProviderFor(categoryRepository)
 const categoryRepositoryProvider = CategoryRepositoryProvider._();
 
@@ -1916,6 +2294,54 @@ final class BudgetRepositoryProvider
 }
 
 String _$budgetRepositoryHash() => r'04bad8edb2ea732d9f98e0e2c0bbcf28348162f3';
+
+@ProviderFor(savingGoalRepository)
+const savingGoalRepositoryProvider = SavingGoalRepositoryProvider._();
+
+final class SavingGoalRepositoryProvider
+    extends
+        $FunctionalProvider<
+          SavingGoalRepository,
+          SavingGoalRepository,
+          SavingGoalRepository
+        >
+    with $Provider<SavingGoalRepository> {
+  const SavingGoalRepositoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'savingGoalRepositoryProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$savingGoalRepositoryHash();
+
+  @$internal
+  @override
+  $ProviderElement<SavingGoalRepository> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  SavingGoalRepository create(Ref ref) {
+    return savingGoalRepository(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(SavingGoalRepository value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<SavingGoalRepository>(value),
+    );
+  }
+}
+
+String _$savingGoalRepositoryHash() =>
+    r'bcf8e7f60badb0204c74e29f82777e7553571a95';
 
 @ProviderFor(recurringTransactionsRepository)
 const recurringTransactionsRepositoryProvider =
@@ -2744,7 +3170,7 @@ final class SyncServiceProvider
   }
 }
 
-String _$syncServiceHash() => r'f93c4ee941a1783d4a3b7054cdc10e857120af73';
+String _$syncServiceHash() => r'03e0adb3546e049baa1e430740fe733bb166c2d6';
 
 @ProviderFor(authRepository)
 const authRepositoryProvider = AuthRepositoryProvider._();
@@ -2827,4 +3253,4 @@ final class AuthSyncServiceProvider
   }
 }
 
-String _$authSyncServiceHash() => r'4149ebf6b09190bad7171152e6de60fda970ada9';
+String _$authSyncServiceHash() => r'a78c5d5998ff4b896ab39a61219d85f92164ec35';

--- a/lib/core/services/sync_service.dart
+++ b/lib/core/services/sync_service.dart
@@ -13,6 +13,8 @@ import 'package:kopim/features/budgets/domain/entities/budget.dart';
 import 'package:kopim/features/budgets/domain/entities/budget_instance.dart';
 import 'package:kopim/features/categories/data/sources/remote/category_remote_data_source.dart';
 import 'package:kopim/features/categories/domain/entities/category.dart';
+import 'package:kopim/features/savings/data/sources/remote/saving_goal_remote_data_source.dart';
+import 'package:kopim/features/savings/domain/entities/saving_goal.dart';
 import 'package:kopim/features/profile/data/remote/profile_remote_data_source.dart';
 import 'package:kopim/features/profile/domain/entities/profile.dart';
 import 'package:kopim/features/transactions/data/sources/remote/transaction_remote_data_source.dart';
@@ -27,6 +29,7 @@ class SyncService {
     required ProfileRemoteDataSource profileRemoteDataSource,
     required BudgetRemoteDataSource budgetRemoteDataSource,
     required BudgetInstanceRemoteDataSource budgetInstanceRemoteDataSource,
+    required SavingGoalRemoteDataSource savingGoalRemoteDataSource,
     FirebaseAuth? firebaseAuth,
     Connectivity? connectivity,
   }) : _outboxDao = outboxDao,
@@ -36,6 +39,7 @@ class SyncService {
        _profileRemoteDataSource = profileRemoteDataSource,
        _budgetRemoteDataSource = budgetRemoteDataSource,
        _budgetInstanceRemoteDataSource = budgetInstanceRemoteDataSource,
+       _savingGoalRemoteDataSource = savingGoalRemoteDataSource,
        _auth = firebaseAuth ?? FirebaseAuth.instance,
        _connectivity = connectivity ?? Connectivity();
 
@@ -46,6 +50,7 @@ class SyncService {
   final ProfileRemoteDataSource _profileRemoteDataSource;
   final BudgetRemoteDataSource _budgetRemoteDataSource;
   final BudgetInstanceRemoteDataSource _budgetInstanceRemoteDataSource;
+  final SavingGoalRemoteDataSource _savingGoalRemoteDataSource;
   final FirebaseAuth _auth;
   final Connectivity _connectivity;
 
@@ -132,6 +137,10 @@ class SyncService {
         case 'budget_instance':
           final BudgetInstance instance = BudgetInstance.fromJson(payload);
           await _dispatchBudgetInstance(userId, instance, operation);
+          break;
+        case 'saving_goal':
+          final SavingGoal goal = SavingGoal.fromJson(payload);
+          await _dispatchSavingGoal(userId, goal, operation);
           break;
         default:
           throw UnsupportedError(
@@ -239,6 +248,14 @@ class SyncService {
       return _budgetInstanceRemoteDataSource.delete(userId, instance);
     }
     return _budgetInstanceRemoteDataSource.upsert(userId, instance);
+  }
+
+  Future<void> _dispatchSavingGoal(
+    String userId,
+    SavingGoal goal,
+    OutboxOperation operation,
+  ) {
+    return _savingGoalRemoteDataSource.upsert(userId, goal);
   }
 
   Future<void> _handleConnectivity(List<ConnectivityResult> results) async {

--- a/lib/features/app_shell/presentation/providers/main_navigation_tabs_provider.dart
+++ b/lib/features/app_shell/presentation/providers/main_navigation_tabs_provider.dart
@@ -5,6 +5,7 @@ import 'package:kopim/features/budgets/presentation/budgets_screen.dart';
 import 'package:kopim/features/home/presentation/screens/home_screen.dart';
 import 'package:kopim/features/profile/presentation/screens/general_settings_screen.dart';
 import 'package:kopim/features/profile/presentation/screens/profile_screen.dart';
+import 'package:kopim/features/savings/presentation/screens/savings_list_screen.dart';
 import 'package:kopim/l10n/app_localizations.dart';
 
 import '../models/navigation_tab_config.dart';
@@ -27,6 +28,14 @@ final Provider<List<NavigationTabConfig>> mainNavigationTabsProvider =
           labelBuilder: (BuildContext context) =>
               AppLocalizations.of(context)!.homeNavAnalytics,
           contentBuilder: buildAnalyticsTabContent,
+        ),
+        NavigationTabConfig(
+          id: 'savings',
+          icon: Icons.savings_outlined,
+          activeIcon: Icons.savings,
+          labelBuilder: (BuildContext context) =>
+              AppLocalizations.of(context)!.homeNavSavings,
+          contentBuilder: buildSavingsTabContent,
         ),
         NavigationTabConfig(
           id: 'budgets',

--- a/lib/features/savings/data/repositories/saving_goal_repository_impl.dart
+++ b/lib/features/savings/data/repositories/saving_goal_repository_impl.dart
@@ -1,0 +1,148 @@
+import 'package:kopim/core/data/database.dart' as db;
+import 'package:kopim/core/data/outbox/outbox_dao.dart';
+import 'package:kopim/core/services/analytics_service.dart';
+import 'package:kopim/core/services/logger_service.dart';
+import 'package:kopim/features/savings/data/sources/local/saving_goal_dao.dart';
+import 'package:kopim/features/savings/domain/entities/saving_goal.dart';
+import 'package:kopim/features/savings/domain/repositories/saving_goal_repository.dart';
+
+class SavingGoalRepositoryImpl implements SavingGoalRepository {
+  SavingGoalRepositoryImpl({
+    required db.AppDatabase database,
+    required SavingGoalDao savingGoalDao,
+    required OutboxDao outboxDao,
+    required AnalyticsService analyticsService,
+    required LoggerService loggerService,
+  }) : _database = database,
+       _savingGoalDao = savingGoalDao,
+       _outboxDao = outboxDao,
+       _analyticsService = analyticsService,
+       _logger = loggerService;
+
+  static const String _entityType = 'saving_goal';
+
+  final db.AppDatabase _database;
+  final SavingGoalDao _savingGoalDao;
+  final OutboxDao _outboxDao;
+  final AnalyticsService _analyticsService;
+  final LoggerService _logger;
+
+  @override
+  Stream<List<SavingGoal>> watchGoals({required bool includeArchived}) {
+    return _savingGoalDao.watchGoals(includeArchived: includeArchived);
+  }
+
+  @override
+  Future<List<SavingGoal>> loadGoals({required bool includeArchived}) {
+    return _savingGoalDao.getGoals(includeArchived: includeArchived);
+  }
+
+  @override
+  Future<SavingGoal?> findById(String id) {
+    return _savingGoalDao.findById(id);
+  }
+
+  @override
+  Future<void> create(SavingGoal goal) async {
+    final DateTime now = DateTime.now().toUtc();
+    final SavingGoal toPersist = goal.copyWith(updatedAt: now);
+    await _database.transaction(() async {
+      await _savingGoalDao.upsert(toPersist);
+      await _outboxDao.enqueue(
+        entityType: _entityType,
+        entityId: toPersist.id,
+        operation: OutboxOperation.upsert,
+        payload: _mapGoalPayload(toPersist),
+      );
+    });
+    await _analyticsService.logEvent('savings_goal_create', <String, dynamic>{
+      'goalId': toPersist.id,
+      'target': toPersist.targetAmount,
+    });
+    _logger.logInfo('Saving goal created: ${toPersist.id}');
+  }
+
+  @override
+  Future<void> update(SavingGoal goal) async {
+    final DateTime now = DateTime.now().toUtc();
+    final SavingGoal toPersist = goal.copyWith(updatedAt: now);
+    await _database.transaction(() async {
+      await _savingGoalDao.upsert(toPersist);
+      await _outboxDao.enqueue(
+        entityType: _entityType,
+        entityId: toPersist.id,
+        operation: OutboxOperation.upsert,
+        payload: _mapGoalPayload(toPersist),
+      );
+    });
+    await _analyticsService.logEvent('savings_goal_update', <String, dynamic>{
+      'goalId': toPersist.id,
+      'target': toPersist.targetAmount,
+    });
+    _logger.logInfo('Saving goal updated: ${toPersist.id}');
+  }
+
+  @override
+  Future<void> archive(String goalId, DateTime archivedAt) async {
+    await _database.transaction(() async {
+      await _savingGoalDao.archive(goalId, archivedAt);
+      final SavingGoal? updated = await _savingGoalDao.findById(goalId);
+      if (updated == null) {
+        return;
+      }
+      await _outboxDao.enqueue(
+        entityType: _entityType,
+        entityId: goalId,
+        operation: OutboxOperation.upsert,
+        payload: _mapGoalPayload(updated),
+      );
+    });
+    await _analyticsService.logEvent('savings_goal_archive', <String, dynamic>{
+      'goalId': goalId,
+    });
+    _logger.logInfo('Saving goal archived: $goalId');
+  }
+
+  @override
+  Future<void> addContribution({
+    required SavingGoal updatedGoal,
+    required int contributionAmount,
+    String? sourceAccountId,
+    String? contributionNote,
+  }) async {
+    final DateTime now = DateTime.now().toUtc();
+    final SavingGoal toPersist = updatedGoal.copyWith(updatedAt: now);
+    await _database.transaction(() async {
+      await _savingGoalDao.upsert(toPersist);
+      await _outboxDao.enqueue(
+        entityType: _entityType,
+        entityId: toPersist.id,
+        operation: OutboxOperation.upsert,
+        payload: _mapGoalPayload(toPersist),
+      );
+    });
+    await _analyticsService
+        .logEvent('savings_goal_contribution', <String, dynamic>{
+          'goalId': toPersist.id,
+          'amount': contributionAmount,
+          if (sourceAccountId != null) 'sourceAccountId': sourceAccountId,
+        });
+    if (contributionNote != null) {
+      _logger.logInfo(
+        'Contribution added to ${toPersist.id} for $contributionAmount with note $contributionNote',
+      );
+    } else {
+      _logger.logInfo(
+        'Contribution added to ${toPersist.id} for $contributionAmount',
+      );
+    }
+  }
+
+  Map<String, dynamic> _mapGoalPayload(SavingGoal goal) {
+    final Map<String, dynamic> json = goal.toJson();
+    json['createdAt'] = goal.createdAt.toIso8601String();
+    json['updatedAt'] = goal.updatedAt.toIso8601String();
+    json['archivedAt'] = goal.archivedAt?.toIso8601String();
+    return json;
+  }
+}

--- a/lib/features/savings/data/sources/local/saving_goal_dao.dart
+++ b/lib/features/savings/data/sources/local/saving_goal_dao.dart
@@ -1,0 +1,105 @@
+import 'package:drift/drift.dart';
+import 'package:kopim/core/data/database.dart' as db;
+import 'package:kopim/features/savings/domain/entities/saving_goal.dart';
+
+class SavingGoalDao {
+  SavingGoalDao(this._db);
+
+  final db.AppDatabase _db;
+
+  Stream<List<SavingGoal>> watchGoals({required bool includeArchived}) {
+    final SimpleSelectStatement<db.$SavingGoalsTable, db.SavingGoalRow> query =
+        _db.select(
+          _db.savingGoals,
+        )..orderBy(<OrderingTerm Function(db.$SavingGoalsTable)>[
+          (db.$SavingGoalsTable tbl) =>
+              OrderingTerm(expression: tbl.updatedAt, mode: OrderingMode.desc),
+        ]);
+    if (!includeArchived) {
+      query.where((db.$SavingGoalsTable tbl) => tbl.archivedAt.isNull());
+    }
+    return query.watch().map(
+      (List<db.SavingGoalRow> rows) =>
+          rows.map(_mapRowToEntity).toList(growable: false),
+    );
+  }
+
+  Future<List<SavingGoal>> getGoals({required bool includeArchived}) async {
+    final SimpleSelectStatement<db.$SavingGoalsTable, db.SavingGoalRow> query =
+        _db.select(
+          _db.savingGoals,
+        )..orderBy(<OrderingTerm Function(db.$SavingGoalsTable)>[
+          (db.$SavingGoalsTable tbl) =>
+              OrderingTerm(expression: tbl.updatedAt, mode: OrderingMode.desc),
+        ]);
+    if (!includeArchived) {
+      query.where((db.$SavingGoalsTable tbl) => tbl.archivedAt.isNull());
+    }
+    final List<db.SavingGoalRow> rows = await query.get();
+    return rows.map(_mapRowToEntity).toList(growable: false);
+  }
+
+  Future<SavingGoal?> findById(String id) async {
+    final db.SavingGoalRow? row =
+        await (_db.select(_db.savingGoals)
+              ..where((db.$SavingGoalsTable tbl) => tbl.id.equals(id)))
+            .getSingleOrNull();
+    if (row == null) return null;
+    return _mapRowToEntity(row);
+  }
+
+  Future<void> upsert(SavingGoal goal) async {
+    await _db
+        .into(_db.savingGoals)
+        .insertOnConflictUpdate(_mapToCompanion(goal));
+  }
+
+  Future<void> upsertAll(List<SavingGoal> goals) async {
+    if (goals.isEmpty) return;
+    await _db.batch((Batch batch) {
+      batch.insertAllOnConflictUpdate(
+        _db.savingGoals,
+        goals.map(_mapToCompanion).toList(growable: false),
+      );
+    });
+  }
+
+  Future<void> archive(String id, DateTime archivedAt) {
+    return (_db.update(
+      _db.savingGoals,
+    )..where((db.$SavingGoalsTable tbl) => tbl.id.equals(id))).write(
+      db.SavingGoalsCompanion(
+        archivedAt: Value<DateTime?>(archivedAt),
+        updatedAt: Value<DateTime>(archivedAt),
+      ),
+    );
+  }
+
+  db.SavingGoalsCompanion _mapToCompanion(SavingGoal goal) {
+    return db.SavingGoalsCompanion(
+      id: Value<String>(goal.id),
+      userId: Value<String>(goal.userId),
+      name: Value<String>(goal.name),
+      targetAmount: Value<int>(goal.targetAmount),
+      currentAmount: Value<int>(goal.currentAmount),
+      note: Value<String?>(goal.note),
+      createdAt: Value<DateTime>(goal.createdAt),
+      updatedAt: Value<DateTime>(goal.updatedAt),
+      archivedAt: Value<DateTime?>(goal.archivedAt),
+    );
+  }
+
+  SavingGoal _mapRowToEntity(db.SavingGoalRow row) {
+    return SavingGoal(
+      id: row.id,
+      userId: row.userId,
+      name: row.name,
+      targetAmount: row.targetAmount,
+      currentAmount: row.currentAmount,
+      note: row.note,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+      archivedAt: row.archivedAt,
+    );
+  }
+}

--- a/lib/features/savings/data/sources/remote/saving_goal_remote_data_source.dart
+++ b/lib/features/savings/data/sources/remote/saving_goal_remote_data_source.dart
@@ -1,0 +1,88 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:kopim/features/savings/domain/entities/saving_goal.dart';
+
+class SavingGoalRemoteDataSource {
+  SavingGoalRemoteDataSource(this._firestore);
+
+  final FirebaseFirestore _firestore;
+
+  CollectionReference<Map<String, dynamic>> _collection(String userId) {
+    return _firestore
+        .collection('users')
+        .doc(userId)
+        .collection('saving_goals');
+  }
+
+  DocumentReference<Map<String, dynamic>> _doc(String userId, String id) {
+    return _collection(userId).doc(id);
+  }
+
+  Future<void> upsert(String userId, SavingGoal goal) {
+    return _doc(userId, goal.id).set(_mapGoal(goal), SetOptions(merge: true));
+  }
+
+  void upsertInTransaction(
+    Transaction transaction,
+    String userId,
+    SavingGoal goal,
+  ) {
+    transaction.set(
+      _doc(userId, goal.id),
+      _mapGoal(goal),
+      SetOptions(merge: true),
+    );
+  }
+
+  Future<List<SavingGoal>> fetchAll(String userId) async {
+    final QuerySnapshot<Map<String, dynamic>> snapshot = await _collection(
+      userId,
+    ).get();
+    return snapshot.docs.map(_fromDocument).toList(growable: false);
+  }
+
+  Map<String, dynamic> _mapGoal(SavingGoal goal) {
+    return <String, dynamic>{
+      'id': goal.id,
+      'userId': goal.userId,
+      'name': goal.name,
+      'targetAmount': goal.targetAmount,
+      'currentAmount': goal.currentAmount,
+      'note': goal.note,
+      'createdAt': Timestamp.fromDate(goal.createdAt.toUtc()),
+      'updatedAt': Timestamp.fromDate(goal.updatedAt.toUtc()),
+      'archivedAt': goal.archivedAt != null
+          ? Timestamp.fromDate(goal.archivedAt!.toUtc())
+          : null,
+    }..removeWhere((String key, Object? value) => value == null);
+  }
+
+  SavingGoal _fromDocument(QueryDocumentSnapshot<Map<String, dynamic>> doc) {
+    final Map<String, dynamic> data = doc.data();
+    return SavingGoal(
+      id: data['id'] as String? ?? doc.id,
+      userId: data['userId'] as String? ?? '',
+      name: data['name'] as String? ?? '',
+      targetAmount: (data['targetAmount'] as num?)?.toInt() ?? 0,
+      currentAmount: (data['currentAmount'] as num?)?.toInt() ?? 0,
+      note: data['note'] as String?,
+      createdAt: _parseTimestamp(data['createdAt']),
+      updatedAt: _parseTimestamp(data['updatedAt']),
+      archivedAt: _parseOptionalTimestamp(data['archivedAt']),
+    );
+  }
+
+  DateTime _parseTimestamp(Object? value) {
+    if (value is Timestamp) {
+      return value.toDate().toUtc();
+    }
+    if (value is DateTime) {
+      return value.toUtc();
+    }
+    return DateTime.now().toUtc();
+  }
+
+  DateTime? _parseOptionalTimestamp(Object? value) {
+    if (value == null) return null;
+    return _parseTimestamp(value);
+  }
+}

--- a/lib/features/savings/domain/entities/saving_goal.dart
+++ b/lib/features/savings/domain/entities/saving_goal.dart
@@ -1,0 +1,28 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'saving_goal.freezed.dart';
+part 'saving_goal.g.dart';
+
+@freezed
+abstract class SavingGoal with _$SavingGoal {
+  const SavingGoal._();
+
+  const factory SavingGoal({
+    required String id,
+    required String userId,
+    required String name,
+    required int targetAmount,
+    required int currentAmount,
+    String? note,
+    required DateTime createdAt,
+    required DateTime updatedAt,
+    DateTime? archivedAt,
+  }) = _SavingGoal;
+
+  factory SavingGoal.fromJson(Map<String, dynamic> json) =>
+      _$SavingGoalFromJson(json);
+
+  bool get isArchived => archivedAt != null;
+
+  int get remainingAmount => targetAmount - currentAmount;
+}

--- a/lib/features/savings/domain/entities/saving_goal.freezed.dart
+++ b/lib/features/savings/domain/entities/saving_goal.freezed.dart
@@ -1,0 +1,301 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'saving_goal.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$SavingGoal {
+
+ String get id; String get userId; String get name; int get targetAmount; int get currentAmount; String? get note; DateTime get createdAt; DateTime get updatedAt; DateTime? get archivedAt;
+/// Create a copy of SavingGoal
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SavingGoalCopyWith<SavingGoal> get copyWith => _$SavingGoalCopyWithImpl<SavingGoal>(this as SavingGoal, _$identity);
+
+  /// Serializes this SavingGoal to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SavingGoal&&(identical(other.id, id) || other.id == id)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.name, name) || other.name == name)&&(identical(other.targetAmount, targetAmount) || other.targetAmount == targetAmount)&&(identical(other.currentAmount, currentAmount) || other.currentAmount == currentAmount)&&(identical(other.note, note) || other.note == note)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.archivedAt, archivedAt) || other.archivedAt == archivedAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,userId,name,targetAmount,currentAmount,note,createdAt,updatedAt,archivedAt);
+
+@override
+String toString() {
+  return 'SavingGoal(id: $id, userId: $userId, name: $name, targetAmount: $targetAmount, currentAmount: $currentAmount, note: $note, createdAt: $createdAt, updatedAt: $updatedAt, archivedAt: $archivedAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $SavingGoalCopyWith<$Res>  {
+  factory $SavingGoalCopyWith(SavingGoal value, $Res Function(SavingGoal) _then) = _$SavingGoalCopyWithImpl;
+@useResult
+$Res call({
+ String id, String userId, String name, int targetAmount, int currentAmount, String? note, DateTime createdAt, DateTime updatedAt, DateTime? archivedAt
+});
+
+
+
+
+}
+/// @nodoc
+class _$SavingGoalCopyWithImpl<$Res>
+    implements $SavingGoalCopyWith<$Res> {
+  _$SavingGoalCopyWithImpl(this._self, this._then);
+
+  final SavingGoal _self;
+  final $Res Function(SavingGoal) _then;
+
+/// Create a copy of SavingGoal
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? userId = null,Object? name = null,Object? targetAmount = null,Object? currentAmount = null,Object? note = freezed,Object? createdAt = null,Object? updatedAt = null,Object? archivedAt = freezed,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,userId: null == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,targetAmount: null == targetAmount ? _self.targetAmount : targetAmount // ignore: cast_nullable_to_non_nullable
+as int,currentAmount: null == currentAmount ? _self.currentAmount : currentAmount // ignore: cast_nullable_to_non_nullable
+as int,note: freezed == note ? _self.note : note // ignore: cast_nullable_to_non_nullable
+as String?,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,archivedAt: freezed == archivedAt ? _self.archivedAt : archivedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [SavingGoal].
+extension SavingGoalPatterns on SavingGoal {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _SavingGoal value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _SavingGoal() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _SavingGoal value)  $default,){
+final _that = this;
+switch (_that) {
+case _SavingGoal():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _SavingGoal value)?  $default,){
+final _that = this;
+switch (_that) {
+case _SavingGoal() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String userId,  String name,  int targetAmount,  int currentAmount,  String? note,  DateTime createdAt,  DateTime updatedAt,  DateTime? archivedAt)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _SavingGoal() when $default != null:
+return $default(_that.id,_that.userId,_that.name,_that.targetAmount,_that.currentAmount,_that.note,_that.createdAt,_that.updatedAt,_that.archivedAt);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String userId,  String name,  int targetAmount,  int currentAmount,  String? note,  DateTime createdAt,  DateTime updatedAt,  DateTime? archivedAt)  $default,) {final _that = this;
+switch (_that) {
+case _SavingGoal():
+return $default(_that.id,_that.userId,_that.name,_that.targetAmount,_that.currentAmount,_that.note,_that.createdAt,_that.updatedAt,_that.archivedAt);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String userId,  String name,  int targetAmount,  int currentAmount,  String? note,  DateTime createdAt,  DateTime updatedAt,  DateTime? archivedAt)?  $default,) {final _that = this;
+switch (_that) {
+case _SavingGoal() when $default != null:
+return $default(_that.id,_that.userId,_that.name,_that.targetAmount,_that.currentAmount,_that.note,_that.createdAt,_that.updatedAt,_that.archivedAt);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _SavingGoal extends SavingGoal {
+  const _SavingGoal({required this.id, required this.userId, required this.name, required this.targetAmount, required this.currentAmount, this.note, required this.createdAt, required this.updatedAt, this.archivedAt}): super._();
+  factory _SavingGoal.fromJson(Map<String, dynamic> json) => _$SavingGoalFromJson(json);
+
+@override final  String id;
+@override final  String userId;
+@override final  String name;
+@override final  int targetAmount;
+@override final  int currentAmount;
+@override final  String? note;
+@override final  DateTime createdAt;
+@override final  DateTime updatedAt;
+@override final  DateTime? archivedAt;
+
+/// Create a copy of SavingGoal
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$SavingGoalCopyWith<_SavingGoal> get copyWith => __$SavingGoalCopyWithImpl<_SavingGoal>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$SavingGoalToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SavingGoal&&(identical(other.id, id) || other.id == id)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.name, name) || other.name == name)&&(identical(other.targetAmount, targetAmount) || other.targetAmount == targetAmount)&&(identical(other.currentAmount, currentAmount) || other.currentAmount == currentAmount)&&(identical(other.note, note) || other.note == note)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.archivedAt, archivedAt) || other.archivedAt == archivedAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,userId,name,targetAmount,currentAmount,note,createdAt,updatedAt,archivedAt);
+
+@override
+String toString() {
+  return 'SavingGoal(id: $id, userId: $userId, name: $name, targetAmount: $targetAmount, currentAmount: $currentAmount, note: $note, createdAt: $createdAt, updatedAt: $updatedAt, archivedAt: $archivedAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$SavingGoalCopyWith<$Res> implements $SavingGoalCopyWith<$Res> {
+  factory _$SavingGoalCopyWith(_SavingGoal value, $Res Function(_SavingGoal) _then) = __$SavingGoalCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, String userId, String name, int targetAmount, int currentAmount, String? note, DateTime createdAt, DateTime updatedAt, DateTime? archivedAt
+});
+
+
+
+
+}
+/// @nodoc
+class __$SavingGoalCopyWithImpl<$Res>
+    implements _$SavingGoalCopyWith<$Res> {
+  __$SavingGoalCopyWithImpl(this._self, this._then);
+
+  final _SavingGoal _self;
+  final $Res Function(_SavingGoal) _then;
+
+/// Create a copy of SavingGoal
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? userId = null,Object? name = null,Object? targetAmount = null,Object? currentAmount = null,Object? note = freezed,Object? createdAt = null,Object? updatedAt = null,Object? archivedAt = freezed,}) {
+  return _then(_SavingGoal(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,userId: null == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,targetAmount: null == targetAmount ? _self.targetAmount : targetAmount // ignore: cast_nullable_to_non_nullable
+as int,currentAmount: null == currentAmount ? _self.currentAmount : currentAmount // ignore: cast_nullable_to_non_nullable
+as int,note: freezed == note ? _self.note : note // ignore: cast_nullable_to_non_nullable
+as String?,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,archivedAt: freezed == archivedAt ? _self.archivedAt : archivedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/features/savings/domain/entities/saving_goal.g.dart
+++ b/lib/features/savings/domain/entities/saving_goal.g.dart
@@ -1,0 +1,34 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'saving_goal.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_SavingGoal _$SavingGoalFromJson(Map<String, dynamic> json) => _SavingGoal(
+  id: json['id'] as String,
+  userId: json['userId'] as String,
+  name: json['name'] as String,
+  targetAmount: (json['targetAmount'] as num).toInt(),
+  currentAmount: (json['currentAmount'] as num).toInt(),
+  note: json['note'] as String?,
+  createdAt: DateTime.parse(json['createdAt'] as String),
+  updatedAt: DateTime.parse(json['updatedAt'] as String),
+  archivedAt: json['archivedAt'] == null
+      ? null
+      : DateTime.parse(json['archivedAt'] as String),
+);
+
+Map<String, dynamic> _$SavingGoalToJson(_SavingGoal instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'userId': instance.userId,
+      'name': instance.name,
+      'targetAmount': instance.targetAmount,
+      'currentAmount': instance.currentAmount,
+      'note': instance.note,
+      'createdAt': instance.createdAt.toIso8601String(),
+      'updatedAt': instance.updatedAt.toIso8601String(),
+      'archivedAt': instance.archivedAt?.toIso8601String(),
+    };

--- a/lib/features/savings/domain/repositories/saving_goal_repository.dart
+++ b/lib/features/savings/domain/repositories/saving_goal_repository.dart
@@ -1,0 +1,16 @@
+import '../entities/saving_goal.dart';
+
+abstract class SavingGoalRepository {
+  Stream<List<SavingGoal>> watchGoals({required bool includeArchived});
+  Future<List<SavingGoal>> loadGoals({required bool includeArchived});
+  Future<SavingGoal?> findById(String id);
+  Future<void> create(SavingGoal goal);
+  Future<void> update(SavingGoal goal);
+  Future<void> archive(String goalId, DateTime archivedAt);
+  Future<void> addContribution({
+    required SavingGoal updatedGoal,
+    required int contributionAmount,
+    String? sourceAccountId,
+    String? contributionNote,
+  });
+}

--- a/lib/features/savings/domain/use_cases/add_contribution_use_case.dart
+++ b/lib/features/savings/domain/use_cases/add_contribution_use_case.dart
@@ -1,0 +1,90 @@
+import 'package:kopim/features/transactions/domain/entities/add_transaction_request.dart';
+import 'package:kopim/features/transactions/domain/entities/transaction_type.dart';
+import 'package:kopim/features/transactions/domain/use_cases/add_transaction_use_case.dart';
+
+import '../entities/saving_goal.dart';
+import '../repositories/saving_goal_repository.dart';
+import '../value_objects/money.dart';
+
+class AddContributionUseCase {
+  AddContributionUseCase({
+    required SavingGoalRepository repository,
+    required AddTransactionUseCase addTransactionUseCase,
+    DateTime Function()? clock,
+  }) : _repository = repository,
+       _addTransactionUseCase = addTransactionUseCase,
+       _clock = clock ?? DateTime.now;
+
+  static const String savingsCategoryId = 'savings';
+
+  final SavingGoalRepository _repository;
+  final AddTransactionUseCase _addTransactionUseCase;
+  final DateTime Function() _clock;
+
+  Future<SavingGoal> call({
+    required String goalId,
+    required Money amount,
+    String? sourceAccountId,
+    String? note,
+  }) async {
+    if (amount.minorUnits <= 0) {
+      throw ArgumentError.value(
+        amount.minorUnits,
+        'amount',
+        'Contribution amount must be greater than zero',
+      );
+    }
+    final SavingGoal? goal = await _repository.findById(goalId);
+    if (goal == null) {
+      throw StateError('Saving goal not found');
+    }
+    if (goal.isArchived) {
+      throw StateError('Cannot contribute to archived goals');
+    }
+    if (goal.currentAmount >= goal.targetAmount) {
+      throw StateError('Goal already reached');
+    }
+    final DateTime now = _clock().toUtc();
+    final int desiredAmount = goal.currentAmount + amount.minorUnits;
+    final int cappedAmount = desiredAmount > goal.targetAmount
+        ? goal.targetAmount
+        : desiredAmount;
+    final int appliedDelta = cappedAmount - goal.currentAmount;
+    if (appliedDelta <= 0) {
+      throw StateError('Contribution does not change goal progress');
+    }
+    final SavingGoal updatedGoal = goal.copyWith(
+      currentAmount: cappedAmount,
+      updatedAt: now,
+    );
+
+    final String? trimmedNote = note?.trim().isNotEmpty ?? false
+        ? note!.trim()
+        : null;
+
+    if (sourceAccountId != null && sourceAccountId.isNotEmpty) {
+      final String baseNote = 'Savings: ${goal.name}';
+      final String composedNote = trimmedNote != null
+          ? '$baseNote — $trimmedNote'
+          : baseNote;
+      await _addTransactionUseCase(
+        AddTransactionRequest(
+          accountId: sourceAccountId,
+          categoryId: savingsCategoryId,
+          amount: amount.toDouble(),
+          date: now,
+          note: composedNote,
+          type: TransactionType.expense,
+        ),
+      );
+    }
+
+    await _repository.addContribution(
+      updatedGoal: updatedGoal,
+      contributionAmount: appliedDelta,
+      sourceAccountId: sourceAccountId,
+      contributionNote: trimmedNote,
+    );
+    return updatedGoal;
+  }
+}

--- a/lib/features/savings/domain/use_cases/archive_saving_goal_use_case.dart
+++ b/lib/features/savings/domain/use_cases/archive_saving_goal_use_case.dart
@@ -1,0 +1,19 @@
+import '../repositories/saving_goal_repository.dart';
+
+class ArchiveSavingGoalUseCase {
+  ArchiveSavingGoalUseCase({
+    required SavingGoalRepository repository,
+    DateTime Function()? clock,
+  }) : _repository = repository,
+       _clock = clock ?? DateTime.now;
+
+  final SavingGoalRepository _repository;
+  final DateTime Function() _clock;
+
+  Future<void> call(String goalId) {
+    if (goalId.isEmpty) {
+      throw ArgumentError.value(goalId, 'goalId', 'Goal id required');
+    }
+    return _repository.archive(goalId, _clock().toUtc());
+  }
+}

--- a/lib/features/savings/domain/use_cases/create_saving_goal_use_case.dart
+++ b/lib/features/savings/domain/use_cases/create_saving_goal_use_case.dart
@@ -1,0 +1,58 @@
+import 'package:kopim/features/profile/domain/repositories/auth_repository.dart';
+import 'package:uuid/uuid.dart';
+
+import '../entities/saving_goal.dart';
+import '../repositories/saving_goal_repository.dart';
+import '../value_objects/money.dart';
+
+class CreateSavingGoalUseCase {
+  CreateSavingGoalUseCase({
+    required SavingGoalRepository repository,
+    required AuthRepository authRepository,
+    required Uuid uuidGenerator,
+    DateTime Function()? clock,
+  }) : _repository = repository,
+       _authRepository = authRepository,
+       _uuid = uuidGenerator,
+       _clock = clock ?? DateTime.now;
+
+  final SavingGoalRepository _repository;
+  final AuthRepository _authRepository;
+  final Uuid _uuid;
+  final DateTime Function() _clock;
+
+  Future<SavingGoal> call({
+    required String name,
+    required Money target,
+    String? note,
+  }) async {
+    final String trimmedName = name.trim();
+    if (trimmedName.isEmpty) {
+      throw ArgumentError.value(name, 'name', 'Name cannot be empty');
+    }
+    if (target.minorUnits <= 0) {
+      throw ArgumentError.value(
+        target.minorUnits,
+        'target',
+        'Target amount must be greater than zero',
+      );
+    }
+    final String? userId = _authRepository.currentUser?.uid;
+    if (userId == null || userId.isEmpty) {
+      throw StateError('Authenticated user required to create saving goal');
+    }
+    final DateTime now = _clock().toUtc();
+    final SavingGoal goal = SavingGoal(
+      id: _uuid.v4(),
+      userId: userId,
+      name: trimmedName,
+      targetAmount: target.minorUnits,
+      currentAmount: 0,
+      note: note?.trim().isEmpty ?? true ? null : note!.trim(),
+      createdAt: now,
+      updatedAt: now,
+    );
+    await _repository.create(goal);
+    return goal;
+  }
+}

--- a/lib/features/savings/domain/use_cases/get_saving_goals_use_case.dart
+++ b/lib/features/savings/domain/use_cases/get_saving_goals_use_case.dart
@@ -1,0 +1,13 @@
+import '../entities/saving_goal.dart';
+import '../repositories/saving_goal_repository.dart';
+
+class GetSavingGoalsUseCase {
+  GetSavingGoalsUseCase({required SavingGoalRepository repository})
+    : _repository = repository;
+
+  final SavingGoalRepository _repository;
+
+  Future<List<SavingGoal>> call({required bool includeArchived}) {
+    return _repository.loadGoals(includeArchived: includeArchived);
+  }
+}

--- a/lib/features/savings/domain/use_cases/update_saving_goal_use_case.dart
+++ b/lib/features/savings/domain/use_cases/update_saving_goal_use_case.dart
@@ -1,0 +1,48 @@
+import '../entities/saving_goal.dart';
+import '../repositories/saving_goal_repository.dart';
+import '../value_objects/money.dart';
+
+class UpdateSavingGoalUseCase {
+  UpdateSavingGoalUseCase({
+    required SavingGoalRepository repository,
+    DateTime Function()? clock,
+  }) : _repository = repository,
+       _clock = clock ?? DateTime.now;
+
+  final SavingGoalRepository _repository;
+  final DateTime Function() _clock;
+
+  Future<SavingGoal> call({
+    required SavingGoal goal,
+    String? name,
+    Money? target,
+    String? note,
+  }) async {
+    final String updatedName = name?.trim().isNotEmpty ?? false
+        ? name!.trim()
+        : goal.name;
+    if (updatedName.isEmpty) {
+      throw ArgumentError.value(name, 'name', 'Name cannot be empty');
+    }
+    final int updatedTarget = target?.minorUnits ?? goal.targetAmount;
+    if (updatedTarget <= 0) {
+      throw ArgumentError.value(
+        updatedTarget,
+        'target',
+        'Target amount must be greater than zero',
+      );
+    }
+    if (goal.currentAmount > updatedTarget) {
+      throw StateError('Current amount exceeds new target');
+    }
+    final DateTime now = _clock().toUtc();
+    final SavingGoal updatedGoal = goal.copyWith(
+      name: updatedName,
+      targetAmount: updatedTarget,
+      note: note?.trim().isNotEmpty ?? false ? note!.trim() : null,
+      updatedAt: now,
+    );
+    await _repository.update(updatedGoal);
+    return updatedGoal;
+  }
+}

--- a/lib/features/savings/domain/use_cases/watch_saving_goals_use_case.dart
+++ b/lib/features/savings/domain/use_cases/watch_saving_goals_use_case.dart
@@ -1,0 +1,13 @@
+import '../entities/saving_goal.dart';
+import '../repositories/saving_goal_repository.dart';
+
+class WatchSavingGoalsUseCase {
+  WatchSavingGoalsUseCase({required SavingGoalRepository repository})
+    : _repository = repository;
+
+  final SavingGoalRepository _repository;
+
+  Stream<List<SavingGoal>> call({required bool includeArchived}) {
+    return _repository.watchGoals(includeArchived: includeArchived);
+  }
+}

--- a/lib/features/savings/domain/value_objects/goal_progress.dart
+++ b/lib/features/savings/domain/value_objects/goal_progress.dart
@@ -1,0 +1,29 @@
+import 'package:equatable/equatable.dart';
+
+import '../entities/saving_goal.dart';
+import 'money.dart';
+
+class GoalProgress extends Equatable {
+  const GoalProgress({
+    required this.goal,
+    required this.percent,
+    required this.remaining,
+  });
+
+  factory GoalProgress.fromGoal(SavingGoal goal) {
+    final Money remaining = Money.fromMinorUnits(
+      (goal.targetAmount - goal.currentAmount).clamp(0, goal.targetAmount),
+    );
+    final double percent = goal.targetAmount == 0
+        ? 0
+        : (goal.currentAmount / goal.targetAmount).clamp(0, 1);
+    return GoalProgress(goal: goal, percent: percent, remaining: remaining);
+  }
+
+  final SavingGoal goal;
+  final double percent;
+  final Money remaining;
+
+  @override
+  List<Object?> get props => <Object?>[goal, percent, remaining];
+}

--- a/lib/features/savings/domain/value_objects/money.dart
+++ b/lib/features/savings/domain/value_objects/money.dart
@@ -1,0 +1,33 @@
+import 'dart:math';
+
+import 'package:equatable/equatable.dart';
+
+class Money extends Equatable {
+  const Money._(this.minorUnits);
+
+  factory Money.fromMinorUnits(int value) {
+    return Money._(max(0, value));
+  }
+
+  factory Money.fromDouble(double value, {int fractionDigits = 2}) {
+    final int factor = pow(10, fractionDigits).toInt();
+    final int minor = (value * factor).round();
+    return Money.fromMinorUnits(minor);
+  }
+
+  final int minorUnits;
+
+  double toDouble({int fractionDigits = 2}) {
+    final int factor = pow(10, fractionDigits).toInt();
+    return minorUnits / factor;
+  }
+
+  Money operator +(Money other) =>
+      Money.fromMinorUnits(minorUnits + other.minorUnits);
+
+  Money operator -(Money other) =>
+      Money.fromMinorUnits(minorUnits - other.minorUnits);
+
+  @override
+  List<Object?> get props => <Object?>[minorUnits];
+}

--- a/lib/features/savings/presentation/controllers/contribute_controller.dart
+++ b/lib/features/savings/presentation/controllers/contribute_controller.dart
@@ -1,0 +1,102 @@
+import 'dart:async';
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'package:kopim/core/di/injectors.dart';
+import 'package:kopim/features/accounts/domain/entities/account_entity.dart';
+import 'package:kopim/features/accounts/domain/use_cases/watch_accounts_use_case.dart';
+import 'package:kopim/features/savings/domain/entities/saving_goal.dart';
+import 'package:kopim/features/savings/domain/use_cases/add_contribution_use_case.dart';
+import 'package:kopim/features/savings/domain/value_objects/money.dart';
+
+import 'contribute_state.dart';
+
+part 'contribute_controller.g.dart';
+
+@riverpod
+class ContributeController extends _$ContributeController {
+  StreamSubscription<List<AccountEntity>>? _subscription;
+
+  @override
+  ContributeState build(SavingGoal goal) {
+    ref.onDispose(() async {
+      await _subscription?.cancel();
+    });
+    final ContributeState initial = ContributeState(goal: goal);
+    state = initial;
+    _subscribeAccounts();
+    return initial;
+  }
+
+  void updateAmount(String value) {
+    state = state.copyWith(
+      amountInput: value,
+      amountError: null,
+      success: false,
+    );
+  }
+
+  void updateNote(String value) {
+    state = state.copyWith(note: value, success: false);
+  }
+
+  void selectAccount(String? accountId) {
+    state = state.copyWith(selectedAccountId: accountId, success: false);
+  }
+
+  Future<void> submit() async {
+    final String normalized = state.amountInput.replaceAll(',', '.');
+    final double? parsed = double.tryParse(normalized);
+    if (parsed == null || parsed <= 0) {
+      state = state.copyWith(amountError: 'Введите сумму больше нуля');
+      return;
+    }
+    final Money amount = Money.fromDouble(parsed);
+    state = state.copyWith(
+      isSubmitting: true,
+      amountError: null,
+      errorMessage: null,
+    );
+    try {
+      final AddContributionUseCase addContribution = ref.read(
+        addContributionUseCaseProvider,
+      );
+      await addContribution(
+        goalId: state.goal.id,
+        amount: amount,
+        sourceAccountId: state.selectedAccountId,
+        note: state.note,
+      );
+      state = state.copyWith(
+        isSubmitting: false,
+        success: true,
+        errorMessage: null,
+      );
+    } catch (error) {
+      state = state.copyWith(
+        isSubmitting: false,
+        errorMessage: error.toString(),
+      );
+      ref
+          .read(loggerServiceProvider)
+          .logError('Failed to add contribution', error);
+    }
+  }
+
+  void _subscribeAccounts() {
+    _subscription?.cancel();
+    final WatchAccountsUseCase watchAccounts = ref.watch(
+      watchAccountsUseCaseProvider,
+    );
+    _subscription = watchAccounts().listen((List<AccountEntity> accounts) {
+      final String? selected = state.selectedAccountId;
+      final bool stillExists = selected == null
+          ? true
+          : accounts.any((AccountEntity account) => account.id == selected);
+      state = state.copyWith(
+        accounts: accounts,
+        selectedAccountId: stillExists ? selected : null,
+      );
+    });
+  }
+}

--- a/lib/features/savings/presentation/controllers/contribute_controller.g.dart
+++ b/lib/features/savings/presentation/controllers/contribute_controller.g.dart
@@ -1,0 +1,109 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'contribute_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(ContributeController)
+const contributeControllerProvider = ContributeControllerFamily._();
+
+final class ContributeControllerProvider
+    extends $NotifierProvider<ContributeController, ContributeState> {
+  const ContributeControllerProvider._({
+    required ContributeControllerFamily super.from,
+    required SavingGoal super.argument,
+  }) : super(
+         retry: null,
+         name: r'contributeControllerProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$contributeControllerHash();
+
+  @override
+  String toString() {
+    return r'contributeControllerProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  ContributeController create() => ContributeController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(ContributeState value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<ContributeState>(value),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is ContributeControllerProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$contributeControllerHash() =>
+    r'7475dfdadea099dbeb75246f2bade04103e16ff6';
+
+final class ContributeControllerFamily extends $Family
+    with
+        $ClassFamilyOverride<
+          ContributeController,
+          ContributeState,
+          ContributeState,
+          ContributeState,
+          SavingGoal
+        > {
+  const ContributeControllerFamily._()
+    : super(
+        retry: null,
+        name: r'contributeControllerProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  ContributeControllerProvider call(SavingGoal goal) =>
+      ContributeControllerProvider._(argument: goal, from: this);
+
+  @override
+  String toString() => r'contributeControllerProvider';
+}
+
+abstract class _$ContributeController extends $Notifier<ContributeState> {
+  late final _$args = ref.$arg as SavingGoal;
+  SavingGoal get goal => _$args;
+
+  ContributeState build(SavingGoal goal);
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build(_$args);
+    final ref = this.ref as $Ref<ContributeState, ContributeState>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<ContributeState, ContributeState>,
+              ContributeState,
+              Object?,
+              Object?
+            >;
+    element.handleValue(ref, created);
+  }
+}

--- a/lib/features/savings/presentation/controllers/contribute_state.dart
+++ b/lib/features/savings/presentation/controllers/contribute_state.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:kopim/features/accounts/domain/entities/account_entity.dart';
+import 'package:kopim/features/savings/domain/entities/saving_goal.dart';
+
+part 'contribute_state.freezed.dart';
+
+@freezed
+abstract class ContributeState with _$ContributeState {
+  const factory ContributeState({
+    required SavingGoal goal,
+    @Default(<AccountEntity>[]) List<AccountEntity> accounts,
+    String? selectedAccountId,
+    @Default('') String amountInput,
+    String? amountError,
+    String? note,
+    @Default(false) bool isSubmitting,
+    @Default(false) bool success,
+    String? errorMessage,
+  }) = _ContributeState;
+}

--- a/lib/features/savings/presentation/controllers/contribute_state.freezed.dart
+++ b/lib/features/savings/presentation/controllers/contribute_state.freezed.dart
@@ -1,0 +1,319 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'contribute_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$ContributeState {
+
+ SavingGoal get goal; List<AccountEntity> get accounts; String? get selectedAccountId; String get amountInput; String? get amountError; String? get note; bool get isSubmitting; bool get success; String? get errorMessage;
+/// Create a copy of ContributeState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ContributeStateCopyWith<ContributeState> get copyWith => _$ContributeStateCopyWithImpl<ContributeState>(this as ContributeState, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ContributeState&&(identical(other.goal, goal) || other.goal == goal)&&const DeepCollectionEquality().equals(other.accounts, accounts)&&(identical(other.selectedAccountId, selectedAccountId) || other.selectedAccountId == selectedAccountId)&&(identical(other.amountInput, amountInput) || other.amountInput == amountInput)&&(identical(other.amountError, amountError) || other.amountError == amountError)&&(identical(other.note, note) || other.note == note)&&(identical(other.isSubmitting, isSubmitting) || other.isSubmitting == isSubmitting)&&(identical(other.success, success) || other.success == success)&&(identical(other.errorMessage, errorMessage) || other.errorMessage == errorMessage));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,goal,const DeepCollectionEquality().hash(accounts),selectedAccountId,amountInput,amountError,note,isSubmitting,success,errorMessage);
+
+@override
+String toString() {
+  return 'ContributeState(goal: $goal, accounts: $accounts, selectedAccountId: $selectedAccountId, amountInput: $amountInput, amountError: $amountError, note: $note, isSubmitting: $isSubmitting, success: $success, errorMessage: $errorMessage)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ContributeStateCopyWith<$Res>  {
+  factory $ContributeStateCopyWith(ContributeState value, $Res Function(ContributeState) _then) = _$ContributeStateCopyWithImpl;
+@useResult
+$Res call({
+ SavingGoal goal, List<AccountEntity> accounts, String? selectedAccountId, String amountInput, String? amountError, String? note, bool isSubmitting, bool success, String? errorMessage
+});
+
+
+$SavingGoalCopyWith<$Res> get goal;
+
+}
+/// @nodoc
+class _$ContributeStateCopyWithImpl<$Res>
+    implements $ContributeStateCopyWith<$Res> {
+  _$ContributeStateCopyWithImpl(this._self, this._then);
+
+  final ContributeState _self;
+  final $Res Function(ContributeState) _then;
+
+/// Create a copy of ContributeState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? goal = null,Object? accounts = null,Object? selectedAccountId = freezed,Object? amountInput = null,Object? amountError = freezed,Object? note = freezed,Object? isSubmitting = null,Object? success = null,Object? errorMessage = freezed,}) {
+  return _then(_self.copyWith(
+goal: null == goal ? _self.goal : goal // ignore: cast_nullable_to_non_nullable
+as SavingGoal,accounts: null == accounts ? _self.accounts : accounts // ignore: cast_nullable_to_non_nullable
+as List<AccountEntity>,selectedAccountId: freezed == selectedAccountId ? _self.selectedAccountId : selectedAccountId // ignore: cast_nullable_to_non_nullable
+as String?,amountInput: null == amountInput ? _self.amountInput : amountInput // ignore: cast_nullable_to_non_nullable
+as String,amountError: freezed == amountError ? _self.amountError : amountError // ignore: cast_nullable_to_non_nullable
+as String?,note: freezed == note ? _self.note : note // ignore: cast_nullable_to_non_nullable
+as String?,isSubmitting: null == isSubmitting ? _self.isSubmitting : isSubmitting // ignore: cast_nullable_to_non_nullable
+as bool,success: null == success ? _self.success : success // ignore: cast_nullable_to_non_nullable
+as bool,errorMessage: freezed == errorMessage ? _self.errorMessage : errorMessage // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+/// Create a copy of ContributeState
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$SavingGoalCopyWith<$Res> get goal {
+  
+  return $SavingGoalCopyWith<$Res>(_self.goal, (value) {
+    return _then(_self.copyWith(goal: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [ContributeState].
+extension ContributeStatePatterns on ContributeState {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _ContributeState value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _ContributeState() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _ContributeState value)  $default,){
+final _that = this;
+switch (_that) {
+case _ContributeState():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _ContributeState value)?  $default,){
+final _that = this;
+switch (_that) {
+case _ContributeState() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( SavingGoal goal,  List<AccountEntity> accounts,  String? selectedAccountId,  String amountInput,  String? amountError,  String? note,  bool isSubmitting,  bool success,  String? errorMessage)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _ContributeState() when $default != null:
+return $default(_that.goal,_that.accounts,_that.selectedAccountId,_that.amountInput,_that.amountError,_that.note,_that.isSubmitting,_that.success,_that.errorMessage);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( SavingGoal goal,  List<AccountEntity> accounts,  String? selectedAccountId,  String amountInput,  String? amountError,  String? note,  bool isSubmitting,  bool success,  String? errorMessage)  $default,) {final _that = this;
+switch (_that) {
+case _ContributeState():
+return $default(_that.goal,_that.accounts,_that.selectedAccountId,_that.amountInput,_that.amountError,_that.note,_that.isSubmitting,_that.success,_that.errorMessage);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( SavingGoal goal,  List<AccountEntity> accounts,  String? selectedAccountId,  String amountInput,  String? amountError,  String? note,  bool isSubmitting,  bool success,  String? errorMessage)?  $default,) {final _that = this;
+switch (_that) {
+case _ContributeState() when $default != null:
+return $default(_that.goal,_that.accounts,_that.selectedAccountId,_that.amountInput,_that.amountError,_that.note,_that.isSubmitting,_that.success,_that.errorMessage);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _ContributeState implements ContributeState {
+  const _ContributeState({required this.goal, final  List<AccountEntity> accounts = const <AccountEntity>[], this.selectedAccountId, this.amountInput = '', this.amountError, this.note, this.isSubmitting = false, this.success = false, this.errorMessage}): _accounts = accounts;
+  
+
+@override final  SavingGoal goal;
+ final  List<AccountEntity> _accounts;
+@override@JsonKey() List<AccountEntity> get accounts {
+  if (_accounts is EqualUnmodifiableListView) return _accounts;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_accounts);
+}
+
+@override final  String? selectedAccountId;
+@override@JsonKey() final  String amountInput;
+@override final  String? amountError;
+@override final  String? note;
+@override@JsonKey() final  bool isSubmitting;
+@override@JsonKey() final  bool success;
+@override final  String? errorMessage;
+
+/// Create a copy of ContributeState
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ContributeStateCopyWith<_ContributeState> get copyWith => __$ContributeStateCopyWithImpl<_ContributeState>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ContributeState&&(identical(other.goal, goal) || other.goal == goal)&&const DeepCollectionEquality().equals(other._accounts, _accounts)&&(identical(other.selectedAccountId, selectedAccountId) || other.selectedAccountId == selectedAccountId)&&(identical(other.amountInput, amountInput) || other.amountInput == amountInput)&&(identical(other.amountError, amountError) || other.amountError == amountError)&&(identical(other.note, note) || other.note == note)&&(identical(other.isSubmitting, isSubmitting) || other.isSubmitting == isSubmitting)&&(identical(other.success, success) || other.success == success)&&(identical(other.errorMessage, errorMessage) || other.errorMessage == errorMessage));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,goal,const DeepCollectionEquality().hash(_accounts),selectedAccountId,amountInput,amountError,note,isSubmitting,success,errorMessage);
+
+@override
+String toString() {
+  return 'ContributeState(goal: $goal, accounts: $accounts, selectedAccountId: $selectedAccountId, amountInput: $amountInput, amountError: $amountError, note: $note, isSubmitting: $isSubmitting, success: $success, errorMessage: $errorMessage)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$ContributeStateCopyWith<$Res> implements $ContributeStateCopyWith<$Res> {
+  factory _$ContributeStateCopyWith(_ContributeState value, $Res Function(_ContributeState) _then) = __$ContributeStateCopyWithImpl;
+@override @useResult
+$Res call({
+ SavingGoal goal, List<AccountEntity> accounts, String? selectedAccountId, String amountInput, String? amountError, String? note, bool isSubmitting, bool success, String? errorMessage
+});
+
+
+@override $SavingGoalCopyWith<$Res> get goal;
+
+}
+/// @nodoc
+class __$ContributeStateCopyWithImpl<$Res>
+    implements _$ContributeStateCopyWith<$Res> {
+  __$ContributeStateCopyWithImpl(this._self, this._then);
+
+  final _ContributeState _self;
+  final $Res Function(_ContributeState) _then;
+
+/// Create a copy of ContributeState
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? goal = null,Object? accounts = null,Object? selectedAccountId = freezed,Object? amountInput = null,Object? amountError = freezed,Object? note = freezed,Object? isSubmitting = null,Object? success = null,Object? errorMessage = freezed,}) {
+  return _then(_ContributeState(
+goal: null == goal ? _self.goal : goal // ignore: cast_nullable_to_non_nullable
+as SavingGoal,accounts: null == accounts ? _self._accounts : accounts // ignore: cast_nullable_to_non_nullable
+as List<AccountEntity>,selectedAccountId: freezed == selectedAccountId ? _self.selectedAccountId : selectedAccountId // ignore: cast_nullable_to_non_nullable
+as String?,amountInput: null == amountInput ? _self.amountInput : amountInput // ignore: cast_nullable_to_non_nullable
+as String,amountError: freezed == amountError ? _self.amountError : amountError // ignore: cast_nullable_to_non_nullable
+as String?,note: freezed == note ? _self.note : note // ignore: cast_nullable_to_non_nullable
+as String?,isSubmitting: null == isSubmitting ? _self.isSubmitting : isSubmitting // ignore: cast_nullable_to_non_nullable
+as bool,success: null == success ? _self.success : success // ignore: cast_nullable_to_non_nullable
+as bool,errorMessage: freezed == errorMessage ? _self.errorMessage : errorMessage // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+/// Create a copy of ContributeState
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$SavingGoalCopyWith<$Res> get goal {
+  
+  return $SavingGoalCopyWith<$Res>(_self.goal, (value) {
+    return _then(_self.copyWith(goal: value));
+  });
+}
+}
+
+// dart format on

--- a/lib/features/savings/presentation/controllers/edit_goal_controller.dart
+++ b/lib/features/savings/presentation/controllers/edit_goal_controller.dart
@@ -1,0 +1,85 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'package:kopim/core/di/injectors.dart';
+import 'package:kopim/features/savings/domain/entities/saving_goal.dart';
+import 'package:kopim/features/savings/domain/use_cases/create_saving_goal_use_case.dart';
+import 'package:kopim/features/savings/domain/use_cases/update_saving_goal_use_case.dart';
+import 'package:kopim/features/savings/domain/value_objects/money.dart';
+
+import 'edit_goal_state.dart';
+
+part 'edit_goal_controller.g.dart';
+
+@riverpod
+class EditGoalController extends _$EditGoalController {
+  @override
+  EditGoalState build(SavingGoal? goal) {
+    if (goal == null) {
+      return const EditGoalState();
+    }
+    final double target = goal.targetAmount / 100;
+    return EditGoalState(
+      original: goal,
+      name: goal.name,
+      targetInput: target.toStringAsFixed(2),
+      note: goal.note,
+    );
+  }
+
+  void updateName(String value) {
+    state = state.copyWith(name: value, nameError: null);
+  }
+
+  void updateTarget(String value) {
+    state = state.copyWith(targetInput: value, targetError: null);
+  }
+
+  void updateNote(String value) {
+    state = state.copyWith(note: value);
+  }
+
+  Future<void> submit() async {
+    final String trimmedName = state.name.trim();
+    if (trimmedName.isEmpty) {
+      state = state.copyWith(nameError: 'Введите название цели');
+      return;
+    }
+    final String normalizedTarget = state.targetInput.replaceAll(',', '.');
+    final double? parsedTarget = double.tryParse(normalizedTarget);
+    if (parsedTarget == null || parsedTarget <= 0) {
+      state = state.copyWith(targetError: 'Введите сумму больше нуля');
+      return;
+    }
+    final Money targetMoney = Money.fromDouble(parsedTarget);
+    state = state.copyWith(isSaving: true, errorMessage: null);
+    try {
+      final String? trimmedNote = state.note?.trim().isNotEmpty ?? false
+          ? state.note!.trim()
+          : null;
+      if (state.original == null) {
+        final CreateSavingGoalUseCase create = ref.read(
+          createSavingGoalUseCaseProvider,
+        );
+        await create(name: trimmedName, target: targetMoney, note: trimmedNote);
+      } else {
+        final UpdateSavingGoalUseCase update = ref.read(
+          updateSavingGoalUseCaseProvider,
+        );
+        await update(
+          goal: state.original!,
+          name: trimmedName,
+          target: targetMoney,
+          note: trimmedNote,
+        );
+      }
+      state = state.copyWith(
+        isSaving: false,
+        submissionSuccess: true,
+        nameError: null,
+        targetError: null,
+      );
+    } catch (error) {
+      state = state.copyWith(isSaving: false, errorMessage: error.toString());
+    }
+  }
+}

--- a/lib/features/savings/presentation/controllers/edit_goal_controller.g.dart
+++ b/lib/features/savings/presentation/controllers/edit_goal_controller.g.dart
@@ -1,0 +1,109 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'edit_goal_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(EditGoalController)
+const editGoalControllerProvider = EditGoalControllerFamily._();
+
+final class EditGoalControllerProvider
+    extends $NotifierProvider<EditGoalController, EditGoalState> {
+  const EditGoalControllerProvider._({
+    required EditGoalControllerFamily super.from,
+    required SavingGoal? super.argument,
+  }) : super(
+         retry: null,
+         name: r'editGoalControllerProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$editGoalControllerHash();
+
+  @override
+  String toString() {
+    return r'editGoalControllerProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  EditGoalController create() => EditGoalController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(EditGoalState value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<EditGoalState>(value),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is EditGoalControllerProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$editGoalControllerHash() =>
+    r'2f9c5e5382f3b0039332c2ebe053b0129f3dd4d9';
+
+final class EditGoalControllerFamily extends $Family
+    with
+        $ClassFamilyOverride<
+          EditGoalController,
+          EditGoalState,
+          EditGoalState,
+          EditGoalState,
+          SavingGoal?
+        > {
+  const EditGoalControllerFamily._()
+    : super(
+        retry: null,
+        name: r'editGoalControllerProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  EditGoalControllerProvider call(SavingGoal? goal) =>
+      EditGoalControllerProvider._(argument: goal, from: this);
+
+  @override
+  String toString() => r'editGoalControllerProvider';
+}
+
+abstract class _$EditGoalController extends $Notifier<EditGoalState> {
+  late final _$args = ref.$arg as SavingGoal?;
+  SavingGoal? get goal => _$args;
+
+  EditGoalState build(SavingGoal? goal);
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build(_$args);
+    final ref = this.ref as $Ref<EditGoalState, EditGoalState>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<EditGoalState, EditGoalState>,
+              EditGoalState,
+              Object?,
+              Object?
+            >;
+    element.handleValue(ref, created);
+  }
+}

--- a/lib/features/savings/presentation/controllers/edit_goal_state.dart
+++ b/lib/features/savings/presentation/controllers/edit_goal_state.dart
@@ -1,0 +1,19 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:kopim/features/savings/domain/entities/saving_goal.dart';
+
+part 'edit_goal_state.freezed.dart';
+
+@freezed
+abstract class EditGoalState with _$EditGoalState {
+  const factory EditGoalState({
+    SavingGoal? original,
+    @Default('') String name,
+    @Default('') String targetInput,
+    String? nameError,
+    String? targetError,
+    String? note,
+    @Default(false) bool isSaving,
+    @Default(false) bool submissionSuccess,
+    String? errorMessage,
+  }) = _EditGoalState;
+}

--- a/lib/features/savings/presentation/controllers/edit_goal_state.freezed.dart
+++ b/lib/features/savings/presentation/controllers/edit_goal_state.freezed.dart
@@ -1,0 +1,319 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'edit_goal_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$EditGoalState {
+
+ SavingGoal? get original; String get name; String get targetInput; String? get nameError; String? get targetError; String? get note; bool get isSaving; bool get submissionSuccess; String? get errorMessage;
+/// Create a copy of EditGoalState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$EditGoalStateCopyWith<EditGoalState> get copyWith => _$EditGoalStateCopyWithImpl<EditGoalState>(this as EditGoalState, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EditGoalState&&(identical(other.original, original) || other.original == original)&&(identical(other.name, name) || other.name == name)&&(identical(other.targetInput, targetInput) || other.targetInput == targetInput)&&(identical(other.nameError, nameError) || other.nameError == nameError)&&(identical(other.targetError, targetError) || other.targetError == targetError)&&(identical(other.note, note) || other.note == note)&&(identical(other.isSaving, isSaving) || other.isSaving == isSaving)&&(identical(other.submissionSuccess, submissionSuccess) || other.submissionSuccess == submissionSuccess)&&(identical(other.errorMessage, errorMessage) || other.errorMessage == errorMessage));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,original,name,targetInput,nameError,targetError,note,isSaving,submissionSuccess,errorMessage);
+
+@override
+String toString() {
+  return 'EditGoalState(original: $original, name: $name, targetInput: $targetInput, nameError: $nameError, targetError: $targetError, note: $note, isSaving: $isSaving, submissionSuccess: $submissionSuccess, errorMessage: $errorMessage)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $EditGoalStateCopyWith<$Res>  {
+  factory $EditGoalStateCopyWith(EditGoalState value, $Res Function(EditGoalState) _then) = _$EditGoalStateCopyWithImpl;
+@useResult
+$Res call({
+ SavingGoal? original, String name, String targetInput, String? nameError, String? targetError, String? note, bool isSaving, bool submissionSuccess, String? errorMessage
+});
+
+
+$SavingGoalCopyWith<$Res>? get original;
+
+}
+/// @nodoc
+class _$EditGoalStateCopyWithImpl<$Res>
+    implements $EditGoalStateCopyWith<$Res> {
+  _$EditGoalStateCopyWithImpl(this._self, this._then);
+
+  final EditGoalState _self;
+  final $Res Function(EditGoalState) _then;
+
+/// Create a copy of EditGoalState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? original = freezed,Object? name = null,Object? targetInput = null,Object? nameError = freezed,Object? targetError = freezed,Object? note = freezed,Object? isSaving = null,Object? submissionSuccess = null,Object? errorMessage = freezed,}) {
+  return _then(_self.copyWith(
+original: freezed == original ? _self.original : original // ignore: cast_nullable_to_non_nullable
+as SavingGoal?,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,targetInput: null == targetInput ? _self.targetInput : targetInput // ignore: cast_nullable_to_non_nullable
+as String,nameError: freezed == nameError ? _self.nameError : nameError // ignore: cast_nullable_to_non_nullable
+as String?,targetError: freezed == targetError ? _self.targetError : targetError // ignore: cast_nullable_to_non_nullable
+as String?,note: freezed == note ? _self.note : note // ignore: cast_nullable_to_non_nullable
+as String?,isSaving: null == isSaving ? _self.isSaving : isSaving // ignore: cast_nullable_to_non_nullable
+as bool,submissionSuccess: null == submissionSuccess ? _self.submissionSuccess : submissionSuccess // ignore: cast_nullable_to_non_nullable
+as bool,errorMessage: freezed == errorMessage ? _self.errorMessage : errorMessage // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+/// Create a copy of EditGoalState
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$SavingGoalCopyWith<$Res>? get original {
+    if (_self.original == null) {
+    return null;
+  }
+
+  return $SavingGoalCopyWith<$Res>(_self.original!, (value) {
+    return _then(_self.copyWith(original: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [EditGoalState].
+extension EditGoalStatePatterns on EditGoalState {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _EditGoalState value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _EditGoalState() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _EditGoalState value)  $default,){
+final _that = this;
+switch (_that) {
+case _EditGoalState():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _EditGoalState value)?  $default,){
+final _that = this;
+switch (_that) {
+case _EditGoalState() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( SavingGoal? original,  String name,  String targetInput,  String? nameError,  String? targetError,  String? note,  bool isSaving,  bool submissionSuccess,  String? errorMessage)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _EditGoalState() when $default != null:
+return $default(_that.original,_that.name,_that.targetInput,_that.nameError,_that.targetError,_that.note,_that.isSaving,_that.submissionSuccess,_that.errorMessage);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( SavingGoal? original,  String name,  String targetInput,  String? nameError,  String? targetError,  String? note,  bool isSaving,  bool submissionSuccess,  String? errorMessage)  $default,) {final _that = this;
+switch (_that) {
+case _EditGoalState():
+return $default(_that.original,_that.name,_that.targetInput,_that.nameError,_that.targetError,_that.note,_that.isSaving,_that.submissionSuccess,_that.errorMessage);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( SavingGoal? original,  String name,  String targetInput,  String? nameError,  String? targetError,  String? note,  bool isSaving,  bool submissionSuccess,  String? errorMessage)?  $default,) {final _that = this;
+switch (_that) {
+case _EditGoalState() when $default != null:
+return $default(_that.original,_that.name,_that.targetInput,_that.nameError,_that.targetError,_that.note,_that.isSaving,_that.submissionSuccess,_that.errorMessage);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _EditGoalState implements EditGoalState {
+  const _EditGoalState({this.original, this.name = '', this.targetInput = '', this.nameError, this.targetError, this.note, this.isSaving = false, this.submissionSuccess = false, this.errorMessage});
+  
+
+@override final  SavingGoal? original;
+@override@JsonKey() final  String name;
+@override@JsonKey() final  String targetInput;
+@override final  String? nameError;
+@override final  String? targetError;
+@override final  String? note;
+@override@JsonKey() final  bool isSaving;
+@override@JsonKey() final  bool submissionSuccess;
+@override final  String? errorMessage;
+
+/// Create a copy of EditGoalState
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$EditGoalStateCopyWith<_EditGoalState> get copyWith => __$EditGoalStateCopyWithImpl<_EditGoalState>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EditGoalState&&(identical(other.original, original) || other.original == original)&&(identical(other.name, name) || other.name == name)&&(identical(other.targetInput, targetInput) || other.targetInput == targetInput)&&(identical(other.nameError, nameError) || other.nameError == nameError)&&(identical(other.targetError, targetError) || other.targetError == targetError)&&(identical(other.note, note) || other.note == note)&&(identical(other.isSaving, isSaving) || other.isSaving == isSaving)&&(identical(other.submissionSuccess, submissionSuccess) || other.submissionSuccess == submissionSuccess)&&(identical(other.errorMessage, errorMessage) || other.errorMessage == errorMessage));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,original,name,targetInput,nameError,targetError,note,isSaving,submissionSuccess,errorMessage);
+
+@override
+String toString() {
+  return 'EditGoalState(original: $original, name: $name, targetInput: $targetInput, nameError: $nameError, targetError: $targetError, note: $note, isSaving: $isSaving, submissionSuccess: $submissionSuccess, errorMessage: $errorMessage)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$EditGoalStateCopyWith<$Res> implements $EditGoalStateCopyWith<$Res> {
+  factory _$EditGoalStateCopyWith(_EditGoalState value, $Res Function(_EditGoalState) _then) = __$EditGoalStateCopyWithImpl;
+@override @useResult
+$Res call({
+ SavingGoal? original, String name, String targetInput, String? nameError, String? targetError, String? note, bool isSaving, bool submissionSuccess, String? errorMessage
+});
+
+
+@override $SavingGoalCopyWith<$Res>? get original;
+
+}
+/// @nodoc
+class __$EditGoalStateCopyWithImpl<$Res>
+    implements _$EditGoalStateCopyWith<$Res> {
+  __$EditGoalStateCopyWithImpl(this._self, this._then);
+
+  final _EditGoalState _self;
+  final $Res Function(_EditGoalState) _then;
+
+/// Create a copy of EditGoalState
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? original = freezed,Object? name = null,Object? targetInput = null,Object? nameError = freezed,Object? targetError = freezed,Object? note = freezed,Object? isSaving = null,Object? submissionSuccess = null,Object? errorMessage = freezed,}) {
+  return _then(_EditGoalState(
+original: freezed == original ? _self.original : original // ignore: cast_nullable_to_non_nullable
+as SavingGoal?,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,targetInput: null == targetInput ? _self.targetInput : targetInput // ignore: cast_nullable_to_non_nullable
+as String,nameError: freezed == nameError ? _self.nameError : nameError // ignore: cast_nullable_to_non_nullable
+as String?,targetError: freezed == targetError ? _self.targetError : targetError // ignore: cast_nullable_to_non_nullable
+as String?,note: freezed == note ? _self.note : note // ignore: cast_nullable_to_non_nullable
+as String?,isSaving: null == isSaving ? _self.isSaving : isSaving // ignore: cast_nullable_to_non_nullable
+as bool,submissionSuccess: null == submissionSuccess ? _self.submissionSuccess : submissionSuccess // ignore: cast_nullable_to_non_nullable
+as bool,errorMessage: freezed == errorMessage ? _self.errorMessage : errorMessage // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+/// Create a copy of EditGoalState
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$SavingGoalCopyWith<$Res>? get original {
+    if (_self.original == null) {
+    return null;
+  }
+
+  return $SavingGoalCopyWith<$Res>(_self.original!, (value) {
+    return _then(_self.copyWith(original: value));
+  });
+}
+}
+
+// dart format on

--- a/lib/features/savings/presentation/controllers/saving_goals_controller.dart
+++ b/lib/features/savings/presentation/controllers/saving_goals_controller.dart
@@ -1,0 +1,90 @@
+import 'dart:async';
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'package:kopim/core/di/injectors.dart';
+import 'package:kopim/features/savings/domain/entities/saving_goal.dart';
+import 'package:kopim/features/savings/domain/use_cases/archive_saving_goal_use_case.dart';
+import 'package:kopim/features/savings/domain/use_cases/get_saving_goals_use_case.dart';
+import 'package:kopim/features/savings/domain/use_cases/watch_saving_goals_use_case.dart';
+
+import 'saving_goals_state.dart';
+
+part 'saving_goals_controller.g.dart';
+
+@riverpod
+class SavingGoalsController extends _$SavingGoalsController {
+  StreamSubscription<List<SavingGoal>>? _subscription;
+
+  @override
+  SavingGoalsState build() {
+    const SavingGoalsState initial = SavingGoalsState();
+    state = initial;
+    ref.onDispose(() async {
+      await _subscription?.cancel();
+    });
+    _subscribe(initial.showArchived);
+    return state;
+  }
+
+  void toggleShowArchived(bool value) {
+    if (state.showArchived == value) {
+      return;
+    }
+    state = state.copyWith(showArchived: value);
+    _subscribe(value);
+  }
+
+  Future<void> refresh() async {
+    final GetSavingGoalsUseCase loader = ref.read(
+      getSavingGoalsUseCaseProvider,
+    );
+    state = state.copyWith(isLoading: true, error: null);
+    try {
+      final List<SavingGoal> items = await loader(
+        includeArchived: state.showArchived,
+      );
+      state = state.copyWith(goals: items, isLoading: false, error: null);
+    } catch (error) {
+      state = state.copyWith(isLoading: false, error: error.toString());
+      ref
+          .read(loggerServiceProvider)
+          .logError('Failed to refresh saving goals', error);
+    }
+  }
+
+  void _subscribe(bool includeArchived) {
+    _subscription?.cancel();
+    state = state.copyWith(isLoading: true, error: null);
+    final WatchSavingGoalsUseCase watch = ref.watch(
+      watchSavingGoalsUseCaseProvider,
+    );
+    _subscription = watch(includeArchived: includeArchived).listen(
+      (List<SavingGoal> goals) {
+        state = state.copyWith(goals: goals, isLoading: false, error: null);
+      },
+      onError: (Object error, StackTrace _) {
+        state = state.copyWith(isLoading: false, error: error.toString());
+        ref
+            .read(loggerServiceProvider)
+            .logError('Saving goals stream error', error);
+      },
+    );
+  }
+
+  Future<void> archiveGoal(String goalId) async {
+    try {
+      state = state.copyWith(error: null);
+      final ArchiveSavingGoalUseCase archive = ref.read(
+        archiveSavingGoalUseCaseProvider,
+      );
+      await archive(goalId);
+    } catch (error) {
+      state = state.copyWith(error: error.toString());
+      ref
+          .read(loggerServiceProvider)
+          .logError('Failed to archive saving goal', error);
+      rethrow;
+    }
+  }
+}

--- a/lib/features/savings/presentation/controllers/saving_goals_controller.g.dart
+++ b/lib/features/savings/presentation/controllers/saving_goals_controller.g.dart
@@ -1,0 +1,64 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'saving_goals_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(SavingGoalsController)
+const savingGoalsControllerProvider = SavingGoalsControllerProvider._();
+
+final class SavingGoalsControllerProvider
+    extends $NotifierProvider<SavingGoalsController, SavingGoalsState> {
+  const SavingGoalsControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'savingGoalsControllerProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$savingGoalsControllerHash();
+
+  @$internal
+  @override
+  SavingGoalsController create() => SavingGoalsController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(SavingGoalsState value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<SavingGoalsState>(value),
+    );
+  }
+}
+
+String _$savingGoalsControllerHash() =>
+    r'4eb7b877971f9576458cebb9efcea4673502c608';
+
+abstract class _$SavingGoalsController extends $Notifier<SavingGoalsState> {
+  SavingGoalsState build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build();
+    final ref = this.ref as $Ref<SavingGoalsState, SavingGoalsState>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<SavingGoalsState, SavingGoalsState>,
+              SavingGoalsState,
+              Object?,
+              Object?
+            >;
+    element.handleValue(ref, created);
+  }
+}

--- a/lib/features/savings/presentation/controllers/saving_goals_providers.dart
+++ b/lib/features/savings/presentation/controllers/saving_goals_providers.dart
@@ -1,0 +1,18 @@
+import 'package:riverpod/riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'package:kopim/features/savings/domain/entities/saving_goal.dart';
+
+import 'saving_goals_controller.dart';
+import 'saving_goals_state.dart';
+
+part 'saving_goals_providers.g.dart';
+
+@riverpod
+List<SavingGoal> goalsStream(Ref ref) {
+  return ref.watch(
+    savingGoalsControllerProvider.select(
+      (SavingGoalsState value) => value.goals,
+    ),
+  );
+}

--- a/lib/features/savings/presentation/controllers/saving_goals_providers.g.dart
+++ b/lib/features/savings/presentation/controllers/saving_goals_providers.g.dart
@@ -1,0 +1,56 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'saving_goals_providers.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(goalsStream)
+const goalsStreamProvider = GoalsStreamProvider._();
+
+final class GoalsStreamProvider
+    extends
+        $FunctionalProvider<
+          List<SavingGoal>,
+          List<SavingGoal>,
+          List<SavingGoal>
+        >
+    with $Provider<List<SavingGoal>> {
+  const GoalsStreamProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'goalsStreamProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$goalsStreamHash();
+
+  @$internal
+  @override
+  $ProviderElement<List<SavingGoal>> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  List<SavingGoal> create(Ref ref) {
+    return goalsStream(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(List<SavingGoal> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<List<SavingGoal>>(value),
+    );
+  }
+}
+
+String _$goalsStreamHash() => r'829d8f06c7af6efeebd04e0fbb5c8c6f2071748a';

--- a/lib/features/savings/presentation/controllers/saving_goals_state.dart
+++ b/lib/features/savings/presentation/controllers/saving_goals_state.dart
@@ -1,0 +1,14 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:kopim/features/savings/domain/entities/saving_goal.dart';
+
+part 'saving_goals_state.freezed.dart';
+
+@freezed
+abstract class SavingGoalsState with _$SavingGoalsState {
+  const factory SavingGoalsState({
+    @Default(<SavingGoal>[]) List<SavingGoal> goals,
+    @Default(false) bool showArchived,
+    @Default(true) bool isLoading,
+    String? error,
+  }) = _SavingGoalsState;
+}

--- a/lib/features/savings/presentation/controllers/saving_goals_state.freezed.dart
+++ b/lib/features/savings/presentation/controllers/saving_goals_state.freezed.dart
@@ -1,0 +1,286 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'saving_goals_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$SavingGoalsState {
+
+ List<SavingGoal> get goals; bool get showArchived; bool get isLoading; String? get error;
+/// Create a copy of SavingGoalsState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SavingGoalsStateCopyWith<SavingGoalsState> get copyWith => _$SavingGoalsStateCopyWithImpl<SavingGoalsState>(this as SavingGoalsState, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SavingGoalsState&&const DeepCollectionEquality().equals(other.goals, goals)&&(identical(other.showArchived, showArchived) || other.showArchived == showArchived)&&(identical(other.isLoading, isLoading) || other.isLoading == isLoading)&&(identical(other.error, error) || other.error == error));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(goals),showArchived,isLoading,error);
+
+@override
+String toString() {
+  return 'SavingGoalsState(goals: $goals, showArchived: $showArchived, isLoading: $isLoading, error: $error)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $SavingGoalsStateCopyWith<$Res>  {
+  factory $SavingGoalsStateCopyWith(SavingGoalsState value, $Res Function(SavingGoalsState) _then) = _$SavingGoalsStateCopyWithImpl;
+@useResult
+$Res call({
+ List<SavingGoal> goals, bool showArchived, bool isLoading, String? error
+});
+
+
+
+
+}
+/// @nodoc
+class _$SavingGoalsStateCopyWithImpl<$Res>
+    implements $SavingGoalsStateCopyWith<$Res> {
+  _$SavingGoalsStateCopyWithImpl(this._self, this._then);
+
+  final SavingGoalsState _self;
+  final $Res Function(SavingGoalsState) _then;
+
+/// Create a copy of SavingGoalsState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? goals = null,Object? showArchived = null,Object? isLoading = null,Object? error = freezed,}) {
+  return _then(_self.copyWith(
+goals: null == goals ? _self.goals : goals // ignore: cast_nullable_to_non_nullable
+as List<SavingGoal>,showArchived: null == showArchived ? _self.showArchived : showArchived // ignore: cast_nullable_to_non_nullable
+as bool,isLoading: null == isLoading ? _self.isLoading : isLoading // ignore: cast_nullable_to_non_nullable
+as bool,error: freezed == error ? _self.error : error // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [SavingGoalsState].
+extension SavingGoalsStatePatterns on SavingGoalsState {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _SavingGoalsState value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _SavingGoalsState() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _SavingGoalsState value)  $default,){
+final _that = this;
+switch (_that) {
+case _SavingGoalsState():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _SavingGoalsState value)?  $default,){
+final _that = this;
+switch (_that) {
+case _SavingGoalsState() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( List<SavingGoal> goals,  bool showArchived,  bool isLoading,  String? error)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _SavingGoalsState() when $default != null:
+return $default(_that.goals,_that.showArchived,_that.isLoading,_that.error);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( List<SavingGoal> goals,  bool showArchived,  bool isLoading,  String? error)  $default,) {final _that = this;
+switch (_that) {
+case _SavingGoalsState():
+return $default(_that.goals,_that.showArchived,_that.isLoading,_that.error);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( List<SavingGoal> goals,  bool showArchived,  bool isLoading,  String? error)?  $default,) {final _that = this;
+switch (_that) {
+case _SavingGoalsState() when $default != null:
+return $default(_that.goals,_that.showArchived,_that.isLoading,_that.error);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _SavingGoalsState implements SavingGoalsState {
+  const _SavingGoalsState({final  List<SavingGoal> goals = const <SavingGoal>[], this.showArchived = false, this.isLoading = true, this.error}): _goals = goals;
+  
+
+ final  List<SavingGoal> _goals;
+@override@JsonKey() List<SavingGoal> get goals {
+  if (_goals is EqualUnmodifiableListView) return _goals;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_goals);
+}
+
+@override@JsonKey() final  bool showArchived;
+@override@JsonKey() final  bool isLoading;
+@override final  String? error;
+
+/// Create a copy of SavingGoalsState
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$SavingGoalsStateCopyWith<_SavingGoalsState> get copyWith => __$SavingGoalsStateCopyWithImpl<_SavingGoalsState>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SavingGoalsState&&const DeepCollectionEquality().equals(other._goals, _goals)&&(identical(other.showArchived, showArchived) || other.showArchived == showArchived)&&(identical(other.isLoading, isLoading) || other.isLoading == isLoading)&&(identical(other.error, error) || other.error == error));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_goals),showArchived,isLoading,error);
+
+@override
+String toString() {
+  return 'SavingGoalsState(goals: $goals, showArchived: $showArchived, isLoading: $isLoading, error: $error)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$SavingGoalsStateCopyWith<$Res> implements $SavingGoalsStateCopyWith<$Res> {
+  factory _$SavingGoalsStateCopyWith(_SavingGoalsState value, $Res Function(_SavingGoalsState) _then) = __$SavingGoalsStateCopyWithImpl;
+@override @useResult
+$Res call({
+ List<SavingGoal> goals, bool showArchived, bool isLoading, String? error
+});
+
+
+
+
+}
+/// @nodoc
+class __$SavingGoalsStateCopyWithImpl<$Res>
+    implements _$SavingGoalsStateCopyWith<$Res> {
+  __$SavingGoalsStateCopyWithImpl(this._self, this._then);
+
+  final _SavingGoalsState _self;
+  final $Res Function(_SavingGoalsState) _then;
+
+/// Create a copy of SavingGoalsState
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? goals = null,Object? showArchived = null,Object? isLoading = null,Object? error = freezed,}) {
+  return _then(_SavingGoalsState(
+goals: null == goals ? _self._goals : goals // ignore: cast_nullable_to_non_nullable
+as List<SavingGoal>,showArchived: null == showArchived ? _self.showArchived : showArchived // ignore: cast_nullable_to_non_nullable
+as bool,isLoading: null == isLoading ? _self.isLoading : isLoading // ignore: cast_nullable_to_non_nullable
+as bool,error: freezed == error ? _self.error : error // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/features/savings/presentation/screens/add_edit_goal_screen.dart
+++ b/lib/features/savings/presentation/screens/add_edit_goal_screen.dart
@@ -1,0 +1,162 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:kopim/features/savings/domain/entities/saving_goal.dart';
+import 'package:kopim/features/savings/presentation/controllers/edit_goal_controller.dart';
+import 'package:kopim/features/savings/presentation/controllers/edit_goal_state.dart';
+import 'package:kopim/l10n/app_localizations.dart';
+
+class AddEditGoalScreen extends ConsumerStatefulWidget {
+  const AddEditGoalScreen({super.key, this.goal});
+
+  final SavingGoal? goal;
+
+  static Route<void> route({SavingGoal? goal}) {
+    return MaterialPageRoute<void>(
+      builder: (BuildContext context) => AddEditGoalScreen(goal: goal),
+    );
+  }
+
+  @override
+  ConsumerState<AddEditGoalScreen> createState() => _AddEditGoalScreenState();
+}
+
+class _AddEditGoalScreenState extends ConsumerState<AddEditGoalScreen> {
+  late final TextEditingController _nameController;
+  late final TextEditingController _targetController;
+  late final TextEditingController _noteController;
+  ProviderSubscription<EditGoalState>? _subscription;
+
+  @override
+  void initState() {
+    super.initState();
+    _nameController = TextEditingController(text: widget.goal?.name ?? '');
+    _targetController = TextEditingController(
+      text: widget.goal != null
+          ? (widget.goal!.targetAmount / 100).toStringAsFixed(2)
+          : '',
+    );
+    _noteController = TextEditingController(text: widget.goal?.note ?? '');
+    _subscription = ref.listenManual<EditGoalState>(
+      editGoalControllerProvider(widget.goal),
+      (EditGoalState? previous, EditGoalState next) {
+        if (next.submissionSuccess) {
+          final AppLocalizations strings = AppLocalizations.of(context)!;
+          if (!mounted) {
+            return;
+          }
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(strings.savingsGoalSavedMessage)),
+          );
+          Navigator.of(context).pop();
+        } else if (next.errorMessage != null && next.errorMessage!.isNotEmpty) {
+          if (!mounted) {
+            return;
+          }
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(SnackBar(content: Text(next.errorMessage!)));
+        }
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _subscription?.close();
+    _nameController.dispose();
+    _targetController.dispose();
+    _noteController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final EditGoalState state = ref.watch(
+      editGoalControllerProvider(widget.goal),
+    );
+    final AppLocalizations strings = AppLocalizations.of(context)!;
+    final bool isEditing = widget.goal != null;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          isEditing
+              ? strings.savingsEditGoalTitle
+              : strings.savingsAddGoalTitle,
+        ),
+      ),
+      body: SafeArea(
+        child: Form(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                TextFormField(
+                  controller: _nameController,
+                  decoration: InputDecoration(
+                    labelText: strings.savingsNameLabel,
+                    errorText: state.nameError,
+                  ),
+                  textInputAction: TextInputAction.next,
+                  onChanged: (String value) => ref
+                      .read(editGoalControllerProvider(widget.goal).notifier)
+                      .updateName(value),
+                ),
+                const SizedBox(height: 16),
+                TextFormField(
+                  controller: _targetController,
+                  decoration: InputDecoration(
+                    labelText: strings.savingsTargetLabel,
+                    helperText: strings.savingsTargetHelper,
+                    errorText: state.targetError,
+                  ),
+                  keyboardType: const TextInputType.numberWithOptions(
+                    decimal: true,
+                  ),
+                  textInputAction: TextInputAction.next,
+                  onChanged: (String value) => ref
+                      .read(editGoalControllerProvider(widget.goal).notifier)
+                      .updateTarget(value),
+                ),
+                const SizedBox(height: 16),
+                TextFormField(
+                  controller: _noteController,
+                  decoration: InputDecoration(
+                    labelText: strings.savingsNoteLabel,
+                  ),
+                  maxLines: 3,
+                  onChanged: (String value) => ref
+                      .read(editGoalControllerProvider(widget.goal).notifier)
+                      .updateNote(value),
+                ),
+                const SizedBox(height: 24),
+                SizedBox(
+                  width: double.infinity,
+                  child: FilledButton(
+                    onPressed: state.isSaving
+                        ? null
+                        : () => ref
+                              .read(
+                                editGoalControllerProvider(
+                                  widget.goal,
+                                ).notifier,
+                              )
+                              .submit(),
+                    child: state.isSaving
+                        ? const SizedBox(
+                            width: 20,
+                            height: 20,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : Text(strings.savingsSaveGoalButton),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/savings/presentation/screens/contribute_screen.dart
+++ b/lib/features/savings/presentation/screens/contribute_screen.dart
@@ -1,0 +1,188 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+
+import 'package:kopim/features/accounts/domain/entities/account_entity.dart';
+import 'package:kopim/features/savings/domain/entities/saving_goal.dart';
+import 'package:kopim/features/savings/domain/value_objects/goal_progress.dart';
+import 'package:kopim/features/savings/presentation/controllers/contribute_controller.dart';
+import 'package:kopim/features/savings/presentation/controllers/contribute_state.dart';
+import 'package:kopim/l10n/app_localizations.dart';
+
+class ContributeScreen extends ConsumerStatefulWidget {
+  const ContributeScreen({super.key, required this.goal});
+
+  final SavingGoal goal;
+
+  static Route<void> route(SavingGoal goal) {
+    return MaterialPageRoute<void>(
+      builder: (BuildContext context) => ContributeScreen(goal: goal),
+    );
+  }
+
+  @override
+  ConsumerState<ContributeScreen> createState() => _ContributeScreenState();
+}
+
+class _ContributeScreenState extends ConsumerState<ContributeScreen> {
+  late final TextEditingController _amountController;
+  late final TextEditingController _noteController;
+  ProviderSubscription<ContributeState>? _subscription;
+
+  @override
+  void initState() {
+    super.initState();
+    _amountController = TextEditingController();
+    _noteController = TextEditingController();
+    _subscription = ref.listenManual<ContributeState>(
+      contributeControllerProvider(widget.goal),
+      (ContributeState? previous, ContributeState next) {
+        if (!mounted) {
+          return;
+        }
+        if (previous?.success != true && next.success) {
+          final AppLocalizations strings = AppLocalizations.of(context)!;
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(strings.savingsContributionSuccess)),
+          );
+          Navigator.of(context).pop();
+        } else if (next.errorMessage != null && next.errorMessage!.isNotEmpty) {
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(SnackBar(content: Text(next.errorMessage!)));
+        }
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _subscription?.close();
+    _amountController.dispose();
+    _noteController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ContributeState state = ref.watch(
+      contributeControllerProvider(widget.goal),
+    );
+    final AppLocalizations strings = AppLocalizations.of(context)!;
+    final GoalProgress progress = GoalProgress.fromGoal(widget.goal);
+    final NumberFormat currencyFormat = NumberFormat.simpleCurrency(
+      locale: Localizations.localeOf(context).toString(),
+    );
+    final String remainingLabel = currencyFormat.format(
+      progress.remaining.minorUnits / 100,
+    );
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(strings.savingsContributeTitle(widget.goal.name)),
+      ),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Card(
+                elevation: 0,
+                color: Theme.of(context).colorScheme.surfaceContainerHighest,
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      Text(
+                        widget.goal.name,
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                      const SizedBox(height: 8),
+                      LinearProgressIndicator(value: progress.percent),
+                      const SizedBox(height: 8),
+                      Text(
+                        strings.savingsRemainingLabel(remainingLabel),
+                        style: Theme.of(context).textTheme.bodyMedium,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(height: 24),
+              TextField(
+                controller: _amountController,
+                decoration: InputDecoration(
+                  labelText: strings.savingsAmountLabel,
+                  errorText: state.amountError,
+                ),
+                keyboardType: const TextInputType.numberWithOptions(
+                  decimal: true,
+                ),
+                onChanged: (String value) => ref
+                    .read(contributeControllerProvider(widget.goal).notifier)
+                    .updateAmount(value),
+              ),
+              const SizedBox(height: 16),
+              DropdownButtonFormField<String?>(
+                initialValue: state.selectedAccountId,
+                decoration: InputDecoration(
+                  labelText: strings.savingsSourceAccountLabel,
+                ),
+                items: <DropdownMenuItem<String?>>[
+                  DropdownMenuItem<String?>(
+                    value: null,
+                    child: Text(strings.savingsNoAccountOption),
+                  ),
+                  ...state.accounts.map(
+                    (AccountEntity account) => DropdownMenuItem<String?>(
+                      value: account.id,
+                      child: Text(account.name),
+                    ),
+                  ),
+                ],
+                onChanged: (String? value) => ref
+                    .read(contributeControllerProvider(widget.goal).notifier)
+                    .selectAccount(value),
+              ),
+              const SizedBox(height: 16),
+              TextField(
+                controller: _noteController,
+                decoration: InputDecoration(
+                  labelText: strings.savingsContributionNoteLabel,
+                ),
+                maxLines: 3,
+                onChanged: (String value) => ref
+                    .read(contributeControllerProvider(widget.goal).notifier)
+                    .updateNote(value),
+              ),
+              const SizedBox(height: 24),
+              SizedBox(
+                width: double.infinity,
+                child: FilledButton.icon(
+                  onPressed: state.isSubmitting
+                      ? null
+                      : () => ref
+                            .read(
+                              contributeControllerProvider(
+                                widget.goal,
+                              ).notifier,
+                            )
+                            .submit(),
+                  icon: const Icon(Icons.trending_up),
+                  label: state.isSubmitting
+                      ? const SizedBox(
+                          width: 20,
+                          height: 20,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : Text(strings.savingsSubmitContributionButton),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/savings/presentation/screens/savings_list_screen.dart
+++ b/lib/features/savings/presentation/screens/savings_list_screen.dart
@@ -1,0 +1,265 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:kopim/features/app_shell/presentation/models/navigation_tab_content.dart';
+import 'package:kopim/features/savings/domain/entities/saving_goal.dart';
+import 'package:kopim/features/savings/domain/value_objects/goal_progress.dart';
+import 'package:kopim/features/savings/presentation/controllers/saving_goals_controller.dart';
+import 'package:kopim/features/savings/presentation/controllers/saving_goals_providers.dart';
+import 'package:kopim/features/savings/presentation/controllers/saving_goals_state.dart';
+import 'package:kopim/features/savings/presentation/screens/add_edit_goal_screen.dart';
+import 'package:kopim/features/savings/presentation/screens/contribute_screen.dart';
+import 'package:kopim/features/savings/presentation/widgets/saving_goal_card.dart';
+import 'package:kopim/l10n/app_localizations.dart';
+
+class SavingsListScreen extends ConsumerWidget {
+  const SavingsListScreen({super.key});
+
+  static const String routeName = '/savings';
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final NavigationTabContent content = buildSavingsTabContent(context, ref);
+    return Scaffold(
+      appBar: content.appBarBuilder?.call(context, ref),
+      body: content.bodyBuilder(context, ref),
+      floatingActionButton: content.floatingActionButtonBuilder?.call(
+        context,
+        ref,
+      ),
+    );
+  }
+}
+
+NavigationTabContent buildSavingsTabContent(
+  BuildContext context,
+  WidgetRef ref,
+) {
+  final AppLocalizations strings = AppLocalizations.of(context)!;
+  return NavigationTabContent(
+    appBarBuilder: (BuildContext context, WidgetRef ref) =>
+        AppBar(title: Text(strings.savingsTitle)),
+    floatingActionButtonBuilder: (BuildContext context, WidgetRef ref) {
+      return FloatingActionButton(
+        onPressed: () {
+          Navigator.of(context).push(AddEditGoalScreen.route());
+        },
+        child: const Icon(Icons.add),
+      );
+    },
+    bodyBuilder: (BuildContext context, WidgetRef ref) => const _SavingsBody(),
+  );
+}
+
+class _SavingsBody extends ConsumerStatefulWidget {
+  const _SavingsBody();
+
+  @override
+  ConsumerState<_SavingsBody> createState() => _SavingsBodyState();
+}
+
+class _SavingsBodyState extends ConsumerState<_SavingsBody> {
+  Future<void> _archiveGoal(SavingGoal goal) async {
+    final AppLocalizations strings = AppLocalizations.of(context)!;
+    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+    try {
+      await ref
+          .read(savingGoalsControllerProvider.notifier)
+          .archiveGoal(goal.id);
+      if (!mounted) {
+        return;
+      }
+      messenger.showSnackBar(
+        SnackBar(content: Text(strings.savingsGoalArchivedMessage(goal.name))),
+      );
+    } catch (_) {
+      if (!mounted) {
+        return;
+      }
+      messenger.showSnackBar(
+        SnackBar(content: Text(strings.genericErrorMessage)),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final SavingGoalsState state = ref.watch(savingGoalsControllerProvider);
+    final List<SavingGoal> goals = ref.watch(goalsStreamProvider);
+    final bool isLoading = ref.watch(
+      savingGoalsControllerProvider.select(
+        (SavingGoalsState value) => value.isLoading,
+      ),
+    );
+    final String? error = ref.watch(
+      savingGoalsControllerProvider.select(
+        (SavingGoalsState value) => value.error,
+      ),
+    );
+    final bool showArchived = state.showArchived;
+
+    if (isLoading && goals.isEmpty) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (error != null && goals.isEmpty) {
+      return _SavingsErrorState(
+        message: error,
+        onRetry: () =>
+            ref.read(savingGoalsControllerProvider.notifier).refresh(),
+      );
+    }
+    if (goals.isEmpty) {
+      return _SavingsEmptyState(
+        onCreate: () {
+          Navigator.of(context).push(AddEditGoalScreen.route());
+        },
+      );
+    }
+    final List<GoalProgress> progressList = goals
+        .map(GoalProgress.fromGoal)
+        .toList(growable: false);
+    return RefreshIndicator(
+      onRefresh: () =>
+          ref.read(savingGoalsControllerProvider.notifier).refresh(),
+      child: ListView.builder(
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        itemCount: progressList.length + 1,
+        itemBuilder: (BuildContext context, int index) {
+          if (index == 0) {
+            return _FilterRow(
+              showArchived: showArchived,
+              onChanged: (bool value) => ref
+                  .read(savingGoalsControllerProvider.notifier)
+                  .toggleShowArchived(value),
+            );
+          }
+          final GoalProgress progress = progressList[index - 1];
+          return Padding(
+            padding: const EdgeInsets.only(bottom: 12),
+            child: SavingGoalCard(
+              goal: progress.goal,
+              progress: progress,
+              onContribute: () {
+                Navigator.of(
+                  context,
+                ).push(ContributeScreen.route(progress.goal));
+              },
+              onEdit: () {
+                Navigator.of(
+                  context,
+                ).push(AddEditGoalScreen.route(goal: progress.goal));
+              },
+              onArchive: () => unawaited(_archiveGoal(progress.goal)),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _FilterRow extends StatelessWidget {
+  const _FilterRow({required this.showArchived, required this.onChanged});
+
+  final bool showArchived;
+  final ValueChanged<bool> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations strings = AppLocalizations.of(context)!;
+    return SwitchListTile.adaptive(
+      value: showArchived,
+      onChanged: onChanged,
+      title: Text(strings.savingsShowArchivedToggle),
+      contentPadding: EdgeInsets.zero,
+    );
+  }
+}
+
+class _SavingsEmptyState extends StatelessWidget {
+  const _SavingsEmptyState({required this.onCreate});
+
+  final VoidCallback onCreate;
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations strings = AppLocalizations.of(context)!;
+    final ThemeData theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Icon(
+              Icons.savings_outlined,
+              size: 72,
+              color: theme.colorScheme.primary,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              strings.savingsEmptyTitle,
+              style: theme.textTheme.titleMedium,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              strings.savingsEmptyMessage,
+              style: theme.textTheme.bodyMedium,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 16),
+            FilledButton(
+              onPressed: onCreate,
+              child: Text(strings.savingsAddGoalButton),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SavingsErrorState extends StatelessWidget {
+  const _SavingsErrorState({required this.message, required this.onRetry});
+
+  final String message;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations strings = AppLocalizations.of(context)!;
+    final ThemeData theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Icon(Icons.error_outline, size: 48, color: theme.colorScheme.error),
+            const SizedBox(height: 12),
+            Text(
+              strings.savingsErrorTitle,
+              style: theme.textTheme.titleMedium,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              message,
+              style: theme.textTheme.bodySmall,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 16),
+            OutlinedButton(
+              onPressed: onRetry,
+              child: Text(strings.savingsRetryButton),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/savings/presentation/widgets/saving_goal_card.dart
+++ b/lib/features/savings/presentation/widgets/saving_goal_card.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import 'package:kopim/features/savings/domain/entities/saving_goal.dart';
+import 'package:kopim/features/savings/domain/value_objects/goal_progress.dart';
+import 'package:kopim/l10n/app_localizations.dart';
+
+class SavingGoalCard extends StatelessWidget {
+  const SavingGoalCard({
+    super.key,
+    required this.goal,
+    required this.progress,
+    required this.onContribute,
+    required this.onEdit,
+    required this.onArchive,
+  });
+
+  final SavingGoal goal;
+  final GoalProgress progress;
+  final VoidCallback onContribute;
+  final VoidCallback onEdit;
+  final VoidCallback onArchive;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final AppLocalizations strings = AppLocalizations.of(context)!;
+    final NumberFormat currencyFormat = NumberFormat.simpleCurrency(
+      locale: Localizations.localeOf(context).toString(),
+    );
+    final NumberFormat percentFormat = NumberFormat.percentPattern(
+      Localizations.localeOf(context).toString(),
+    );
+    final double percentValue = progress.percent.clamp(0, 1);
+    final String percentLabel = percentFormat.format(percentValue);
+    final String currentLabel = currencyFormat.format(
+      progress.goal.currentAmount / 100,
+    );
+    final String targetLabel = currencyFormat.format(
+      progress.goal.targetAmount / 100,
+    );
+    final String remainingLabel = currencyFormat.format(
+      progress.remaining.minorUnits / 100,
+    );
+
+    return Card(
+      elevation: 0,
+      clipBehavior: Clip.antiAlias,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(16),
+        side: BorderSide(color: theme.colorScheme.outlineVariant),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Row(
+              children: <Widget>[
+                Expanded(
+                  child: Text(goal.name, style: theme.textTheme.titleMedium),
+                ),
+                PopupMenuButton<_GoalAction>(
+                  onSelected: (_GoalAction action) {
+                    switch (action) {
+                      case _GoalAction.edit:
+                        onEdit();
+                        break;
+                      case _GoalAction.archive:
+                        onArchive();
+                        break;
+                    }
+                  },
+                  itemBuilder: (BuildContext context) =>
+                      <PopupMenuEntry<_GoalAction>>[
+                        PopupMenuItem<_GoalAction>(
+                          value: _GoalAction.edit,
+                          child: Text(strings.savingsEditAction),
+                        ),
+                        PopupMenuItem<_GoalAction>(
+                          value: _GoalAction.archive,
+                          enabled: !goal.isArchived,
+                          child: Text(strings.savingsArchiveAction),
+                        ),
+                      ],
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            LinearProgressIndicator(value: percentValue),
+            const SizedBox(height: 8),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: <Widget>[
+                Text(
+                  '$currentLabel / $targetLabel',
+                  style: theme.textTheme.bodyMedium,
+                ),
+                Text(percentLabel, style: theme.textTheme.bodyMedium),
+              ],
+            ),
+            if (goal.note != null && goal.note!.isNotEmpty) ...<Widget>[
+              const SizedBox(height: 8),
+              Text(goal.note!, style: theme.textTheme.bodySmall),
+            ],
+            const SizedBox(height: 12),
+            Row(
+              children: <Widget>[
+                Expanded(
+                  child: Text(
+                    strings.savingsRemainingLabel(remainingLabel),
+                    style: theme.textTheme.bodySmall,
+                  ),
+                ),
+                const SizedBox(width: 12),
+                ElevatedButton.icon(
+                  onPressed: onContribute,
+                  icon: const Icon(Icons.savings_outlined),
+                  label: Text(strings.savingsContributeAction),
+                ),
+              ],
+            ),
+            if (goal.isArchived) ...<Widget>[
+              const SizedBox(height: 12),
+              Chip(label: Text(strings.savingsArchivedBadge)),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+enum _GoalAction { edit, archive }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -674,6 +674,10 @@
   "@homeNavAnalytics": {
     "description": "Bottom navigation label for analytics"
   },
+  "homeNavSavings": "Savings",
+  "@homeNavSavings": {
+    "description": "Bottom navigation label for savings"
+  },
   "homeNavSettings": "Settings",
   "@homeNavSettings": {
     "description": "Bottom navigation label for settings"
@@ -1304,6 +1308,133 @@
   "saveButtonLabel": "Save",
   "@saveButtonLabel": {
     "description": "Generic label for save buttons"
+  },
+  "savingsTitle": "Savings goals",
+  "@savingsTitle": {
+    "description": "Title for the savings goals screen"
+  },
+  "savingsAddGoalTitle": "New goal",
+  "@savingsAddGoalTitle": {
+    "description": "Title for the add savings goal screen"
+  },
+  "savingsEditGoalTitle": "Edit goal",
+  "@savingsEditGoalTitle": {
+    "description": "Title for the edit savings goal screen"
+  },
+  "savingsNameLabel": "Name",
+  "@savingsNameLabel": {
+    "description": "Label for the savings goal name field"
+  },
+  "savingsTargetLabel": "Target amount",
+  "@savingsTargetLabel": {
+    "description": "Label for the target amount field"
+  },
+  "savingsTargetHelper": "Enter the desired total amount",
+  "@savingsTargetHelper": {
+    "description": "Helper text for the target amount field"
+  },
+  "savingsNoteLabel": "Note",
+  "@savingsNoteLabel": {
+    "description": "Label for the optional goal note"
+  },
+  "savingsSaveGoalButton": "Save goal",
+  "@savingsSaveGoalButton": {
+    "description": "Primary action button for saving goal forms"
+  },
+  "savingsGoalSavedMessage": "Goal saved",
+  "@savingsGoalSavedMessage": {
+    "description": "Snackbar message when a goal is saved"
+  },
+  "savingsAddGoalButton": "Create goal",
+  "@savingsAddGoalButton": {
+    "description": "Call to action button on the empty state"
+  },
+  "savingsEmptyTitle": "Create your first savings goal",
+  "@savingsEmptyTitle": {
+    "description": "Headline for the empty savings state"
+  },
+  "savingsEmptyMessage": "Track progress towards your targets and stay motivated.",
+  "@savingsEmptyMessage": {
+    "description": "Supporting text for the empty savings state"
+  },
+  "savingsErrorTitle": "Unable to load savings goals",
+  "@savingsErrorTitle": {
+    "description": "Title for the savings error state"
+  },
+  "savingsRetryButton": "Try again",
+  "@savingsRetryButton": {
+    "description": "Retry button label for savings error state"
+  },
+  "savingsContributeAction": "Contribute",
+  "@savingsContributeAction": {
+    "description": "Label for contribute action button"
+  },
+  "savingsEditAction": "Edit",
+  "@savingsEditAction": {
+    "description": "Label for edit goal action"
+  },
+  "savingsArchiveAction": "Archive",
+  "@savingsArchiveAction": {
+    "description": "Label for archive goal action"
+  },
+  "savingsGoalArchivedMessage": "Goal \"{goal}\" archived",
+  "@savingsGoalArchivedMessage": {
+    "description": "Snackbar message shown after archiving a savings goal",
+    "placeholders": {
+      "goal": {
+        "type": "String"
+      }
+    }
+  },
+  "savingsArchivedBadge": "Archived",
+  "@savingsArchivedBadge": {
+    "description": "Badge label for archived goals"
+  },
+  "savingsRemainingLabel": "Remaining {amount}",
+  "@savingsRemainingLabel": {
+    "description": "Text showing remaining amount to reach target",
+    "placeholders": {
+      "amount": {
+        "type": "String"
+      }
+    }
+  },
+  "savingsShowArchivedToggle": "Show archived goals",
+  "@savingsShowArchivedToggle": {
+    "description": "Toggle label to show archived goals"
+  },
+  "savingsContributeTitle": "Contribute to {goal}",
+  "@savingsContributeTitle": {
+    "description": "Title for the contribute screen",
+    "placeholders": {
+      "goal": {
+        "type": "String"
+      }
+    }
+  },
+  "savingsAmountLabel": "Amount",
+  "@savingsAmountLabel": {
+    "description": "Label for contribution amount field"
+  },
+  "savingsSourceAccountLabel": "Source account",
+  "@savingsSourceAccountLabel": {
+    "description": "Label for the contribution account picker"
+  },
+  "savingsNoAccountOption": "No account",
+  "@savingsNoAccountOption": {
+    "description": "Dropdown option when no account is selected"
+  },
+  "savingsContributionNoteLabel": "Note (optional)",
+  "@savingsContributionNoteLabel": {
+    "description": "Label for the optional contribution note"
+  },
+  "savingsSubmitContributionButton": "Add contribution",
+  "@savingsSubmitContributionButton": {
+    "description": "Primary action button on contribute screen"
+  },
+  "savingsContributionSuccess": "Contribution added",
+  "@savingsContributionSuccess": {
+    "description": "Snackbar after adding a contribution"
   },
   "transactionDefaultTitle": "Transaction",
   "@transactionDefaultTitle": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1004,6 +1004,180 @@ abstract class AppLocalizations {
   /// **'Analytics'**
   String get homeNavAnalytics;
 
+  /// Bottom navigation label for savings
+  ///
+  /// In en, this message translates to:
+  /// **'Savings'**
+  String get homeNavSavings;
+
+  /// Title for the savings goals screen
+  ///
+  /// In en, this message translates to:
+  /// **'Savings goals'**
+  String get savingsTitle;
+
+  /// Title for the add savings goal screen
+  ///
+  /// In en, this message translates to:
+  /// **'New goal'**
+  String get savingsAddGoalTitle;
+
+  /// Title for the edit savings goal screen
+  ///
+  /// In en, this message translates to:
+  /// **'Edit goal'**
+  String get savingsEditGoalTitle;
+
+  /// Label for the savings goal name field
+  ///
+  /// In en, this message translates to:
+  /// **'Name'**
+  String get savingsNameLabel;
+
+  /// Label for the target amount field
+  ///
+  /// In en, this message translates to:
+  /// **'Target amount'**
+  String get savingsTargetLabel;
+
+  /// Helper text for the target amount field
+  ///
+  /// In en, this message translates to:
+  /// **'Enter the desired total amount'**
+  String get savingsTargetHelper;
+
+  /// Label for the optional goal note field
+  ///
+  /// In en, this message translates to:
+  /// **'Note'**
+  String get savingsNoteLabel;
+
+  /// Primary action button for saving goal forms
+  ///
+  /// In en, this message translates to:
+  /// **'Save goal'**
+  String get savingsSaveGoalButton;
+
+  /// Snackbar message after saving a goal
+  ///
+  /// In en, this message translates to:
+  /// **'Goal saved'**
+  String get savingsGoalSavedMessage;
+
+  /// Call to action button on the savings empty state
+  ///
+  /// In en, this message translates to:
+  /// **'Create goal'**
+  String get savingsAddGoalButton;
+
+  /// Headline for the empty savings state
+  ///
+  /// In en, this message translates to:
+  /// **'Create your first savings goal'**
+  String get savingsEmptyTitle;
+
+  /// Supporting text for the empty savings state
+  ///
+  /// In en, this message translates to:
+  /// **'Track progress towards your targets and stay motivated.'**
+  String get savingsEmptyMessage;
+
+  /// Title shown when savings goals fail to load
+  ///
+  /// In en, this message translates to:
+  /// **'Unable to load savings goals'**
+  String get savingsErrorTitle;
+
+  /// Retry button label on the savings error state
+  ///
+  /// In en, this message translates to:
+  /// **'Try again'**
+  String get savingsRetryButton;
+
+  /// Label for the contribute action button
+  ///
+  /// In en, this message translates to:
+  /// **'Contribute'**
+  String get savingsContributeAction;
+
+  /// Label for the edit action
+  ///
+  /// In en, this message translates to:
+  /// **'Edit'**
+  String get savingsEditAction;
+
+  /// Label for the archive action
+  ///
+  /// In en, this message translates to:
+  /// **'Archive'**
+  String get savingsArchiveAction;
+
+  /// Snackbar message after a goal has been archived
+  ///
+  /// In en, this message translates to:
+  /// **'Goal "{goal}" archived'**
+  String savingsGoalArchivedMessage(String goal);
+
+  /// Badge text for archived goals
+  ///
+  /// In en, this message translates to:
+  /// **'Archived'**
+  String get savingsArchivedBadge;
+
+  /// Text showing the remaining amount to reach the target
+  ///
+  /// In en, this message translates to:
+  /// **'Remaining {amount}'**
+  String savingsRemainingLabel(String amount);
+
+  /// Toggle label for showing archived goals
+  ///
+  /// In en, this message translates to:
+  /// **'Show archived goals'**
+  String get savingsShowArchivedToggle;
+
+  /// Title for the contribute screen
+  ///
+  /// In en, this message translates to:
+  /// **'Contribute to {goal}'**
+  String savingsContributeTitle(String goal);
+
+  /// Label for the contribution amount field
+  ///
+  /// In en, this message translates to:
+  /// **'Amount'**
+  String get savingsAmountLabel;
+
+  /// Label for the source account picker
+  ///
+  /// In en, this message translates to:
+  /// **'Source account'**
+  String get savingsSourceAccountLabel;
+
+  /// Option label when no account is selected
+  ///
+  /// In en, this message translates to:
+  /// **'No account'**
+  String get savingsNoAccountOption;
+
+  /// Label for the optional contribution note field
+  ///
+  /// In en, this message translates to:
+  /// **'Note (optional)'**
+  String get savingsContributionNoteLabel;
+
+  /// Primary action button on the contribute screen
+  ///
+  /// In en, this message translates to:
+  /// **'Add contribution'**
+  String get savingsSubmitContributionButton;
+
+  /// Snackbar message after a contribution succeeds
+  ///
+  /// In en, this message translates to:
+  /// **'Contribution added'**
+  String get savingsContributionSuccess;
+
   /// Bottom navigation label for settings
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -506,7 +506,95 @@ class AppLocalizationsEn extends AppLocalizations {
   String get homeNavAnalytics => 'Analytics';
 
   @override
+  String get homeNavSavings => 'Savings';
+
+  @override
   String get homeNavSettings => 'Settings';
+
+  @override
+  String get savingsTitle => 'Savings goals';
+
+  @override
+  String get savingsAddGoalTitle => 'New goal';
+
+  @override
+  String get savingsEditGoalTitle => 'Edit goal';
+
+  @override
+  String get savingsNameLabel => 'Name';
+
+  @override
+  String get savingsTargetLabel => 'Target amount';
+
+  @override
+  String get savingsTargetHelper => 'Enter the desired total amount';
+
+  @override
+  String get savingsNoteLabel => 'Note';
+
+  @override
+  String get savingsSaveGoalButton => 'Save goal';
+
+  @override
+  String get savingsGoalSavedMessage => 'Goal saved';
+
+  @override
+  String get savingsAddGoalButton => 'Create goal';
+
+  @override
+  String get savingsEmptyTitle => 'Create your first savings goal';
+
+  @override
+  String get savingsEmptyMessage =>
+      'Track progress towards your targets and stay motivated.';
+
+  @override
+  String get savingsErrorTitle => 'Unable to load savings goals';
+
+  @override
+  String get savingsRetryButton => 'Try again';
+
+  @override
+  String get savingsContributeAction => 'Contribute';
+
+  @override
+  String get savingsEditAction => 'Edit';
+
+  @override
+  String get savingsArchiveAction => 'Archive';
+
+  @override
+  String savingsGoalArchivedMessage(String goal) => 'Goal "$goal" archived';
+
+  @override
+  String get savingsArchivedBadge => 'Archived';
+
+  @override
+  String savingsRemainingLabel(String amount) => 'Remaining $amount';
+
+  @override
+  String get savingsShowArchivedToggle => 'Show archived goals';
+
+  @override
+  String savingsContributeTitle(String goal) => 'Contribute to $goal';
+
+  @override
+  String get savingsAmountLabel => 'Amount';
+
+  @override
+  String get savingsSourceAccountLabel => 'Source account';
+
+  @override
+  String get savingsNoAccountOption => 'No account';
+
+  @override
+  String get savingsContributionNoteLabel => 'Note (optional)';
+
+  @override
+  String get savingsSubmitContributionButton => 'Add contribution';
+
+  @override
+  String get savingsContributionSuccess => 'Contribution added';
 
   @override
   String get analyticsTitle => 'Analytics';

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -510,7 +510,95 @@ class AppLocalizationsRu extends AppLocalizations {
   String get homeNavAnalytics => 'Аналитика';
 
   @override
+  String get homeNavSavings => 'Накопления';
+
+  @override
   String get homeNavSettings => 'Настройки';
+
+  @override
+  String get savingsTitle => 'Цели по накоплениям';
+
+  @override
+  String get savingsAddGoalTitle => 'Новая цель';
+
+  @override
+  String get savingsEditGoalTitle => 'Редактирование цели';
+
+  @override
+  String get savingsNameLabel => 'Название';
+
+  @override
+  String get savingsTargetLabel => 'Целевая сумма';
+
+  @override
+  String get savingsTargetHelper => 'Введите желаемую сумму';
+
+  @override
+  String get savingsNoteLabel => 'Заметка';
+
+  @override
+  String get savingsSaveGoalButton => 'Сохранить цель';
+
+  @override
+  String get savingsGoalSavedMessage => 'Цель сохранена';
+
+  @override
+  String get savingsAddGoalButton => 'Создать цель';
+
+  @override
+  String get savingsEmptyTitle => 'Создайте первую цель';
+
+  @override
+  String get savingsEmptyMessage =>
+      'Отслеживайте прогресс и сохраняйте мотивацию.';
+
+  @override
+  String get savingsErrorTitle => 'Не удалось загрузить цели';
+
+  @override
+  String get savingsRetryButton => 'Повторить попытку';
+
+  @override
+  String get savingsContributeAction => 'Пополнить';
+
+  @override
+  String get savingsEditAction => 'Редактировать';
+
+  @override
+  String get savingsArchiveAction => 'Архивировать';
+
+  @override
+  String savingsGoalArchivedMessage(String goal) => 'Цель «$goal» архивирована';
+
+  @override
+  String get savingsArchivedBadge => 'В архиве';
+
+  @override
+  String savingsRemainingLabel(String amount) => 'Осталось $amount';
+
+  @override
+  String get savingsShowArchivedToggle => 'Показывать архивные цели';
+
+  @override
+  String savingsContributeTitle(String goal) => 'Пополнение цели «$goal»';
+
+  @override
+  String get savingsAmountLabel => 'Сумма';
+
+  @override
+  String get savingsSourceAccountLabel => 'Счёт списания';
+
+  @override
+  String get savingsNoAccountOption => 'Без счёта';
+
+  @override
+  String get savingsContributionNoteLabel => 'Заметка (необязательно)';
+
+  @override
+  String get savingsSubmitContributionButton => 'Добавить пополнение';
+
+  @override
+  String get savingsContributionSuccess => 'Пополнение добавлено';
 
   @override
   String get analyticsTitle => 'Аналитика';

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -674,6 +674,10 @@
   "@homeNavAnalytics": {
     "description": "Подпись для раздела аналитики"
   },
+  "homeNavSavings": "Накопления",
+  "@homeNavSavings": {
+    "description": "Подпись для раздела накоплений"
+  },
   "homeNavSettings": "Настройки",
   "@homeNavSettings": {
     "description": "Подпись для раздела настроек"
@@ -1304,6 +1308,133 @@
   "saveButtonLabel": "Сохранить",
   "@saveButtonLabel": {
     "description": "Общая подпись кнопки сохранения"
+  },
+  "savingsTitle": "Цели по накоплениям",
+  "@savingsTitle": {
+    "description": "Заголовок экрана накоплений"
+  },
+  "savingsAddGoalTitle": "Новая цель",
+  "@savingsAddGoalTitle": {
+    "description": "Заголовок экрана создания цели"
+  },
+  "savingsEditGoalTitle": "Редактирование цели",
+  "@savingsEditGoalTitle": {
+    "description": "Заголовок экрана редактирования цели"
+  },
+  "savingsNameLabel": "Название",
+  "@savingsNameLabel": {
+    "description": "Подпись поля названия цели"
+  },
+  "savingsTargetLabel": "Целевая сумма",
+  "@savingsTargetLabel": {
+    "description": "Подпись поля целевой суммы"
+  },
+  "savingsTargetHelper": "Введите желаемую сумму",
+  "@savingsTargetHelper": {
+    "description": "Подсказка для поля целевой суммы"
+  },
+  "savingsNoteLabel": "Заметка",
+  "@savingsNoteLabel": {
+    "description": "Подпись поля заметки"
+  },
+  "savingsSaveGoalButton": "Сохранить цель",
+  "@savingsSaveGoalButton": {
+    "description": "Кнопка сохранения цели"
+  },
+  "savingsGoalSavedMessage": "Цель сохранена",
+  "@savingsGoalSavedMessage": {
+    "description": "Сообщение после успешного сохранения"
+  },
+  "savingsAddGoalButton": "Создать цель",
+  "@savingsAddGoalButton": {
+    "description": "Кнопка создания цели в пустом состоянии"
+  },
+  "savingsEmptyTitle": "Создайте первую цель",
+  "@savingsEmptyTitle": {
+    "description": "Заголовок пустого состояния накоплений"
+  },
+  "savingsEmptyMessage": "Отслеживайте прогресс и сохраняйте мотивацию.",
+  "@savingsEmptyMessage": {
+    "description": "Описание пустого состояния накоплений"
+  },
+  "savingsErrorTitle": "Не удалось загрузить цели",
+  "@savingsErrorTitle": {
+    "description": "Заголовок экрана ошибки накоплений"
+  },
+  "savingsRetryButton": "Повторить попытку",
+  "@savingsRetryButton": {
+    "description": "Кнопка повторной загрузки целей"
+  },
+  "savingsContributeAction": "Пополнить",
+  "@savingsContributeAction": {
+    "description": "Подпись действия пополнения"
+  },
+  "savingsEditAction": "Редактировать",
+  "@savingsEditAction": {
+    "description": "Подпись действия редактирования"
+  },
+  "savingsArchiveAction": "Архивировать",
+  "@savingsArchiveAction": {
+    "description": "Подпись действия архивирования"
+  },
+  "savingsGoalArchivedMessage": "Цель «{goal}» архивирована",
+  "@savingsGoalArchivedMessage": {
+    "description": "Сообщение после архивации цели",
+    "placeholders": {
+      "goal": {
+        "type": "String"
+      }
+    }
+  },
+  "savingsArchivedBadge": "В архиве",
+  "@savingsArchivedBadge": {
+    "description": "Бейдж для архивных целей"
+  },
+  "savingsRemainingLabel": "Осталось {amount}",
+  "@savingsRemainingLabel": {
+    "description": "Текст с оставшейся суммой",
+    "placeholders": {
+      "amount": {
+        "type": "String"
+      }
+    }
+  },
+  "savingsShowArchivedToggle": "Показывать архивные цели",
+  "@savingsShowArchivedToggle": {
+    "description": "Переключатель отображения архивных целей"
+  },
+  "savingsContributeTitle": "Пополнение цели «{goal}»",
+  "@savingsContributeTitle": {
+    "description": "Заголовок экрана пополнения",
+    "placeholders": {
+      "goal": {
+        "type": "String"
+      }
+    }
+  },
+  "savingsAmountLabel": "Сумма",
+  "@savingsAmountLabel": {
+    "description": "Подпись поля суммы пополнения"
+  },
+  "savingsSourceAccountLabel": "Счёт списания",
+  "@savingsSourceAccountLabel": {
+    "description": "Подпись поля выбора счёта"
+  },
+  "savingsNoAccountOption": "Без счёта",
+  "@savingsNoAccountOption": {
+    "description": "Опция выбора без счёта"
+  },
+  "savingsContributionNoteLabel": "Заметка (необязательно)",
+  "@savingsContributionNoteLabel": {
+    "description": "Подпись поля заметки при пополнении"
+  },
+  "savingsSubmitContributionButton": "Добавить пополнение",
+  "@savingsSubmitContributionButton": {
+    "description": "Кнопка отправки пополнения"
+  },
+  "savingsContributionSuccess": "Пополнение добавлено",
+  "@savingsContributionSuccess": {
+    "description": "Сообщение после успешного пополнения"
   },
   "transactionDefaultTitle": "Транзакция",
   "@transactionDefaultTitle": {

--- a/test/core/services/auth_sync_service_test.dart
+++ b/test/core/services/auth_sync_service_test.dart
@@ -26,6 +26,8 @@ import 'package:kopim/features/profile/data/remote/profile_remote_data_source.da
 import 'package:kopim/features/profile/domain/entities/auth_user.dart';
 import 'package:kopim/features/profile/domain/entities/profile.dart';
 import 'package:kopim/features/profile/domain/failures/auth_failure.dart';
+import 'package:kopim/features/savings/data/sources/local/saving_goal_dao.dart';
+import 'package:kopim/features/savings/data/sources/remote/saving_goal_remote_data_source.dart';
 import 'package:kopim/features/transactions/data/sources/local/transaction_dao.dart';
 import 'package:kopim/features/transactions/data/sources/remote/transaction_remote_data_source.dart';
 import 'package:mocktail/mocktail.dart';
@@ -55,17 +57,20 @@ void main() {
   late TransactionDao transactionDao;
   late BudgetDao budgetDao;
   late BudgetInstanceDao budgetInstanceDao;
+  late SavingGoalDao savingGoalDao;
   late ProfileDao profileDao;
   late FirebaseFirestore firestore;
   late MockLoggerService logger;
   late MockAnalyticsService analytics;
   late BudgetRemoteDataSource budgetRemote;
   late BudgetInstanceRemoteDataSource budgetInstanceRemote;
+  late SavingGoalRemoteDataSource savingGoalRemote;
 
   AuthSyncService buildService({
     AccountRemoteDataSource? accountRemoteDataSource,
     BudgetRemoteDataSource? budgetRemoteDataSource,
     BudgetInstanceRemoteDataSource? budgetInstanceRemoteDataSource,
+    SavingGoalRemoteDataSource? savingGoalRemoteDataSource,
   }) {
     return AuthSyncService(
       database: database,
@@ -75,6 +80,7 @@ void main() {
       transactionDao: transactionDao,
       budgetDao: budgetDao,
       budgetInstanceDao: budgetInstanceDao,
+      savingGoalDao: savingGoalDao,
       profileDao: profileDao,
       accountRemoteDataSource:
           accountRemoteDataSource ?? AccountRemoteDataSource(firestore),
@@ -83,6 +89,8 @@ void main() {
       budgetRemoteDataSource: budgetRemoteDataSource ?? budgetRemote,
       budgetInstanceRemoteDataSource:
           budgetInstanceRemoteDataSource ?? budgetInstanceRemote,
+      savingGoalRemoteDataSource:
+          savingGoalRemoteDataSource ?? savingGoalRemote,
       profileRemoteDataSource: ProfileRemoteDataSource(firestore),
       firestore: firestore,
       loggerService: logger,
@@ -105,12 +113,14 @@ void main() {
     transactionDao = TransactionDao(database);
     budgetDao = BudgetDao(database);
     budgetInstanceDao = BudgetInstanceDao(database);
+    savingGoalDao = SavingGoalDao(database);
     profileDao = ProfileDao(database);
     firestore = FakeFirebaseFirestore();
     logger = MockLoggerService();
     analytics = MockAnalyticsService();
     budgetRemote = BudgetRemoteDataSource(firestore);
     budgetInstanceRemote = BudgetInstanceRemoteDataSource(firestore);
+    savingGoalRemote = SavingGoalRemoteDataSource(firestore);
 
     when(() => analytics.logEvent(any(), any())).thenAnswer((_) async {});
     when(() => analytics.reportError(any(), any())).thenReturn(null);

--- a/test/core/services/sync_service_profile_test.dart
+++ b/test/core/services/sync_service_profile_test.dart
@@ -19,6 +19,7 @@ import 'package:kopim/features/profile/data/local/profile_dao.dart';
 import 'package:kopim/features/profile/data/profile_repository_impl.dart';
 import 'package:kopim/features/profile/data/remote/profile_remote_data_source.dart';
 import 'package:kopim/features/profile/domain/entities/profile.dart';
+import 'package:kopim/features/savings/data/sources/remote/saving_goal_remote_data_source.dart';
 import 'package:kopim/features/transactions/data/sources/remote/transaction_remote_data_source.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -84,6 +85,7 @@ void main() {
       transactionRemoteDataSource: TransactionRemoteDataSource(firestore),
       budgetRemoteDataSource: BudgetRemoteDataSource(firestore),
       budgetInstanceRemoteDataSource: BudgetInstanceRemoteDataSource(firestore),
+      savingGoalRemoteDataSource: SavingGoalRemoteDataSource(firestore),
       profileRemoteDataSource: profileRemote,
       firebaseAuth: firebaseAuth,
       connectivity: connectivity,

--- a/test/features/app_shell/presentation/main_navigation_shell_test.dart
+++ b/test/features/app_shell/presentation/main_navigation_shell_test.dart
@@ -25,6 +25,11 @@ import 'package:kopim/features/home/domain/models/upcoming_payment.dart';
 import 'package:kopim/features/profile/domain/entities/auth_user.dart';
 import 'package:kopim/features/profile/presentation/controllers/auth_controller.dart';
 import 'package:kopim/features/profile/presentation/screens/general_settings_screen.dart';
+import 'package:kopim/features/savings/domain/entities/saving_goal.dart';
+import 'package:kopim/features/savings/domain/repositories/saving_goal_repository.dart';
+import 'package:kopim/features/savings/domain/use_cases/archive_saving_goal_use_case.dart';
+import 'package:kopim/features/savings/domain/use_cases/get_saving_goals_use_case.dart';
+import 'package:kopim/features/savings/domain/use_cases/watch_saving_goals_use_case.dart';
 import 'package:kopim/features/recurring_transactions/domain/entities/recurring_rule.dart';
 import 'package:kopim/features/transactions/domain/entities/transaction.dart';
 import 'package:kopim/features/transactions/domain/repositories/transaction_repository.dart';
@@ -114,6 +119,38 @@ class _StreamCategoryRepository implements CategoryRepository {
   Future<void> upsert(Category category) => throw UnimplementedError();
 }
 
+class _FakeSavingGoalRepository implements SavingGoalRepository {
+  const _FakeSavingGoalRepository();
+
+  @override
+  Future<void> addContribution({
+    required SavingGoal updatedGoal,
+    required int contributionAmount,
+    String? sourceAccountId,
+    String? contributionNote,
+  }) async {}
+
+  @override
+  Future<void> archive(String goalId, DateTime archivedAt) async {}
+
+  @override
+  Future<void> create(SavingGoal goal) async {}
+
+  @override
+  Future<SavingGoal?> findById(String id) async => null;
+
+  @override
+  Future<List<SavingGoal>> loadGoals({required bool includeArchived}) async =>
+      const <SavingGoal>[];
+
+  @override
+  Future<void> update(SavingGoal goal) async {}
+
+  @override
+  Stream<List<SavingGoal>> watchGoals({required bool includeArchived}) =>
+      Stream<List<SavingGoal>>.value(const <SavingGoal>[]);
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -136,6 +173,8 @@ void main() {
         _StreamTransactionRepository(
           Stream<List<TransactionEntity>>.value(const <TransactionEntity>[]),
         );
+    const _FakeSavingGoalRepository savingGoalRepository =
+        _FakeSavingGoalRepository();
 
     return ProviderScope(
       // ignore: always_specify_types, the Override type is internal to riverpod
@@ -202,6 +241,16 @@ void main() {
         ),
         computeBudgetProgressUseCaseProvider.overrideWithValue(
           ComputeBudgetProgressUseCase(),
+        ),
+        savingGoalRepositoryProvider.overrideWithValue(savingGoalRepository),
+        watchSavingGoalsUseCaseProvider.overrideWithValue(
+          WatchSavingGoalsUseCase(repository: savingGoalRepository),
+        ),
+        getSavingGoalsUseCaseProvider.overrideWithValue(
+          GetSavingGoalsUseCase(repository: savingGoalRepository),
+        ),
+        archiveSavingGoalUseCaseProvider.overrideWithValue(
+          ArchiveSavingGoalUseCase(repository: savingGoalRepository),
         ),
         budgetsWithProgressProvider.overrideWith(
           (Ref ref) =>

--- a/test/features/savings/data/saving_goal_dao_test.dart
+++ b/test/features/savings/data/saving_goal_dao_test.dart
@@ -1,0 +1,90 @@
+import 'package:drift/drift.dart' show DatabaseConnection;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kopim/core/data/database.dart';
+import 'package:kopim/features/savings/data/sources/local/saving_goal_dao.dart';
+import 'package:kopim/features/savings/domain/entities/saving_goal.dart';
+
+SavingGoal _goal({
+  required String id,
+  required DateTime createdAt,
+  required DateTime updatedAt,
+  int target = 1000,
+  int current = 0,
+  DateTime? archivedAt,
+}) {
+  return SavingGoal(
+    id: id,
+    userId: 'user-1',
+    name: 'Goal $id',
+    targetAmount: target,
+    currentAmount: current,
+    createdAt: createdAt,
+    updatedAt: updatedAt,
+    archivedAt: archivedAt,
+  );
+}
+
+void main() {
+  late AppDatabase database;
+  late SavingGoalDao dao;
+  final DateTime now = DateTime.utc(2024, 1, 1);
+
+  setUp(() {
+    database = AppDatabase.connect(DatabaseConnection(NativeDatabase.memory()));
+    dao = SavingGoalDao(database);
+  });
+
+  tearDown(() async {
+    await database.close();
+  });
+
+  test('getGoals returns active goals ordered by updatedAt desc', () async {
+    final SavingGoal older = _goal(
+      id: 'goal-1',
+      createdAt: now,
+      updatedAt: now,
+    );
+    final SavingGoal newer = _goal(
+      id: 'goal-2',
+      createdAt: now,
+      updatedAt: now.add(const Duration(days: 1)),
+    );
+
+    await dao.upsert(older);
+    await dao.upsert(newer);
+
+    final List<SavingGoal> results = await dao.getGoals(includeArchived: false);
+
+    expect(results, hasLength(2));
+    expect(results.first.id, 'goal-2');
+    expect(results.last.id, 'goal-1');
+  });
+
+  test('archive marks goal and hides it from active list', () async {
+    final DateTime createdAt = now;
+    final SavingGoal goal = _goal(
+      id: 'goal-archive',
+      createdAt: createdAt,
+      updatedAt: createdAt,
+    );
+    await dao.upsert(goal);
+
+    final DateTime archivedAt = now.add(const Duration(hours: 4));
+    await dao.archive(goal.id, archivedAt);
+
+    final SavingGoal? stored = await dao.findById(goal.id);
+    expect(stored, isNotNull);
+    expect(stored!.isArchived, isTrue);
+    expect(stored.archivedAt, isNotNull);
+    expect(stored.archivedAt!.isAtSameMomentAs(archivedAt), isTrue);
+    expect(stored.updatedAt.isAtSameMomentAs(archivedAt), isTrue);
+
+    final List<SavingGoal> active = await dao.getGoals(includeArchived: false);
+    expect(active, isEmpty);
+
+    final List<SavingGoal> all = await dao.getGoals(includeArchived: true);
+    expect(all, hasLength(1));
+    expect(all.single.id, goal.id);
+  });
+}

--- a/test/features/savings/domain/use_cases/add_contribution_use_case_test.dart
+++ b/test/features/savings/domain/use_cases/add_contribution_use_case_test.dart
@@ -1,0 +1,170 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kopim/features/savings/domain/entities/saving_goal.dart';
+import 'package:kopim/features/savings/domain/repositories/saving_goal_repository.dart';
+import 'package:kopim/features/savings/domain/use_cases/add_contribution_use_case.dart';
+import 'package:kopim/features/savings/domain/value_objects/money.dart';
+import 'package:kopim/features/transactions/domain/entities/add_transaction_request.dart';
+import 'package:kopim/features/transactions/domain/entities/transaction_type.dart';
+import 'package:kopim/features/transactions/domain/use_cases/add_transaction_use_case.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockSavingGoalRepository extends Mock implements SavingGoalRepository {}
+
+class _MockAddTransactionUseCase extends Mock
+    implements AddTransactionUseCase {}
+
+SavingGoal _buildGoal({
+  int current = 0,
+  int target = 1000,
+  DateTime? archivedAt,
+}) {
+  final DateTime now = DateTime.utc(2024, 1, 1);
+  return SavingGoal(
+    id: 'goal-1',
+    userId: 'user-1',
+    name: 'Vacation',
+    targetAmount: target,
+    currentAmount: current,
+    createdAt: now,
+    updatedAt: now,
+    archivedAt: archivedAt,
+  );
+}
+
+AddTransactionRequest _dummyRequest() => AddTransactionRequest(
+  accountId: 'acc',
+  amount: 1,
+  date: DateTime.utc(2024),
+);
+
+void main() {
+  late _MockSavingGoalRepository repository;
+  late _MockAddTransactionUseCase addTransactionUseCase;
+  late AddContributionUseCase useCase;
+  final DateTime fixedNow = DateTime.utc(2024, 7, 1, 9);
+
+  setUpAll(() {
+    registerFallbackValue(_buildGoal());
+    registerFallbackValue(_dummyRequest());
+  });
+
+  setUp(() {
+    repository = _MockSavingGoalRepository();
+    addTransactionUseCase = _MockAddTransactionUseCase();
+    useCase = AddContributionUseCase(
+      repository: repository,
+      addTransactionUseCase: addTransactionUseCase,
+      clock: () => fixedNow,
+    );
+    when(() => addTransactionUseCase(any())).thenAnswer((_) async {});
+    when(
+      () => repository.addContribution(
+        updatedGoal: any(named: 'updatedGoal'),
+        contributionAmount: any(named: 'contributionAmount'),
+        sourceAccountId: any(named: 'sourceAccountId'),
+        contributionNote: any(named: 'contributionNote'),
+      ),
+    ).thenAnswer((_) async {});
+  });
+
+  test('adds contribution, caps at target and posts transaction', () async {
+    when(
+      () => repository.findById('goal-1'),
+    ).thenAnswer((_) async => _buildGoal(current: 800, target: 1000));
+
+    final SavingGoal updated = await useCase(
+      goalId: 'goal-1',
+      amount: Money.fromMinorUnits(300),
+      sourceAccountId: 'acc-1',
+      note: '  Keep going  ',
+    );
+
+    expect(updated.currentAmount, 1000);
+    expect(updated.updatedAt, fixedNow);
+
+    final VerificationResult repoCall = verify(
+      () => repository.addContribution(
+        updatedGoal: captureAny(named: 'updatedGoal'),
+        contributionAmount: 200,
+        sourceAccountId: 'acc-1',
+        contributionNote: 'Keep going',
+      ),
+    );
+    repoCall.called(1);
+    final SavingGoal persisted = repoCall.captured.single as SavingGoal;
+    expect(persisted.currentAmount, 1000);
+    expect(persisted.updatedAt, fixedNow);
+
+    final VerificationResult txCall = verify(
+      () => addTransactionUseCase(captureAny()),
+    );
+    txCall.called(1);
+    final AddTransactionRequest request =
+        txCall.captured.single as AddTransactionRequest;
+    expect(request.accountId, 'acc-1');
+    expect(request.categoryId, AddContributionUseCase.savingsCategoryId);
+    expect(request.amount, Money.fromMinorUnits(300).toDouble());
+    expect(request.note, 'Savings: Vacation — Keep going');
+    expect(request.type, TransactionType.expense);
+  });
+
+  test('skips transaction when source account not provided', () async {
+    when(
+      () => repository.findById('goal-1'),
+    ).thenAnswer((_) async => _buildGoal(current: 200, target: 500));
+
+    final SavingGoal updated = await useCase(
+      goalId: 'goal-1',
+      amount: Money.fromMinorUnits(200),
+    );
+
+    expect(updated.currentAmount, 400);
+    verifyNever(() => addTransactionUseCase(any()));
+    verify(
+      () => repository.addContribution(
+        updatedGoal: any(named: 'updatedGoal'),
+        contributionAmount: 200,
+        sourceAccountId: null,
+        contributionNote: null,
+      ),
+    ).called(1);
+  });
+
+  test('throws when goal is archived', () async {
+    when(
+      () => repository.findById('goal-1'),
+    ).thenAnswer((_) async => _buildGoal(archivedAt: DateTime.utc(2024, 1, 2)));
+
+    expect(
+      () => useCase(goalId: 'goal-1', amount: Money.fromMinorUnits(100)),
+      throwsStateError,
+    );
+  });
+
+  test('throws when goal already reached its target', () async {
+    when(
+      () => repository.findById('goal-1'),
+    ).thenAnswer((_) async => _buildGoal(current: 1000, target: 1000));
+
+    expect(
+      () => useCase(goalId: 'goal-1', amount: Money.fromMinorUnits(100)),
+      throwsStateError,
+    );
+  });
+
+  test('throws when goal cannot be found', () async {
+    when(() => repository.findById('missing')).thenAnswer((_) async => null);
+
+    expect(
+      () => useCase(goalId: 'missing', amount: Money.fromMinorUnits(50)),
+      throwsStateError,
+    );
+  });
+
+  test('throws when contribution amount is not positive', () async {
+    expect(
+      () => useCase(goalId: 'goal-1', amount: Money.fromMinorUnits(0)),
+      throwsArgumentError,
+    );
+  });
+}

--- a/test/features/savings/domain/use_cases/create_saving_goal_use_case_test.dart
+++ b/test/features/savings/domain/use_cases/create_saving_goal_use_case_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kopim/features/profile/domain/entities/auth_user.dart';
+import 'package:kopim/features/profile/domain/repositories/auth_repository.dart';
+import 'package:kopim/features/savings/domain/entities/saving_goal.dart';
+import 'package:kopim/features/savings/domain/repositories/saving_goal_repository.dart';
+import 'package:kopim/features/savings/domain/use_cases/create_saving_goal_use_case.dart';
+import 'package:kopim/features/savings/domain/value_objects/money.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:uuid/uuid.dart';
+
+class _MockSavingGoalRepository extends Mock implements SavingGoalRepository {}
+
+class _MockAuthRepository extends Mock implements AuthRepository {}
+
+SavingGoal _dummyGoal() {
+  final DateTime now = DateTime.utc(2024, 1, 1);
+  return SavingGoal(
+    id: 'dummy',
+    userId: 'user',
+    name: 'Sample',
+    targetAmount: 100,
+    currentAmount: 0,
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+void main() {
+  late _MockSavingGoalRepository repository;
+  late _MockAuthRepository authRepository;
+  late CreateSavingGoalUseCase useCase;
+  final DateTime fixedNow = DateTime.utc(2024, 4, 5, 12);
+
+  setUpAll(() {
+    registerFallbackValue(_dummyGoal());
+  });
+
+  setUp(() {
+    repository = _MockSavingGoalRepository();
+    authRepository = _MockAuthRepository();
+    useCase = CreateSavingGoalUseCase(
+      repository: repository,
+      authRepository: authRepository,
+      uuidGenerator: const Uuid(),
+      clock: () => fixedNow,
+    );
+    when(() => repository.create(any())).thenAnswer((_) async {});
+    when(
+      () => authRepository.currentUser,
+    ).thenReturn(const AuthUser(uid: 'user-1'));
+  });
+
+  test(
+    'creates goal with trimmed values and delegates to repository',
+    () async {
+      final SavingGoal result = await useCase(
+        name: '  Vacation  ',
+        target: Money.fromMinorUnits(5000),
+        note: '  Beach house  ',
+      );
+
+      expect(result.name, 'Vacation');
+      expect(result.note, 'Beach house');
+      expect(result.targetAmount, 5000);
+      expect(result.createdAt, fixedNow);
+      expect(result.updatedAt, fixedNow);
+
+      final VerificationResult verification = verify(
+        () => repository.create(captureAny()),
+      );
+      verification.called(1);
+      final SavingGoal persisted = verification.captured.single as SavingGoal;
+      expect(persisted.userId, 'user-1');
+      expect(persisted.name, 'Vacation');
+      expect(persisted.note, 'Beach house');
+    },
+  );
+
+  test('throws when target amount is not positive', () async {
+    expect(
+      () => useCase(name: 'Trip', target: Money.fromMinorUnits(0)),
+      throwsArgumentError,
+    );
+  });
+
+  test('throws when no authenticated user available', () async {
+    when(() => authRepository.currentUser).thenReturn(null);
+
+    expect(
+      () => useCase(name: 'Trip', target: Money.fromMinorUnits(1000)),
+      throwsStateError,
+    );
+  });
+}

--- a/test/features/savings/domain/use_cases/update_saving_goal_use_case_test.dart
+++ b/test/features/savings/domain/use_cases/update_saving_goal_use_case_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kopim/features/savings/domain/entities/saving_goal.dart';
+import 'package:kopim/features/savings/domain/repositories/saving_goal_repository.dart';
+import 'package:kopim/features/savings/domain/use_cases/update_saving_goal_use_case.dart';
+import 'package:kopim/features/savings/domain/value_objects/money.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockSavingGoalRepository extends Mock implements SavingGoalRepository {}
+
+SavingGoal _goal() {
+  final DateTime now = DateTime.utc(2024, 1, 1);
+  return SavingGoal(
+    id: 'goal',
+    userId: 'user-1',
+    name: 'Old name',
+    targetAmount: 2000,
+    currentAmount: 500,
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+void main() {
+  late _MockSavingGoalRepository repository;
+  late UpdateSavingGoalUseCase useCase;
+  final DateTime fixedNow = DateTime.utc(2024, 6, 1, 10);
+
+  setUpAll(() {
+    registerFallbackValue(_goal());
+  });
+
+  setUp(() {
+    repository = _MockSavingGoalRepository();
+    useCase = UpdateSavingGoalUseCase(
+      repository: repository,
+      clock: () => fixedNow,
+    );
+    when(() => repository.update(any())).thenAnswer((_) async {});
+  });
+
+  test('updates goal with trimmed fields', () async {
+    final SavingGoal updated = await useCase(
+      goal: _goal(),
+      name: '  New name  ',
+      target: Money.fromMinorUnits(2500),
+      note: '  Focus on flights  ',
+    );
+
+    expect(updated.name, 'New name');
+    expect(updated.targetAmount, 2500);
+    expect(updated.note, 'Focus on flights');
+    expect(updated.updatedAt, fixedNow);
+
+    verify(() => repository.update(updated)).called(1);
+  });
+
+  test('throws when new target is not positive', () async {
+    expect(
+      () => useCase(goal: _goal(), target: Money.fromMinorUnits(0)),
+      throwsArgumentError,
+    );
+  });
+
+  test('throws when current amount exceeds new target', () async {
+    final SavingGoal goal = _goal();
+    expect(
+      () => useCase(
+        goal: goal,
+        target: Money.fromMinorUnits(goal.currentAmount - 10),
+      ),
+      throwsStateError,
+    );
+  });
+}

--- a/test/features/savings/domain/value_objects/goal_progress_test.dart
+++ b/test/features/savings/domain/value_objects/goal_progress_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kopim/features/savings/domain/entities/saving_goal.dart';
+import 'package:kopim/features/savings/domain/value_objects/goal_progress.dart';
+
+SavingGoal _buildGoal({required int target, required int current}) {
+  final DateTime now = DateTime.utc(2024, 1, 1);
+  return SavingGoal(
+    id: 'goal-1',
+    userId: 'user-1',
+    name: 'Vacation',
+    targetAmount: target,
+    currentAmount: current,
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+void main() {
+  group('GoalProgress', () {
+    test('computes remaining amount and percent for partial progress', () {
+      final SavingGoal goal = _buildGoal(target: 1000, current: 250);
+      final GoalProgress progress = GoalProgress.fromGoal(goal);
+
+      expect(progress.remaining.minorUnits, 750);
+      expect(progress.percent, closeTo(0.25, 0.0001));
+    });
+
+    test('clamps percent when current amount exceeds target', () {
+      final SavingGoal goal = _buildGoal(target: 500, current: 800);
+      final GoalProgress progress = GoalProgress.fromGoal(goal);
+
+      expect(progress.percent, 1);
+      expect(progress.remaining.minorUnits, 0);
+    });
+  });
+}

--- a/test/features/savings/domain/value_objects/money_test.dart
+++ b/test/features/savings/domain/value_objects/money_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kopim/features/savings/domain/value_objects/money.dart';
+
+void main() {
+  group('Money', () {
+    test('fromMinorUnits clamps negative values to zero', () {
+      final Money money = Money.fromMinorUnits(-250);
+      expect(money.minorUnits, 0);
+    });
+
+    test('fromDouble converts value using fraction digits', () {
+      final Money money = Money.fromDouble(12.345, fractionDigits: 2);
+      expect(money.minorUnits, 1235);
+    });
+
+    test('toDouble returns normalized value', () {
+      final Money money = Money.fromMinorUnits(990);
+      expect(money.toDouble(), 9.9);
+    });
+
+    test('addition and subtraction operate on minor units', () {
+      final Money left = Money.fromMinorUnits(500);
+      final Money right = Money.fromMinorUnits(125);
+
+      expect((left + right).minorUnits, 625);
+      expect((left - right).minorUnits, 375);
+    });
+  });
+}


### PR DESCRIPTION
## Описание
- реализован доменный слой накоплений: сущность цели, value-объекты денег и прогресса, сценарии создания, обновления, архивации и пополнений
- добавлены DAO, репозиторий и удалённый источник с синхронизацией Drift ↔ Firestore и интеграцией в AuthSyncService/DI
- создан UI модуль накоплений с вкладкой в нижней навигации, экранами списка, редактирования и пополнения, локализациями и тестами

## Тестирование
- `dart format --set-exit-if-changed .`
- `flutter analyze`
- `dart run build_runner build --delete-conflicting-outputs`
- `flutter test --reporter expanded`
- `flutter pub outdated`


------
https://chatgpt.com/codex/tasks/task_e_68e21e4d88a0832eac70697a609f5211