### PR TITLE
Локализация заметок накоплений и удаление неиспользуемых зависимостей

### DIFF
--- a/lib/features/savings/data/repositories/saving_goal_repository_impl.dart
+++ b/lib/features/savings/data/repositories/saving_goal_repository_impl.dart
@@ -274,10 +274,10 @@ class SavingGoalRepositoryImpl implements SavingGoalRepository {
         });
     final String logNote =
         contributionNote != null && contributionNote.isNotEmpty
-        ? ' with note $contributionNote'
+        ? ' с заметкой $contributionNote'
         : '';
     _logger.logInfo(
-      'Contribution added to ${persisted.id} for $appliedDelta$logNote',
+      'Добавлен взнос в ${persisted.id} на сумму $appliedDelta$logNote',
     );
     return persisted;
   }
@@ -335,7 +335,7 @@ class SavingGoalRepositoryImpl implements SavingGoalRepository {
   }
 
   String _composeContributionNote(String goalName, String? note) {
-    final String base = 'Savings: $goalName';
+    final String base = 'Накопление: $goalName';
     if (note == null || note.isEmpty) {
       return base;
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,11 +54,9 @@ dependencies:
 
   # Additional from user
   go_router: ^16.2.4
-  synquill: ^0.6.0
   connectivity_plus: ^7.0.0
   workmanager: ^0.9.0+3
   flutter_local_notifications: ^19.4.2
-  google_generative_ai: ^0.4.7
   uuid: ^4.5.1
   phosphor_flutter: ^2.1.0
   rrule: ^0.2.17

--- a/test/features/savings/data/saving_goal_repository_impl_test.dart
+++ b/test/features/savings/data/saving_goal_repository_impl_test.dart
@@ -147,7 +147,7 @@ void main() {
               .getSingleOrNull();
       expect(txRow, isNotNull);
       expect(txRow!.amount, closeTo(-25.0, 1e-9));
-      expect(txRow.note, 'Savings: Emergency Fund — Initial boost');
+      expect(txRow.note, 'Накопление: Emergency Fund — Initial boost');
 
       final db.CategoryRow? category =
           await (database.select(database.categories)..where(


### PR DESCRIPTION
## Описание
- перевёл автоматически формируемые заметки по взносам в накопления на русский язык и обновил лог-сообщения
- удалил неиспользуемые зависимости synquill и google_generative_ai из pubspec.yaml
- подкорректировал тест репозитория накоплений под новое сообщение

## Тестирование
- dart format --set-exit-if-changed .
- flutter analyze
- dart run build_runner build --delete-conflicting-outputs
- flutter test --reporter expanded
- flutter pub outdated

------
https://chatgpt.com/codex/tasks/task_e_68e263a7d370832e8f552b100e3d9ad2