### PR TITLE
Добавлен офлайн-вход на экране авторизации

### DIFF
--- a/lib/features/profile/presentation/controllers/auth_controller.g.dart
+++ b/lib/features/profile/presentation/controllers/auth_controller.g.dart
@@ -33,7 +33,7 @@ final class AuthControllerProvider
   AuthController create() => AuthController();
 }
 
-String _$authControllerHash() => r'd89e74d88f9fef983bcc9d60abd3b00ea679d319';
+String _$authControllerHash() => r'6f74072c7f83de7b3c982d673088732779b8eac6';
 
 abstract class _$AuthController extends $AsyncNotifier<AuthUser?> {
   FutureOr<AuthUser?> build();

--- a/lib/features/profile/presentation/controllers/sign_in_form_controller.dart
+++ b/lib/features/profile/presentation/controllers/sign_in_form_controller.dart
@@ -89,6 +89,25 @@ class SignInFormController extends _$SignInFormController {
     }
   }
 
+  Future<void> continueOffline() async {
+    state = state.copyWith(isSubmitting: true, errorMessage: null);
+    try {
+      await ref.read(authControllerProvider.notifier).continueWithOfflineMode();
+
+      if (!ref.mounted) return;
+      state = state.copyWith(isSubmitting: false);
+    } on AuthFailure catch (error) {
+      if (!ref.mounted) return;
+      state = state.copyWith(isSubmitting: false, errorMessage: error.message);
+    } catch (_) {
+      if (!ref.mounted) return;
+      state = state.copyWith(
+        isSubmitting: false,
+        errorMessage: AuthFailure.unknown().message,
+      );
+    }
+  }
+
   void clearError() {
     if (state.errorMessage != null) {
       state = state.copyWith(errorMessage: null);

--- a/lib/features/profile/presentation/controllers/sign_in_form_controller.g.dart
+++ b/lib/features/profile/presentation/controllers/sign_in_form_controller.g.dart
@@ -42,7 +42,7 @@ final class SignInFormControllerProvider
 }
 
 String _$signInFormControllerHash() =>
-    r'3d4794d96129d7a5b35ce62dd8f1996818ca5bef';
+    r'94a97969a0d59f0f11f0864d8ea23607551c4447';
 
 abstract class _$SignInFormController extends $Notifier<SignInFormState> {
   SignInFormState build();

--- a/lib/features/profile/presentation/screens/sign_in_screen.dart
+++ b/lib/features/profile/presentation/screens/sign_in_screen.dart
@@ -201,6 +201,14 @@ class _SignInScreenState extends ConsumerState<SignInScreen> {
                     icon: const Icon(Icons.login),
                     label: Text(strings.signInGoogleCta),
                   ),
+                  const SizedBox(height: 12),
+                  TextButton.icon(
+                    onPressed: formState.isSubmitting
+                        ? null
+                        : () => controller.continueOffline(),
+                    icon: const Icon(Icons.wifi_off),
+                    label: Text(strings.signInOfflineCta),
+                  ),
                 ],
               ),
             ),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -497,6 +497,10 @@
   "@signInGoogleCta": {
     "description": "Button label for Google sign in"
   },
+  "signInOfflineCta": "Work offline",
+  "@signInOfflineCta": {
+    "description": "Button label for starting the app without an account"
+  },
   "signInError": "Could not sign in. Please try again.",
   "@signInError": {
     "description": "Fallback message when sign in fails"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -806,6 +806,12 @@ abstract class AppLocalizations {
   /// **'Continue with Google'**
   String get signInGoogleCta;
 
+  /// Button label for starting the app without an account
+  ///
+  /// In en, this message translates to:
+  /// **'Work offline'**
+  String get signInOfflineCta;
+
   /// Fallback message when sign in fails
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -379,6 +379,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get signInGoogleCta => 'Continue with Google';
 
   @override
+  String get signInOfflineCta => 'Work offline';
+
+  @override
   String get signInError => 'Could not sign in. Please try again.';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -381,6 +381,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get signInGoogleCta => 'Продолжить с Google';
 
   @override
+  String get signInOfflineCta => 'Войти без учетной записи';
+
+  @override
   String get signInError => 'Не удалось выполнить вход. Попробуйте еще раз.';
 
   @override

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -497,6 +497,10 @@
   "@signInGoogleCta": {
     "description": "Кнопка входа через Google"
   },
+  "signInOfflineCta": "Войти без учетной записи",
+  "@signInOfflineCta": {
+    "description": "Кнопка перехода в офлайн-режим без аккаунта"
+  },
   "signInError": "Не удалось выполнить вход. Попробуйте еще раз.",
   "@signInError": {
     "description": "Резервное сообщение об ошибке входа"


### PR DESCRIPTION
## Описание
- добавлена кнопка офлайн-режима на экране входа и локализованные строки
- улучшена обработка ошибок при неудачной авторизации и добавлены unit-тесты для контроллера

## Тестирование
- dart format --set-exit-if-changed .
- flutter analyze
- dart run build_runner build --delete-conflicting-outputs
- flutter test --reporter expanded
- flutter pub outdated

------
https://chatgpt.com/codex/tasks/task_e_68e29ba19de0832e9589bf2c901ba3eb