### PR TITLE
Реализация прогресса уровней и загрузки аватара в профиле

### DIFF
--- a/lib/core/data/database.dart
+++ b/lib/core/data/database.dart
@@ -93,6 +93,7 @@ class Profiles extends Table {
   TextColumn get name => text().withLength(min: 0, max: 120).nullable()();
   TextColumn get currency => text().withLength(min: 3, max: 3).nullable()();
   TextColumn get locale => text().withLength(min: 2, max: 10).nullable()();
+  TextColumn get photoUrl => text().nullable()();
   DateTimeColumn get updatedAt => dateTime().withDefault(currentDateAndTime)();
 
   @override
@@ -272,7 +273,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.connect(DatabaseConnection super.connection);
 
   @override
-  int get schemaVersion => 11;
+  int get schemaVersion => 12;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -359,6 +360,9 @@ class AppDatabase extends _$AppDatabase {
       }
       if (from < 3) {
         await m.createTable(profiles);
+      }
+      if (from < 12) {
+        await m.addColumn(profiles, profiles.photoUrl);
       }
       if (from < 4) {
         await m.addColumn(categories, categories.iconStyle);

--- a/lib/core/data/database.g.dart
+++ b/lib/core/data/database.g.dart
@@ -3189,6 +3189,17 @@ class $ProfilesTable extends Profiles
     type: DriftSqlType.string,
     requiredDuringInsert: false,
   );
+  static const VerificationMeta _photoUrlMeta = const VerificationMeta(
+    'photoUrl',
+  );
+  @override
+  late final GeneratedColumn<String> photoUrl = GeneratedColumn<String>(
+    'photo_url',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
   static const VerificationMeta _updatedAtMeta = const VerificationMeta(
     'updatedAt',
   );
@@ -3207,6 +3218,7 @@ class $ProfilesTable extends Profiles
     name,
     currency,
     locale,
+    photoUrl,
     updatedAt,
   ];
   @override
@@ -3247,6 +3259,12 @@ class $ProfilesTable extends Profiles
         locale.isAcceptableOrUnknown(data['locale']!, _localeMeta),
       );
     }
+    if (data.containsKey('photo_url')) {
+      context.handle(
+        _photoUrlMeta,
+        photoUrl.isAcceptableOrUnknown(data['photo_url']!, _photoUrlMeta),
+      );
+    }
     if (data.containsKey('updated_at')) {
       context.handle(
         _updatedAtMeta,
@@ -3278,6 +3296,10 @@ class $ProfilesTable extends Profiles
         DriftSqlType.string,
         data['${effectivePrefix}locale'],
       ),
+      photoUrl: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}photo_url'],
+      ),
       updatedAt: attachedDatabase.typeMapping.read(
         DriftSqlType.dateTime,
         data['${effectivePrefix}updated_at'],
@@ -3296,12 +3318,14 @@ class ProfileRow extends DataClass implements Insertable<ProfileRow> {
   final String? name;
   final String? currency;
   final String? locale;
+  final String? photoUrl;
   final DateTime updatedAt;
   const ProfileRow({
     required this.uid,
     this.name,
     this.currency,
     this.locale,
+    this.photoUrl,
     required this.updatedAt,
   });
   @override
@@ -3317,6 +3341,9 @@ class ProfileRow extends DataClass implements Insertable<ProfileRow> {
     if (!nullToAbsent || locale != null) {
       map['locale'] = Variable<String>(locale);
     }
+    if (!nullToAbsent || photoUrl != null) {
+      map['photo_url'] = Variable<String>(photoUrl);
+    }
     map['updated_at'] = Variable<DateTime>(updatedAt);
     return map;
   }
@@ -3331,6 +3358,9 @@ class ProfileRow extends DataClass implements Insertable<ProfileRow> {
       locale: locale == null && nullToAbsent
           ? const Value.absent()
           : Value(locale),
+      photoUrl: photoUrl == null && nullToAbsent
+          ? const Value.absent()
+          : Value(photoUrl),
       updatedAt: Value(updatedAt),
     );
   }
@@ -3345,6 +3375,7 @@ class ProfileRow extends DataClass implements Insertable<ProfileRow> {
       name: serializer.fromJson<String?>(json['name']),
       currency: serializer.fromJson<String?>(json['currency']),
       locale: serializer.fromJson<String?>(json['locale']),
+      photoUrl: serializer.fromJson<String?>(json['photoUrl']),
       updatedAt: serializer.fromJson<DateTime>(json['updatedAt']),
     );
   }
@@ -3356,6 +3387,7 @@ class ProfileRow extends DataClass implements Insertable<ProfileRow> {
       'name': serializer.toJson<String?>(name),
       'currency': serializer.toJson<String?>(currency),
       'locale': serializer.toJson<String?>(locale),
+      'photoUrl': serializer.toJson<String?>(photoUrl),
       'updatedAt': serializer.toJson<DateTime>(updatedAt),
     };
   }
@@ -3365,12 +3397,14 @@ class ProfileRow extends DataClass implements Insertable<ProfileRow> {
     Value<String?> name = const Value.absent(),
     Value<String?> currency = const Value.absent(),
     Value<String?> locale = const Value.absent(),
+    Value<String?> photoUrl = const Value.absent(),
     DateTime? updatedAt,
   }) => ProfileRow(
     uid: uid ?? this.uid,
     name: name.present ? name.value : this.name,
     currency: currency.present ? currency.value : this.currency,
     locale: locale.present ? locale.value : this.locale,
+    photoUrl: photoUrl.present ? photoUrl.value : this.photoUrl,
     updatedAt: updatedAt ?? this.updatedAt,
   );
   ProfileRow copyWithCompanion(ProfilesCompanion data) {
@@ -3379,6 +3413,7 @@ class ProfileRow extends DataClass implements Insertable<ProfileRow> {
       name: data.name.present ? data.name.value : this.name,
       currency: data.currency.present ? data.currency.value : this.currency,
       locale: data.locale.present ? data.locale.value : this.locale,
+      photoUrl: data.photoUrl.present ? data.photoUrl.value : this.photoUrl,
       updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
     );
   }
@@ -3390,13 +3425,15 @@ class ProfileRow extends DataClass implements Insertable<ProfileRow> {
           ..write('name: $name, ')
           ..write('currency: $currency, ')
           ..write('locale: $locale, ')
+          ..write('photoUrl: $photoUrl, ')
           ..write('updatedAt: $updatedAt')
           ..write(')'))
         .toString();
   }
 
   @override
-  int get hashCode => Object.hash(uid, name, currency, locale, updatedAt);
+  int get hashCode =>
+      Object.hash(uid, name, currency, locale, photoUrl, updatedAt);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -3405,6 +3442,7 @@ class ProfileRow extends DataClass implements Insertable<ProfileRow> {
           other.name == this.name &&
           other.currency == this.currency &&
           other.locale == this.locale &&
+          other.photoUrl == this.photoUrl &&
           other.updatedAt == this.updatedAt);
 }
 
@@ -3413,6 +3451,7 @@ class ProfilesCompanion extends UpdateCompanion<ProfileRow> {
   final Value<String?> name;
   final Value<String?> currency;
   final Value<String?> locale;
+  final Value<String?> photoUrl;
   final Value<DateTime> updatedAt;
   final Value<int> rowid;
   const ProfilesCompanion({
@@ -3420,6 +3459,7 @@ class ProfilesCompanion extends UpdateCompanion<ProfileRow> {
     this.name = const Value.absent(),
     this.currency = const Value.absent(),
     this.locale = const Value.absent(),
+    this.photoUrl = const Value.absent(),
     this.updatedAt = const Value.absent(),
     this.rowid = const Value.absent(),
   });
@@ -3428,6 +3468,7 @@ class ProfilesCompanion extends UpdateCompanion<ProfileRow> {
     this.name = const Value.absent(),
     this.currency = const Value.absent(),
     this.locale = const Value.absent(),
+    this.photoUrl = const Value.absent(),
     this.updatedAt = const Value.absent(),
     this.rowid = const Value.absent(),
   }) : uid = Value(uid);
@@ -3436,6 +3477,7 @@ class ProfilesCompanion extends UpdateCompanion<ProfileRow> {
     Expression<String>? name,
     Expression<String>? currency,
     Expression<String>? locale,
+    Expression<String>? photoUrl,
     Expression<DateTime>? updatedAt,
     Expression<int>? rowid,
   }) {
@@ -3444,6 +3486,7 @@ class ProfilesCompanion extends UpdateCompanion<ProfileRow> {
       if (name != null) 'name': name,
       if (currency != null) 'currency': currency,
       if (locale != null) 'locale': locale,
+      if (photoUrl != null) 'photo_url': photoUrl,
       if (updatedAt != null) 'updated_at': updatedAt,
       if (rowid != null) 'rowid': rowid,
     });
@@ -3454,6 +3497,7 @@ class ProfilesCompanion extends UpdateCompanion<ProfileRow> {
     Value<String?>? name,
     Value<String?>? currency,
     Value<String?>? locale,
+    Value<String?>? photoUrl,
     Value<DateTime>? updatedAt,
     Value<int>? rowid,
   }) {
@@ -3462,6 +3506,7 @@ class ProfilesCompanion extends UpdateCompanion<ProfileRow> {
       name: name ?? this.name,
       currency: currency ?? this.currency,
       locale: locale ?? this.locale,
+      photoUrl: photoUrl ?? this.photoUrl,
       updatedAt: updatedAt ?? this.updatedAt,
       rowid: rowid ?? this.rowid,
     );
@@ -3482,6 +3527,9 @@ class ProfilesCompanion extends UpdateCompanion<ProfileRow> {
     if (locale.present) {
       map['locale'] = Variable<String>(locale.value);
     }
+    if (photoUrl.present) {
+      map['photo_url'] = Variable<String>(photoUrl.value);
+    }
     if (updatedAt.present) {
       map['updated_at'] = Variable<DateTime>(updatedAt.value);
     }
@@ -3498,6 +3546,7 @@ class ProfilesCompanion extends UpdateCompanion<ProfileRow> {
           ..write('name: $name, ')
           ..write('currency: $currency, ')
           ..write('locale: $locale, ')
+          ..write('photoUrl: $photoUrl, ')
           ..write('updatedAt: $updatedAt, ')
           ..write('rowid: $rowid')
           ..write(')'))
@@ -10448,6 +10497,7 @@ typedef $$ProfilesTableCreateCompanionBuilder =
       Value<String?> name,
       Value<String?> currency,
       Value<String?> locale,
+      Value<String?> photoUrl,
       Value<DateTime> updatedAt,
       Value<int> rowid,
     });
@@ -10457,6 +10507,7 @@ typedef $$ProfilesTableUpdateCompanionBuilder =
       Value<String?> name,
       Value<String?> currency,
       Value<String?> locale,
+      Value<String?> photoUrl,
       Value<DateTime> updatedAt,
       Value<int> rowid,
     });
@@ -10487,6 +10538,11 @@ class $$ProfilesTableFilterComposer
 
   ColumnFilters<String> get locale => $composableBuilder(
     column: $table.locale,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get photoUrl => $composableBuilder(
+    column: $table.photoUrl,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -10525,6 +10581,11 @@ class $$ProfilesTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get photoUrl => $composableBuilder(
+    column: $table.photoUrl,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<DateTime> get updatedAt => $composableBuilder(
     column: $table.updatedAt,
     builder: (column) => ColumnOrderings(column),
@@ -10551,6 +10612,9 @@ class $$ProfilesTableAnnotationComposer
 
   GeneratedColumn<String> get locale =>
       $composableBuilder(column: $table.locale, builder: (column) => column);
+
+  GeneratedColumn<String> get photoUrl =>
+      $composableBuilder(column: $table.photoUrl, builder: (column) => column);
 
   GeneratedColumn<DateTime> get updatedAt =>
       $composableBuilder(column: $table.updatedAt, builder: (column) => column);
@@ -10591,6 +10655,7 @@ class $$ProfilesTableTableManager
                 Value<String?> name = const Value.absent(),
                 Value<String?> currency = const Value.absent(),
                 Value<String?> locale = const Value.absent(),
+                Value<String?> photoUrl = const Value.absent(),
                 Value<DateTime> updatedAt = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => ProfilesCompanion(
@@ -10598,6 +10663,7 @@ class $$ProfilesTableTableManager
                 name: name,
                 currency: currency,
                 locale: locale,
+                photoUrl: photoUrl,
                 updatedAt: updatedAt,
                 rowid: rowid,
               ),
@@ -10607,6 +10673,7 @@ class $$ProfilesTableTableManager
                 Value<String?> name = const Value.absent(),
                 Value<String?> currency = const Value.absent(),
                 Value<String?> locale = const Value.absent(),
+                Value<String?> photoUrl = const Value.absent(),
                 Value<DateTime> updatedAt = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => ProfilesCompanion.insert(
@@ -10614,6 +10681,7 @@ class $$ProfilesTableTableManager
                 name: name,
                 currency: currency,
                 locale: locale,
+                photoUrl: photoUrl,
                 updatedAt: updatedAt,
                 rowid: rowid,
               ),

--- a/lib/core/di/injectors.g.dart
+++ b/lib/core/di/injectors.g.dart
@@ -225,6 +225,89 @@ final class GoogleSignInProvider
 
 String _$googleSignInHash() => r'16cf38da6ba66b02462d5ad518f809a45382089f';
 
+@ProviderFor(firebaseStorage)
+const firebaseStorageProvider = FirebaseStorageProvider._();
+
+final class FirebaseStorageProvider
+    extends
+        $FunctionalProvider<FirebaseStorage, FirebaseStorage, FirebaseStorage>
+    with $Provider<FirebaseStorage> {
+  const FirebaseStorageProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'firebaseStorageProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$firebaseStorageHash();
+
+  @$internal
+  @override
+  $ProviderElement<FirebaseStorage> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  FirebaseStorage create(Ref ref) {
+    return firebaseStorage(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(FirebaseStorage value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<FirebaseStorage>(value),
+    );
+  }
+}
+
+String _$firebaseStorageHash() => r'47903c48019f7dfa1ba82fa0a905885442d69f6b';
+
+@ProviderFor(levelPolicy)
+const levelPolicyProvider = LevelPolicyProvider._();
+
+final class LevelPolicyProvider
+    extends $FunctionalProvider<LevelPolicy, LevelPolicy, LevelPolicy>
+    with $Provider<LevelPolicy> {
+  const LevelPolicyProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'levelPolicyProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$levelPolicyHash();
+
+  @$internal
+  @override
+  $ProviderElement<LevelPolicy> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  LevelPolicy create(Ref ref) {
+    return levelPolicy(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(LevelPolicy value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<LevelPolicy>(value),
+    );
+  }
+}
+
+String _$levelPolicyHash() => r'cf33f35f707b67802f3c09b81ce189fa94a1620f';
+
 @ProviderFor(connectivity)
 const connectivityProvider = ConnectivityProvider._();
 
@@ -1285,6 +1368,103 @@ final class ProfileRemoteDataSourceProvider
 
 String _$profileRemoteDataSourceHash() =>
     r'45baf2527988bcc7389803c7cea36c9fa578effb';
+
+@ProviderFor(avatarRemoteDataSource)
+const avatarRemoteDataSourceProvider = AvatarRemoteDataSourceProvider._();
+
+final class AvatarRemoteDataSourceProvider
+    extends
+        $FunctionalProvider<
+          AvatarRemoteDataSource,
+          AvatarRemoteDataSource,
+          AvatarRemoteDataSource
+        >
+    with $Provider<AvatarRemoteDataSource> {
+  const AvatarRemoteDataSourceProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'avatarRemoteDataSourceProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$avatarRemoteDataSourceHash();
+
+  @$internal
+  @override
+  $ProviderElement<AvatarRemoteDataSource> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  AvatarRemoteDataSource create(Ref ref) {
+    return avatarRemoteDataSource(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AvatarRemoteDataSource value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AvatarRemoteDataSource>(value),
+    );
+  }
+}
+
+String _$avatarRemoteDataSourceHash() =>
+    r'62a0f450283b5803e52fe4159c8dc4586da8244c';
+
+@ProviderFor(userProgressRemoteDataSource)
+const userProgressRemoteDataSourceProvider =
+    UserProgressRemoteDataSourceProvider._();
+
+final class UserProgressRemoteDataSourceProvider
+    extends
+        $FunctionalProvider<
+          UserProgressRemoteDataSource,
+          UserProgressRemoteDataSource,
+          UserProgressRemoteDataSource
+        >
+    with $Provider<UserProgressRemoteDataSource> {
+  const UserProgressRemoteDataSourceProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'userProgressRemoteDataSourceProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$userProgressRemoteDataSourceHash();
+
+  @$internal
+  @override
+  $ProviderElement<UserProgressRemoteDataSource> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  UserProgressRemoteDataSource create(Ref ref) {
+    return userProgressRemoteDataSource(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(UserProgressRemoteDataSource value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<UserProgressRemoteDataSource>(value),
+    );
+  }
+}
+
+String _$userProgressRemoteDataSourceHash() =>
+    r'009e10b99822950953d87758f1fe3aa367ab63b4';
 
 @ProviderFor(budgetRemoteDataSource)
 const budgetRemoteDataSourceProvider = BudgetRemoteDataSourceProvider._();
@@ -3131,6 +3311,102 @@ final class ProfileRepositoryProvider
 
 String _$profileRepositoryHash() => r'50349dac8ba8e300957ef12232c08d9febe5ec97';
 
+@ProviderFor(profileAvatarRepository)
+const profileAvatarRepositoryProvider = ProfileAvatarRepositoryProvider._();
+
+final class ProfileAvatarRepositoryProvider
+    extends
+        $FunctionalProvider<
+          ProfileAvatarRepository,
+          ProfileAvatarRepository,
+          ProfileAvatarRepository
+        >
+    with $Provider<ProfileAvatarRepository> {
+  const ProfileAvatarRepositoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'profileAvatarRepositoryProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$profileAvatarRepositoryHash();
+
+  @$internal
+  @override
+  $ProviderElement<ProfileAvatarRepository> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  ProfileAvatarRepository create(Ref ref) {
+    return profileAvatarRepository(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(ProfileAvatarRepository value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<ProfileAvatarRepository>(value),
+    );
+  }
+}
+
+String _$profileAvatarRepositoryHash() =>
+    r'539f637f58f3297d5d3067de950ce44eabbf6a6f';
+
+@ProviderFor(userProgressRepository)
+const userProgressRepositoryProvider = UserProgressRepositoryProvider._();
+
+final class UserProgressRepositoryProvider
+    extends
+        $FunctionalProvider<
+          UserProgressRepository,
+          UserProgressRepository,
+          UserProgressRepository
+        >
+    with $Provider<UserProgressRepository> {
+  const UserProgressRepositoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'userProgressRepositoryProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$userProgressRepositoryHash();
+
+  @$internal
+  @override
+  $ProviderElement<UserProgressRepository> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  UserProgressRepository create(Ref ref) {
+    return userProgressRepository(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(UserProgressRepository value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<UserProgressRepository>(value),
+    );
+  }
+}
+
+String _$userProgressRepositoryHash() =>
+    r'27ecf4905dc13c7c3c31285e5b659c5eb236a8f8';
+
 @ProviderFor(updateProfileUseCase)
 const updateProfileUseCaseProvider = UpdateProfileUseCaseProvider._();
 
@@ -3178,6 +3454,202 @@ final class UpdateProfileUseCaseProvider
 
 String _$updateProfileUseCaseHash() =>
     r'9a588af407d61e02f7c35d5e0ec46c115704d472';
+
+@ProviderFor(recomputeUserProgressUseCase)
+const recomputeUserProgressUseCaseProvider =
+    RecomputeUserProgressUseCaseProvider._();
+
+final class RecomputeUserProgressUseCaseProvider
+    extends
+        $FunctionalProvider<
+          RecomputeUserProgressUseCase,
+          RecomputeUserProgressUseCase,
+          RecomputeUserProgressUseCase
+        >
+    with $Provider<RecomputeUserProgressUseCase> {
+  const RecomputeUserProgressUseCaseProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'recomputeUserProgressUseCaseProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$recomputeUserProgressUseCaseHash();
+
+  @$internal
+  @override
+  $ProviderElement<RecomputeUserProgressUseCase> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  RecomputeUserProgressUseCase create(Ref ref) {
+    return recomputeUserProgressUseCase(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(RecomputeUserProgressUseCase value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<RecomputeUserProgressUseCase>(value),
+    );
+  }
+}
+
+String _$recomputeUserProgressUseCaseHash() =>
+    r'06aa08489f3ca62c0f7ebbbb164167cca6256ef7';
+
+@ProviderFor(onTransactionCreatedUseCase)
+const onTransactionCreatedUseCaseProvider =
+    OnTransactionCreatedUseCaseProvider._();
+
+final class OnTransactionCreatedUseCaseProvider
+    extends
+        $FunctionalProvider<
+          OnTransactionCreatedUseCase,
+          OnTransactionCreatedUseCase,
+          OnTransactionCreatedUseCase
+        >
+    with $Provider<OnTransactionCreatedUseCase> {
+  const OnTransactionCreatedUseCaseProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'onTransactionCreatedUseCaseProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$onTransactionCreatedUseCaseHash();
+
+  @$internal
+  @override
+  $ProviderElement<OnTransactionCreatedUseCase> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  OnTransactionCreatedUseCase create(Ref ref) {
+    return onTransactionCreatedUseCase(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(OnTransactionCreatedUseCase value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<OnTransactionCreatedUseCase>(value),
+    );
+  }
+}
+
+String _$onTransactionCreatedUseCaseHash() =>
+    r'9fe7a7625113314739dcac82d957b6efdf695414';
+
+@ProviderFor(onTransactionDeletedUseCase)
+const onTransactionDeletedUseCaseProvider =
+    OnTransactionDeletedUseCaseProvider._();
+
+final class OnTransactionDeletedUseCaseProvider
+    extends
+        $FunctionalProvider<
+          OnTransactionDeletedUseCase,
+          OnTransactionDeletedUseCase,
+          OnTransactionDeletedUseCase
+        >
+    with $Provider<OnTransactionDeletedUseCase> {
+  const OnTransactionDeletedUseCaseProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'onTransactionDeletedUseCaseProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$onTransactionDeletedUseCaseHash();
+
+  @$internal
+  @override
+  $ProviderElement<OnTransactionDeletedUseCase> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  OnTransactionDeletedUseCase create(Ref ref) {
+    return onTransactionDeletedUseCase(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(OnTransactionDeletedUseCase value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<OnTransactionDeletedUseCase>(value),
+    );
+  }
+}
+
+String _$onTransactionDeletedUseCaseHash() =>
+    r'34dc92ca2db0124451716e5cd2aa0ab9525d96bf';
+
+@ProviderFor(updateProfileAvatarUseCase)
+const updateProfileAvatarUseCaseProvider =
+    UpdateProfileAvatarUseCaseProvider._();
+
+final class UpdateProfileAvatarUseCaseProvider
+    extends
+        $FunctionalProvider<
+          UpdateProfileAvatarUseCase,
+          UpdateProfileAvatarUseCase,
+          UpdateProfileAvatarUseCase
+        >
+    with $Provider<UpdateProfileAvatarUseCase> {
+  const UpdateProfileAvatarUseCaseProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'updateProfileAvatarUseCaseProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$updateProfileAvatarUseCaseHash();
+
+  @$internal
+  @override
+  $ProviderElement<UpdateProfileAvatarUseCase> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  UpdateProfileAvatarUseCase create(Ref ref) {
+    return updateProfileAvatarUseCase(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(UpdateProfileAvatarUseCase value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<UpdateProfileAvatarUseCase>(value),
+    );
+  }
+}
+
+String _$updateProfileAvatarUseCaseHash() =>
+    r'55cc74f78fefb1db555da7d3a03c91c4c53adc9f';
 
 @ProviderFor(syncService)
 const syncServiceProvider = SyncServiceProvider._();

--- a/lib/features/profile/data/local/profile_dao.dart
+++ b/lib/features/profile/data/local/profile_dao.dart
@@ -40,6 +40,7 @@ class ProfileDao {
       name: row.name ?? '',
       currency: _parseCurrency(row.currency),
       locale: row.locale ?? 'en',
+      photoUrl: row.photoUrl,
       updatedAt: row.updatedAt,
     );
   }
@@ -50,6 +51,7 @@ class ProfileDao {
       name: Value<String>(profile.name),
       currency: Value<String>(profile.currency.name.toUpperCase()),
       locale: Value<String>(profile.locale),
+      photoUrl: Value<String?>(profile.photoUrl),
       updatedAt: Value<DateTime>(profile.updatedAt),
     );
   }

--- a/lib/features/profile/data/profile_avatar_repository_impl.dart
+++ b/lib/features/profile/data/profile_avatar_repository_impl.dart
@@ -1,0 +1,30 @@
+import 'dart:typed_data';
+
+import 'package:kopim/features/profile/data/remote/avatar_remote_data_source.dart';
+import 'package:kopim/features/profile/domain/repositories/profile_avatar_repository.dart';
+
+class ProfileAvatarRepositoryImpl implements ProfileAvatarRepository {
+  ProfileAvatarRepositoryImpl({
+    required AvatarRemoteDataSource remoteDataSource,
+  }) : _remoteDataSource = remoteDataSource;
+
+  final AvatarRemoteDataSource _remoteDataSource;
+
+  @override
+  Future<void> delete(String uid) {
+    return _remoteDataSource.delete(uid);
+  }
+
+  @override
+  Future<String> upload({
+    required String uid,
+    required Uint8List data,
+    required String contentType,
+  }) {
+    return _remoteDataSource.upload(
+      uid: uid,
+      data: data,
+      contentType: contentType,
+    );
+  }
+}

--- a/lib/features/profile/data/profile_repository_impl.dart
+++ b/lib/features/profile/data/profile_repository_impl.dart
@@ -71,6 +71,7 @@ class ProfileRepositoryImpl implements ProfileRepository {
       'name': profile.name,
       'currency': profile.currency.name,
       'locale': profile.locale,
+      'photoUrl': profile.photoUrl,
       'updatedAt': profile.updatedAt.toIso8601String(),
     };
   }

--- a/lib/features/profile/data/remote/avatar_remote_data_source.dart
+++ b/lib/features/profile/data/remote/avatar_remote_data_source.dart
@@ -1,0 +1,30 @@
+import 'dart:typed_data';
+
+import 'package:firebase_storage/firebase_storage.dart';
+
+class AvatarRemoteDataSource {
+  AvatarRemoteDataSource(this._storage);
+
+  final FirebaseStorage _storage;
+
+  Reference _reference(String uid) {
+    return _storage.ref().child('users/$uid/avatar.jpg');
+  }
+
+  Future<String> upload({
+    required String uid,
+    required Uint8List data,
+    required String contentType,
+  }) async {
+    final Reference ref = _reference(uid);
+    final SettableMetadata metadata = SettableMetadata(
+      contentType: contentType,
+    );
+    await ref.putData(data, metadata);
+    return ref.getDownloadURL();
+  }
+
+  Future<void> delete(String uid) {
+    return _reference(uid).delete();
+  }
+}

--- a/lib/features/profile/data/remote/profile_remote_data_source.dart
+++ b/lib/features/profile/data/remote/profile_remote_data_source.dart
@@ -46,6 +46,7 @@ class ProfileRemoteDataSource {
       'name': profile.name,
       'currency': profile.currency.name.toUpperCase(),
       'locale': profile.locale,
+      'photoUrl': profile.photoUrl,
       'updatedAt': Timestamp.fromDate(profile.updatedAt.toUtc()),
     };
   }
@@ -56,6 +57,9 @@ class ProfileRemoteDataSource {
       name: (data['name'] as String?) ?? '',
       currency: _parseCurrency(data['currency'] as String?),
       locale: (data['locale'] as String?) ?? 'en',
+      photoUrl: (data['photoUrl'] as String?)?.trim().isEmpty ?? true
+          ? null
+          : (data['photoUrl'] as String).trim(),
       updatedAt: _parseTimestamp(data['updatedAt']),
     );
   }

--- a/lib/features/profile/data/remote/user_progress_remote_data_source.dart
+++ b/lib/features/profile/data/remote/user_progress_remote_data_source.dart
@@ -1,0 +1,43 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:kopim/features/profile/domain/repositories/user_progress_repository.dart';
+
+class UserProgressRemoteDataSource {
+  UserProgressRemoteDataSource(this._firestore);
+
+  final FirebaseFirestore _firestore;
+
+  DocumentReference<Map<String, dynamic>> _doc(String uid) {
+    return _firestore
+        .collection('users')
+        .doc(uid)
+        .collection('progress')
+        .doc('progress');
+  }
+
+  Future<ProgressSnapshot?> fetch(String uid) async {
+    final DocumentSnapshot<Map<String, dynamic>> snapshot = await _doc(
+      uid,
+    ).get();
+    if (!snapshot.exists) {
+      return null;
+    }
+    final Map<String, dynamic> data = snapshot.data()!;
+    final int totalTx = (data['total_tx'] as num?)?.toInt() ?? 0;
+    final Timestamp? updatedAtRaw = data['updated_at'] as Timestamp?;
+    final DateTime updatedAt = (updatedAtRaw ?? Timestamp.now())
+        .toDate()
+        .toUtc();
+    return ProgressSnapshot(totalTx: totalTx, updatedAt: updatedAt);
+  }
+
+  Future<void> upsert({
+    required String uid,
+    required int totalTx,
+    required DateTime updatedAt,
+  }) async {
+    await _doc(uid).set(<String, dynamic>{
+      'total_tx': totalTx,
+      'updated_at': Timestamp.fromDate(updatedAt.toUtc()),
+    }, SetOptions(merge: true));
+  }
+}

--- a/lib/features/profile/data/user_progress_repository_impl.dart
+++ b/lib/features/profile/data/user_progress_repository_impl.dart
@@ -1,0 +1,64 @@
+import 'dart:async';
+
+import 'package:kopim/features/profile/data/remote/user_progress_remote_data_source.dart';
+import 'package:kopim/features/profile/domain/entities/user_progress.dart';
+import 'package:kopim/features/profile/domain/repositories/user_progress_repository.dart';
+import 'package:kopim/features/transactions/data/sources/local/transaction_dao.dart';
+
+class UserProgressRepositoryImpl implements UserProgressRepository {
+  UserProgressRepositoryImpl({
+    required TransactionDao transactionDao,
+    required UserProgressRemoteDataSource remoteDataSource,
+  }) : _transactionDao = transactionDao,
+       _remoteDataSource = remoteDataSource;
+
+  final TransactionDao _transactionDao;
+  final UserProgressRemoteDataSource _remoteDataSource;
+  final StreamController<UserProgress?> _cacheController =
+      StreamController<UserProgress?>.broadcast();
+
+  @override
+  Stream<int> watchTransactionCount() {
+    return _transactionDao.watchActiveCount();
+  }
+
+  @override
+  Future<int> countTransactions() {
+    return _transactionDao.countActiveTransactions();
+  }
+
+  @override
+  Future<ProgressSnapshot?> fetchRemoteProgress(String uid) {
+    return _remoteDataSource.fetch(uid);
+  }
+
+  @override
+  Future<void> saveRemoteProgress({
+    required String uid,
+    required int totalTx,
+    required DateTime updatedAt,
+  }) {
+    return _remoteDataSource.upsert(
+      uid: uid,
+      totalTx: totalTx,
+      updatedAt: updatedAt,
+    );
+  }
+
+  @override
+  Future<void> cacheProgress(UserProgress progress) async {
+    if (_cacheController.isClosed) {
+      return;
+    }
+    _cacheController.add(progress);
+  }
+
+  @override
+  Stream<UserProgress?> watchCachedProgress() {
+    return _cacheController.stream;
+  }
+
+  void dispose() {
+    _cacheController.close();
+  }
+}

--- a/lib/features/profile/domain/entities/profile.dart
+++ b/lib/features/profile/domain/entities/profile.dart
@@ -14,6 +14,7 @@ abstract class Profile with _$Profile {
     @Default('') String name,
     @Default(ProfileCurrency.rub) ProfileCurrency currency,
     @Default('en') String locale,
+    String? photoUrl,
     required DateTime updatedAt,
   }) = _Profile;
 

--- a/lib/features/profile/domain/entities/profile.freezed.dart
+++ b/lib/features/profile/domain/entities/profile.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$Profile {
 
- String get uid; String get name; ProfileCurrency get currency; String get locale; DateTime get updatedAt;
+ String get uid; String get name; ProfileCurrency get currency; String get locale; String? get photoUrl; DateTime get updatedAt;
 /// Create a copy of Profile
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $ProfileCopyWith<Profile> get copyWith => _$ProfileCopyWithImpl<Profile>(this as
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is Profile&&(identical(other.uid, uid) || other.uid == uid)&&(identical(other.name, name) || other.name == name)&&(identical(other.currency, currency) || other.currency == currency)&&(identical(other.locale, locale) || other.locale == locale)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Profile&&(identical(other.uid, uid) || other.uid == uid)&&(identical(other.name, name) || other.name == name)&&(identical(other.currency, currency) || other.currency == currency)&&(identical(other.locale, locale) || other.locale == locale)&&(identical(other.photoUrl, photoUrl) || other.photoUrl == photoUrl)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,uid,name,currency,locale,updatedAt);
+int get hashCode => Object.hash(runtimeType,uid,name,currency,locale,photoUrl,updatedAt);
 
 @override
 String toString() {
-  return 'Profile(uid: $uid, name: $name, currency: $currency, locale: $locale, updatedAt: $updatedAt)';
+  return 'Profile(uid: $uid, name: $name, currency: $currency, locale: $locale, photoUrl: $photoUrl, updatedAt: $updatedAt)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $ProfileCopyWith<$Res>  {
   factory $ProfileCopyWith(Profile value, $Res Function(Profile) _then) = _$ProfileCopyWithImpl;
 @useResult
 $Res call({
- String uid, String name, ProfileCurrency currency, String locale, DateTime updatedAt
+ String uid, String name, ProfileCurrency currency, String locale, String? photoUrl, DateTime updatedAt
 });
 
 
@@ -65,13 +65,14 @@ class _$ProfileCopyWithImpl<$Res>
 
 /// Create a copy of Profile
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? uid = null,Object? name = null,Object? currency = null,Object? locale = null,Object? updatedAt = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? uid = null,Object? name = null,Object? currency = null,Object? locale = null,Object? photoUrl = freezed,Object? updatedAt = null,}) {
   return _then(_self.copyWith(
 uid: null == uid ? _self.uid : uid // ignore: cast_nullable_to_non_nullable
 as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
 as String,currency: null == currency ? _self.currency : currency // ignore: cast_nullable_to_non_nullable
 as ProfileCurrency,locale: null == locale ? _self.locale : locale // ignore: cast_nullable_to_non_nullable
-as String,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as String,photoUrl: freezed == photoUrl ? _self.photoUrl : photoUrl // ignore: cast_nullable_to_non_nullable
+as String?,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
 as DateTime,
   ));
 }
@@ -157,10 +158,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String uid,  String name,  ProfileCurrency currency,  String locale,  DateTime updatedAt)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String uid,  String name,  ProfileCurrency currency,  String locale,  String? photoUrl,  DateTime updatedAt)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _Profile() when $default != null:
-return $default(_that.uid,_that.name,_that.currency,_that.locale,_that.updatedAt);case _:
+return $default(_that.uid,_that.name,_that.currency,_that.locale,_that.photoUrl,_that.updatedAt);case _:
   return orElse();
 
 }
@@ -178,10 +179,10 @@ return $default(_that.uid,_that.name,_that.currency,_that.locale,_that.updatedAt
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String uid,  String name,  ProfileCurrency currency,  String locale,  DateTime updatedAt)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String uid,  String name,  ProfileCurrency currency,  String locale,  String? photoUrl,  DateTime updatedAt)  $default,) {final _that = this;
 switch (_that) {
 case _Profile():
-return $default(_that.uid,_that.name,_that.currency,_that.locale,_that.updatedAt);case _:
+return $default(_that.uid,_that.name,_that.currency,_that.locale,_that.photoUrl,_that.updatedAt);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -198,10 +199,10 @@ return $default(_that.uid,_that.name,_that.currency,_that.locale,_that.updatedAt
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String uid,  String name,  ProfileCurrency currency,  String locale,  DateTime updatedAt)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String uid,  String name,  ProfileCurrency currency,  String locale,  String? photoUrl,  DateTime updatedAt)?  $default,) {final _that = this;
 switch (_that) {
 case _Profile() when $default != null:
-return $default(_that.uid,_that.name,_that.currency,_that.locale,_that.updatedAt);case _:
+return $default(_that.uid,_that.name,_that.currency,_that.locale,_that.photoUrl,_that.updatedAt);case _:
   return null;
 
 }
@@ -213,13 +214,14 @@ return $default(_that.uid,_that.name,_that.currency,_that.locale,_that.updatedAt
 @JsonSerializable()
 
 class _Profile extends Profile {
-  const _Profile({required this.uid, this.name = '', this.currency = ProfileCurrency.rub, this.locale = 'en', required this.updatedAt}): super._();
+  const _Profile({required this.uid, this.name = '', this.currency = ProfileCurrency.rub, this.locale = 'en', this.photoUrl, required this.updatedAt}): super._();
   factory _Profile.fromJson(Map<String, dynamic> json) => _$ProfileFromJson(json);
 
 @override final  String uid;
 @override@JsonKey() final  String name;
 @override@JsonKey() final  ProfileCurrency currency;
 @override@JsonKey() final  String locale;
+@override final  String? photoUrl;
 @override final  DateTime updatedAt;
 
 /// Create a copy of Profile
@@ -235,16 +237,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Profile&&(identical(other.uid, uid) || other.uid == uid)&&(identical(other.name, name) || other.name == name)&&(identical(other.currency, currency) || other.currency == currency)&&(identical(other.locale, locale) || other.locale == locale)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Profile&&(identical(other.uid, uid) || other.uid == uid)&&(identical(other.name, name) || other.name == name)&&(identical(other.currency, currency) || other.currency == currency)&&(identical(other.locale, locale) || other.locale == locale)&&(identical(other.photoUrl, photoUrl) || other.photoUrl == photoUrl)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,uid,name,currency,locale,updatedAt);
+int get hashCode => Object.hash(runtimeType,uid,name,currency,locale,photoUrl,updatedAt);
 
 @override
 String toString() {
-  return 'Profile(uid: $uid, name: $name, currency: $currency, locale: $locale, updatedAt: $updatedAt)';
+  return 'Profile(uid: $uid, name: $name, currency: $currency, locale: $locale, photoUrl: $photoUrl, updatedAt: $updatedAt)';
 }
 
 
@@ -255,7 +257,7 @@ abstract mixin class _$ProfileCopyWith<$Res> implements $ProfileCopyWith<$Res> {
   factory _$ProfileCopyWith(_Profile value, $Res Function(_Profile) _then) = __$ProfileCopyWithImpl;
 @override @useResult
 $Res call({
- String uid, String name, ProfileCurrency currency, String locale, DateTime updatedAt
+ String uid, String name, ProfileCurrency currency, String locale, String? photoUrl, DateTime updatedAt
 });
 
 
@@ -272,13 +274,14 @@ class __$ProfileCopyWithImpl<$Res>
 
 /// Create a copy of Profile
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? uid = null,Object? name = null,Object? currency = null,Object? locale = null,Object? updatedAt = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? uid = null,Object? name = null,Object? currency = null,Object? locale = null,Object? photoUrl = freezed,Object? updatedAt = null,}) {
   return _then(_Profile(
 uid: null == uid ? _self.uid : uid // ignore: cast_nullable_to_non_nullable
 as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
 as String,currency: null == currency ? _self.currency : currency // ignore: cast_nullable_to_non_nullable
 as ProfileCurrency,locale: null == locale ? _self.locale : locale // ignore: cast_nullable_to_non_nullable
-as String,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as String,photoUrl: freezed == photoUrl ? _self.photoUrl : photoUrl // ignore: cast_nullable_to_non_nullable
+as String?,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
 as DateTime,
   ));
 }

--- a/lib/features/profile/domain/entities/profile.g.dart
+++ b/lib/features/profile/domain/entities/profile.g.dart
@@ -13,6 +13,7 @@ _Profile _$ProfileFromJson(Map<String, dynamic> json) => _Profile(
       $enumDecodeNullable(_$ProfileCurrencyEnumMap, json['currency']) ??
       ProfileCurrency.rub,
   locale: json['locale'] as String? ?? 'en',
+  photoUrl: json['photoUrl'] as String?,
   updatedAt: DateTime.parse(json['updatedAt'] as String),
 );
 
@@ -21,6 +22,7 @@ Map<String, dynamic> _$ProfileToJson(_Profile instance) => <String, dynamic>{
   'name': instance.name,
   'currency': _$ProfileCurrencyEnumMap[instance.currency]!,
   'locale': instance.locale,
+  'photoUrl': instance.photoUrl,
   'updatedAt': instance.updatedAt.toIso8601String(),
 };
 

--- a/lib/features/profile/domain/entities/user_progress.dart
+++ b/lib/features/profile/domain/entities/user_progress.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'user_progress.freezed.dart';
+part 'user_progress.g.dart';
+
+@freezed
+abstract class UserProgress with _$UserProgress {
+  const UserProgress._();
+
+  const factory UserProgress({
+    @Default(0) int totalTx,
+    @Default(1) int level,
+    required String title,
+    required int nextThreshold,
+    required DateTime updatedAt,
+  }) = _UserProgress;
+
+  factory UserProgress.fromJson(Map<String, dynamic> json) =>
+      _$UserProgressFromJson(json);
+}

--- a/lib/features/profile/domain/entities/user_progress.freezed.dart
+++ b/lib/features/profile/domain/entities/user_progress.freezed.dart
@@ -1,0 +1,289 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'user_progress.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$UserProgress {
+
+ int get totalTx; int get level; String get title; int get nextThreshold; DateTime get updatedAt;
+/// Create a copy of UserProgress
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$UserProgressCopyWith<UserProgress> get copyWith => _$UserProgressCopyWithImpl<UserProgress>(this as UserProgress, _$identity);
+
+  /// Serializes this UserProgress to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is UserProgress&&(identical(other.totalTx, totalTx) || other.totalTx == totalTx)&&(identical(other.level, level) || other.level == level)&&(identical(other.title, title) || other.title == title)&&(identical(other.nextThreshold, nextThreshold) || other.nextThreshold == nextThreshold)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,totalTx,level,title,nextThreshold,updatedAt);
+
+@override
+String toString() {
+  return 'UserProgress(totalTx: $totalTx, level: $level, title: $title, nextThreshold: $nextThreshold, updatedAt: $updatedAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $UserProgressCopyWith<$Res>  {
+  factory $UserProgressCopyWith(UserProgress value, $Res Function(UserProgress) _then) = _$UserProgressCopyWithImpl;
+@useResult
+$Res call({
+ int totalTx, int level, String title, int nextThreshold, DateTime updatedAt
+});
+
+
+
+
+}
+/// @nodoc
+class _$UserProgressCopyWithImpl<$Res>
+    implements $UserProgressCopyWith<$Res> {
+  _$UserProgressCopyWithImpl(this._self, this._then);
+
+  final UserProgress _self;
+  final $Res Function(UserProgress) _then;
+
+/// Create a copy of UserProgress
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? totalTx = null,Object? level = null,Object? title = null,Object? nextThreshold = null,Object? updatedAt = null,}) {
+  return _then(_self.copyWith(
+totalTx: null == totalTx ? _self.totalTx : totalTx // ignore: cast_nullable_to_non_nullable
+as int,level: null == level ? _self.level : level // ignore: cast_nullable_to_non_nullable
+as int,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,nextThreshold: null == nextThreshold ? _self.nextThreshold : nextThreshold // ignore: cast_nullable_to_non_nullable
+as int,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [UserProgress].
+extension UserProgressPatterns on UserProgress {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _UserProgress value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _UserProgress() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _UserProgress value)  $default,){
+final _that = this;
+switch (_that) {
+case _UserProgress():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _UserProgress value)?  $default,){
+final _that = this;
+switch (_that) {
+case _UserProgress() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int totalTx,  int level,  String title,  int nextThreshold,  DateTime updatedAt)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _UserProgress() when $default != null:
+return $default(_that.totalTx,_that.level,_that.title,_that.nextThreshold,_that.updatedAt);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int totalTx,  int level,  String title,  int nextThreshold,  DateTime updatedAt)  $default,) {final _that = this;
+switch (_that) {
+case _UserProgress():
+return $default(_that.totalTx,_that.level,_that.title,_that.nextThreshold,_that.updatedAt);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int totalTx,  int level,  String title,  int nextThreshold,  DateTime updatedAt)?  $default,) {final _that = this;
+switch (_that) {
+case _UserProgress() when $default != null:
+return $default(_that.totalTx,_that.level,_that.title,_that.nextThreshold,_that.updatedAt);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _UserProgress extends UserProgress {
+  const _UserProgress({this.totalTx = 0, this.level = 1, required this.title, required this.nextThreshold, required this.updatedAt}): super._();
+  factory _UserProgress.fromJson(Map<String, dynamic> json) => _$UserProgressFromJson(json);
+
+@override@JsonKey() final  int totalTx;
+@override@JsonKey() final  int level;
+@override final  String title;
+@override final  int nextThreshold;
+@override final  DateTime updatedAt;
+
+/// Create a copy of UserProgress
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$UserProgressCopyWith<_UserProgress> get copyWith => __$UserProgressCopyWithImpl<_UserProgress>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$UserProgressToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _UserProgress&&(identical(other.totalTx, totalTx) || other.totalTx == totalTx)&&(identical(other.level, level) || other.level == level)&&(identical(other.title, title) || other.title == title)&&(identical(other.nextThreshold, nextThreshold) || other.nextThreshold == nextThreshold)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,totalTx,level,title,nextThreshold,updatedAt);
+
+@override
+String toString() {
+  return 'UserProgress(totalTx: $totalTx, level: $level, title: $title, nextThreshold: $nextThreshold, updatedAt: $updatedAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$UserProgressCopyWith<$Res> implements $UserProgressCopyWith<$Res> {
+  factory _$UserProgressCopyWith(_UserProgress value, $Res Function(_UserProgress) _then) = __$UserProgressCopyWithImpl;
+@override @useResult
+$Res call({
+ int totalTx, int level, String title, int nextThreshold, DateTime updatedAt
+});
+
+
+
+
+}
+/// @nodoc
+class __$UserProgressCopyWithImpl<$Res>
+    implements _$UserProgressCopyWith<$Res> {
+  __$UserProgressCopyWithImpl(this._self, this._then);
+
+  final _UserProgress _self;
+  final $Res Function(_UserProgress) _then;
+
+/// Create a copy of UserProgress
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? totalTx = null,Object? level = null,Object? title = null,Object? nextThreshold = null,Object? updatedAt = null,}) {
+  return _then(_UserProgress(
+totalTx: null == totalTx ? _self.totalTx : totalTx // ignore: cast_nullable_to_non_nullable
+as int,level: null == level ? _self.level : level // ignore: cast_nullable_to_non_nullable
+as int,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,nextThreshold: null == nextThreshold ? _self.nextThreshold : nextThreshold // ignore: cast_nullable_to_non_nullable
+as int,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/features/profile/domain/entities/user_progress.g.dart
+++ b/lib/features/profile/domain/entities/user_progress.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'user_progress.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_UserProgress _$UserProgressFromJson(Map<String, dynamic> json) =>
+    _UserProgress(
+      totalTx: (json['totalTx'] as num?)?.toInt() ?? 0,
+      level: (json['level'] as num?)?.toInt() ?? 1,
+      title: json['title'] as String,
+      nextThreshold: (json['nextThreshold'] as num).toInt(),
+      updatedAt: DateTime.parse(json['updatedAt'] as String),
+    );
+
+Map<String, dynamic> _$UserProgressToJson(_UserProgress instance) =>
+    <String, dynamic>{
+      'totalTx': instance.totalTx,
+      'level': instance.level,
+      'title': instance.title,
+      'nextThreshold': instance.nextThreshold,
+      'updatedAt': instance.updatedAt.toIso8601String(),
+    };

--- a/lib/features/profile/domain/policies/level_policy.dart
+++ b/lib/features/profile/domain/policies/level_policy.dart
@@ -1,0 +1,66 @@
+import 'dart:math';
+
+abstract class LevelPolicy {
+  int levelFor(int xp);
+
+  String titleFor(int level);
+
+  int nextThreshold(int xp);
+
+  int previousThreshold(int level);
+}
+
+class SimpleLevelPolicy implements LevelPolicy {
+  const SimpleLevelPolicy();
+
+  static const List<int> _thresholds = <int>[0, 100, 500, 2000, 5000];
+  static const Map<int, String> _titles = <int, String>{
+    1: 'Птенец Тоторо',
+    2: 'Ученик Кодамы',
+    3: 'Путник по Небу Лапуты',
+    4: 'Ходящий по Замкам',
+    5: 'Дракон Реки',
+  };
+
+  @override
+  int levelFor(int xp) {
+    final int safeXp = max(0, xp);
+    if (safeXp >= 5000) return 5;
+    if (safeXp >= 2000) return 4;
+    if (safeXp >= 500) return 3;
+    if (safeXp >= 100) return 2;
+    return 1;
+  }
+
+  @override
+  String titleFor(int level) {
+    return _titles[level] ?? _titles[1]!;
+  }
+
+  @override
+  int nextThreshold(int xp) {
+    final int safeXp = max(0, xp);
+    for (final int threshold in _thresholds.skip(1)) {
+      if (safeXp < threshold) {
+        return threshold;
+      }
+    }
+    return safeXp;
+  }
+
+  @override
+  int previousThreshold(int level) {
+    switch (level) {
+      case 5:
+        return 5000;
+      case 4:
+        return 2000;
+      case 3:
+        return 500;
+      case 2:
+        return 100;
+      default:
+        return 0;
+    }
+  }
+}

--- a/lib/features/profile/domain/repositories/profile_avatar_repository.dart
+++ b/lib/features/profile/domain/repositories/profile_avatar_repository.dart
@@ -1,0 +1,11 @@
+import 'dart:typed_data';
+
+abstract class ProfileAvatarRepository {
+  Future<String> upload({
+    required String uid,
+    required Uint8List data,
+    required String contentType,
+  });
+
+  Future<void> delete(String uid);
+}

--- a/lib/features/profile/domain/repositories/user_progress_repository.dart
+++ b/lib/features/profile/domain/repositories/user_progress_repository.dart
@@ -1,0 +1,26 @@
+import 'package:kopim/features/profile/domain/entities/user_progress.dart';
+
+class ProgressSnapshot {
+  const ProgressSnapshot({required this.totalTx, required this.updatedAt});
+
+  final int totalTx;
+  final DateTime updatedAt;
+}
+
+abstract class UserProgressRepository {
+  Stream<int> watchTransactionCount();
+
+  Future<int> countTransactions();
+
+  Future<ProgressSnapshot?> fetchRemoteProgress(String uid);
+
+  Future<void> saveRemoteProgress({
+    required String uid,
+    required int totalTx,
+    required DateTime updatedAt,
+  });
+
+  Future<void> cacheProgress(UserProgress progress);
+
+  Stream<UserProgress?> watchCachedProgress();
+}

--- a/lib/features/profile/domain/usecases/on_transaction_created_use_case.dart
+++ b/lib/features/profile/domain/usecases/on_transaction_created_use_case.dart
@@ -1,0 +1,34 @@
+import 'package:kopim/core/services/analytics_service.dart';
+import 'package:kopim/features/profile/domain/entities/user_progress.dart';
+import 'package:kopim/features/profile/domain/policies/level_policy.dart';
+
+import 'recompute_user_progress_use_case.dart';
+
+class OnTransactionCreatedUseCase {
+  OnTransactionCreatedUseCase({
+    required RecomputeUserProgressUseCase recomputeUserProgressUseCase,
+    required LevelPolicy levelPolicy,
+    required AnalyticsService analyticsService,
+  }) : _recomputeUserProgressUseCase = recomputeUserProgressUseCase,
+       _levelPolicy = levelPolicy,
+       _analyticsService = analyticsService;
+
+  final RecomputeUserProgressUseCase _recomputeUserProgressUseCase;
+  final LevelPolicy _levelPolicy;
+  final AnalyticsService _analyticsService;
+
+  Future<UserProgress> call() async {
+    final UserProgress progress = await _recomputeUserProgressUseCase();
+    final int previousLevel = _levelPolicy.levelFor(
+      progress.totalTx > 0 ? progress.totalTx - 1 : 0,
+    );
+    if (progress.level > previousLevel) {
+      await _analyticsService.logEvent('level_up', <String, Object?>{
+        'old_level': previousLevel,
+        'new_level': progress.level,
+        'total_tx': progress.totalTx,
+      });
+    }
+    return progress;
+  }
+}

--- a/lib/features/profile/domain/usecases/on_transaction_deleted_use_case.dart
+++ b/lib/features/profile/domain/usecases/on_transaction_deleted_use_case.dart
@@ -1,0 +1,15 @@
+import 'package:kopim/features/profile/domain/entities/user_progress.dart';
+
+import 'recompute_user_progress_use_case.dart';
+
+class OnTransactionDeletedUseCase {
+  OnTransactionDeletedUseCase({
+    required RecomputeUserProgressUseCase recomputeUserProgressUseCase,
+  }) : _recomputeUserProgressUseCase = recomputeUserProgressUseCase;
+
+  final RecomputeUserProgressUseCase _recomputeUserProgressUseCase;
+
+  Future<UserProgress> call() {
+    return _recomputeUserProgressUseCase();
+  }
+}

--- a/lib/features/profile/domain/usecases/recompute_user_progress_use_case.dart
+++ b/lib/features/profile/domain/usecases/recompute_user_progress_use_case.dart
@@ -1,0 +1,65 @@
+import 'dart:math';
+
+import 'package:kopim/core/services/logger_service.dart';
+import 'package:kopim/features/profile/domain/entities/auth_user.dart';
+import 'package:kopim/features/profile/domain/entities/user_progress.dart';
+import 'package:kopim/features/profile/domain/policies/level_policy.dart';
+import 'package:kopim/features/profile/domain/repositories/auth_repository.dart';
+import 'package:kopim/features/profile/domain/repositories/user_progress_repository.dart';
+
+class RecomputeUserProgressUseCase {
+  RecomputeUserProgressUseCase({
+    required UserProgressRepository repository,
+    required LevelPolicy levelPolicy,
+    required AuthRepository authRepository,
+    required LoggerService loggerService,
+    DateTime Function()? clock,
+  }) : _repository = repository,
+       _levelPolicy = levelPolicy,
+       _authRepository = authRepository,
+       _logger = loggerService,
+       _clock = clock ?? DateTime.now;
+
+  final UserProgressRepository _repository;
+  final LevelPolicy _levelPolicy;
+  final AuthRepository _authRepository;
+  final LoggerService _logger;
+  final DateTime Function() _clock;
+
+  Future<UserProgress> call() async {
+    final int localCount = await _repository.countTransactions();
+    final DateTime now = _clock().toUtc();
+
+    final UserProgress progress = UserProgress(
+      totalTx: localCount,
+      level: _levelPolicy.levelFor(localCount),
+      title: _levelPolicy.titleFor(_levelPolicy.levelFor(localCount)),
+      nextThreshold: _levelPolicy.nextThreshold(localCount),
+      updatedAt: now,
+    );
+
+    await _repository.cacheProgress(progress);
+
+    final AuthUser? user = _authRepository.currentUser;
+    if (user != null && !user.isAnonymous) {
+      try {
+        final ProgressSnapshot? remote = await _repository.fetchRemoteProgress(
+          user.uid,
+        );
+        final int resolvedTotal = max(localCount, remote?.totalTx ?? 0);
+        if (remote == null || remote.totalTx != resolvedTotal) {
+          await _repository.saveRemoteProgress(
+            uid: user.uid,
+            totalTx: resolvedTotal,
+            updatedAt: now,
+          );
+        }
+      } catch (error, stackTrace) {
+        _logger.logError('Failed to sync progress for ${user.uid}', error);
+        _logger.logError('Progress sync stack: $stackTrace');
+      }
+    }
+
+    return progress;
+  }
+}

--- a/lib/features/profile/domain/usecases/update_profile_avatar_use_case.dart
+++ b/lib/features/profile/domain/usecases/update_profile_avatar_use_case.dart
@@ -1,0 +1,103 @@
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:image/image.dart' as img;
+import 'package:kopim/core/services/analytics_service.dart';
+import 'package:kopim/core/services/logger_service.dart';
+import 'package:kopim/features/profile/domain/entities/profile.dart';
+import 'package:kopim/features/profile/domain/repositories/profile_repository.dart';
+import 'package:kopim/features/profile/domain/repositories/profile_avatar_repository.dart';
+
+enum AvatarImageSource { gallery, camera }
+
+class UpdateProfileAvatarRequest {
+  const UpdateProfileAvatarRequest({
+    required this.uid,
+    required this.bytes,
+    required this.contentType,
+    required this.source,
+  });
+
+  final String uid;
+  final Uint8List bytes;
+  final String contentType;
+  final AvatarImageSource source;
+}
+
+class UpdateProfileAvatarUseCase {
+  UpdateProfileAvatarUseCase({
+    required ProfileAvatarRepository avatarRepository,
+    required ProfileRepository profileRepository,
+    required AnalyticsService analyticsService,
+    required LoggerService loggerService,
+  }) : _avatarRepository = avatarRepository,
+       _profileRepository = profileRepository,
+       _analyticsService = analyticsService,
+       _logger = loggerService;
+
+  static const int _maxBytes = 512 * 1024;
+  static const int _maxDimension = 512;
+
+  final ProfileAvatarRepository _avatarRepository;
+  final ProfileRepository _profileRepository;
+  final AnalyticsService _analyticsService;
+  final LoggerService _logger;
+
+  Future<Profile> call(UpdateProfileAvatarRequest request) async {
+    final Profile? existing = await _profileRepository.getProfile(request.uid);
+    if (existing == null) {
+      throw StateError('Profile not found for uid ${request.uid}');
+    }
+
+    final Uint8List compressed = await _compress(request.bytes);
+    final String downloadUrl = await _avatarRepository.upload(
+      uid: request.uid,
+      data: compressed,
+      contentType: request.contentType,
+    );
+
+    final Profile updated = existing.copyWith(
+      photoUrl: downloadUrl,
+      updatedAt: DateTime.now().toUtc(),
+    );
+    await _profileRepository.updateProfile(updated);
+
+    await _analyticsService.logEvent('avatar_updated', <String, Object?>{
+      'source': request.source.name,
+      'size_kb': (compressed.lengthInBytes / 1024).round(),
+    });
+
+    return updated;
+  }
+
+  Future<Uint8List> _compress(Uint8List data) async {
+    if (data.lengthInBytes <= _maxBytes) {
+      return data;
+    }
+    final img.Image? decoded = img.decodeImage(data);
+    if (decoded == null) {
+      _logger.logError('Failed to decode avatar image for compression');
+      return data;
+    }
+    final int targetWidth = decoded.width > decoded.height
+        ? _maxDimension
+        : max(1, (decoded.width * _maxDimension) ~/ decoded.height);
+    final int targetHeight = decoded.height >= decoded.width
+        ? _maxDimension
+        : max(1, (decoded.height * _maxDimension) ~/ decoded.width);
+    final img.Image resized = img.copyResize(
+      decoded,
+      width: targetWidth,
+      height: targetHeight,
+    );
+    int quality = 90;
+    Uint8List encoded = Uint8List.fromList(
+      img.encodeJpg(resized, quality: quality),
+    );
+    while (encoded.lengthInBytes > _maxBytes && quality > 50) {
+      quality -= 10;
+      encoded = Uint8List.fromList(img.encodeJpg(resized, quality: quality));
+    }
+    return encoded.lengthInBytes <= _maxBytes ? encoded : data;
+  }
+}

--- a/lib/features/profile/presentation/controllers/auth_controller.dart
+++ b/lib/features/profile/presentation/controllers/auth_controller.dart
@@ -141,6 +141,7 @@ class AuthController extends _$AuthController {
     await ref
         .read(authSyncServiceProvider)
         .synchronizeOnLogin(user: user, previousUser: previousUser);
+    await ref.read(recomputeUserProgressUseCaseProvider)();
     _initialSyncTriggered = true;
   }
 

--- a/lib/features/profile/presentation/controllers/auth_controller.g.dart
+++ b/lib/features/profile/presentation/controllers/auth_controller.g.dart
@@ -33,7 +33,7 @@ final class AuthControllerProvider
   AuthController create() => AuthController();
 }
 
-String _$authControllerHash() => r'6f74072c7f83de7b3c982d673088732779b8eac6';
+String _$authControllerHash() => r'19b53626e4cac0912879423a6ee85e9953afe523';
 
 abstract class _$AuthController extends $AsyncNotifier<AuthUser?> {
   FutureOr<AuthUser?> build();

--- a/lib/features/profile/presentation/controllers/avatar_controller.dart
+++ b/lib/features/profile/presentation/controllers/avatar_controller.dart
@@ -1,0 +1,69 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:image_picker/image_picker.dart';
+import 'package:kopim/core/di/injectors.dart';
+import 'package:kopim/features/profile/domain/usecases/update_profile_avatar_use_case.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'avatar_controller.g.dart';
+
+enum AvatarUploadSource { gallery, camera }
+
+@riverpod
+class AvatarController extends _$AvatarController {
+  final ImagePicker _picker = ImagePicker();
+
+  @override
+  AsyncValue<void> build() => const AsyncValue<void>.data(null);
+
+  Future<void> changeAvatar({
+    required AvatarUploadSource source,
+    required String uid,
+  }) async {
+    state = const AsyncValue<void>.loading();
+    try {
+      final XFile? file = await _picker.pickImage(
+        source: source == AvatarUploadSource.gallery
+            ? ImageSource.gallery
+            : ImageSource.camera,
+        imageQuality: 95,
+        maxWidth: 2048,
+        maxHeight: 2048,
+      );
+      if (file == null) {
+        state = const AsyncValue<void>.data(null);
+        return;
+      }
+      final Uint8List bytes = await file.readAsBytes();
+      final String contentType =
+          file.mimeType ?? _guessContentType(file.path) ?? 'image/jpeg';
+      final UpdateProfileAvatarUseCase useCase = ref.read(
+        updateProfileAvatarUseCaseProvider,
+      );
+      await useCase(
+        UpdateProfileAvatarRequest(
+          uid: uid,
+          bytes: bytes,
+          contentType: contentType,
+          source: source == AvatarUploadSource.gallery
+              ? AvatarImageSource.gallery
+              : AvatarImageSource.camera,
+        ),
+      );
+      state = const AsyncValue<void>.data(null);
+    } catch (error, stackTrace) {
+      state = AsyncValue<void>.error(error, stackTrace);
+    }
+  }
+
+  String? _guessContentType(String path) {
+    final String lower = path.toLowerCase();
+    if (lower.endsWith('.jpg') || lower.endsWith('.jpeg')) {
+      return 'image/jpeg';
+    }
+    if (lower.endsWith('.png')) return 'image/png';
+    if (lower.endsWith('.webp')) return 'image/webp';
+    return null;
+  }
+}

--- a/lib/features/profile/presentation/controllers/avatar_controller.g.dart
+++ b/lib/features/profile/presentation/controllers/avatar_controller.g.dart
@@ -1,0 +1,63 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'avatar_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(AvatarController)
+const avatarControllerProvider = AvatarControllerProvider._();
+
+final class AvatarControllerProvider
+    extends $NotifierProvider<AvatarController, AsyncValue<void>> {
+  const AvatarControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'avatarControllerProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$avatarControllerHash();
+
+  @$internal
+  @override
+  AvatarController create() => AvatarController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<void> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AsyncValue<void>>(value),
+    );
+  }
+}
+
+String _$avatarControllerHash() => r'b79d8f13afd109f094f326191a54a8f50160406d';
+
+abstract class _$AvatarController extends $Notifier<AsyncValue<void>> {
+  AsyncValue<void> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build();
+    final ref = this.ref as $Ref<AsyncValue<void>, AsyncValue<void>>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<void>, AsyncValue<void>>,
+              AsyncValue<void>,
+              Object?,
+              Object?
+            >;
+    element.handleValue(ref, created);
+  }
+}

--- a/lib/features/profile/presentation/controllers/profile_form_controller.dart
+++ b/lib/features/profile/presentation/controllers/profile_form_controller.dart
@@ -31,6 +31,7 @@ class ProfileFormState {
     required this.name,
     required this.currency,
     required this.locale,
+    this.photoUrl,
     required this.isSaving,
     this.errorMessage,
     this.initialProfile,
@@ -44,6 +45,7 @@ class ProfileFormState {
           name: '',
           currency: ProfileCurrency.rub,
           locale: 'en',
+          photoUrl: null,
           updatedAt: DateTime.fromMillisecondsSinceEpoch(0),
         );
     return ProfileFormState(
@@ -51,6 +53,7 @@ class ProfileFormState {
       name: base.name,
       currency: base.currency,
       locale: base.locale,
+      photoUrl: base.photoUrl,
       isSaving: false,
       initialProfile: base,
     );
@@ -60,6 +63,7 @@ class ProfileFormState {
   final String name;
   final ProfileCurrency currency;
   final String locale;
+  final String? photoUrl;
   final bool isSaving;
   final String? errorMessage;
   final Profile? initialProfile;
@@ -72,6 +76,7 @@ class ProfileFormState {
           name: '',
           currency: ProfileCurrency.rub,
           locale: 'en',
+          photoUrl: null,
           updatedAt: DateTime.fromMillisecondsSinceEpoch(0),
         );
     return name != base.name ||
@@ -83,6 +88,7 @@ class ProfileFormState {
     String? name,
     ProfileCurrency? currency,
     String? locale,
+    String? photoUrl,
     bool? isSaving,
     Profile? initialProfile,
     String? errorMessage,
@@ -93,6 +99,7 @@ class ProfileFormState {
       name: name ?? this.name,
       currency: currency ?? this.currency,
       locale: locale ?? this.locale,
+      photoUrl: photoUrl ?? this.photoUrl,
       isSaving: isSaving ?? this.isSaving,
       errorMessage: clearError ? null : (errorMessage ?? this.errorMessage),
       initialProfile: initialProfile ?? this.initialProfile,
@@ -105,6 +112,7 @@ class ProfileFormState {
       name: name,
       currency: currency,
       locale: locale,
+      photoUrl: photoUrl,
       updatedAt: DateTime.now().toUtc(),
     );
   }

--- a/lib/features/profile/presentation/controllers/user_progress_controller.dart
+++ b/lib/features/profile/presentation/controllers/user_progress_controller.dart
@@ -1,0 +1,57 @@
+import 'dart:async';
+
+import 'package:kopim/core/di/injectors.dart';
+import 'package:kopim/features/profile/domain/entities/user_progress.dart';
+import 'package:kopim/features/profile/domain/policies/level_policy.dart';
+import 'package:kopim/features/profile/domain/repositories/user_progress_repository.dart';
+import 'package:kopim/features/profile/domain/usecases/recompute_user_progress_use_case.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'user_progress_controller.g.dart';
+
+@riverpod
+Stream<UserProgress> userProgress(Ref ref, String uid) {
+  final LevelPolicy policy = ref.watch(levelPolicyProvider);
+  final UserProgressRepository repository = ref.watch(
+    userProgressRepositoryProvider,
+  );
+  final RecomputeUserProgressUseCase recompute = ref.watch(
+    recomputeUserProgressUseCaseProvider,
+  );
+
+  unawaited(recompute());
+
+  final StreamController<UserProgress> controller =
+      StreamController<UserProgress>.broadcast();
+
+  final StreamSubscription<int> countSubscription = repository
+      .watchTransactionCount()
+      .listen((int count) {
+        final int level = policy.levelFor(count);
+        final UserProgress progress = UserProgress(
+          totalTx: count,
+          level: level,
+          title: policy.titleFor(level),
+          nextThreshold: policy.nextThreshold(count),
+          updatedAt: DateTime.now().toUtc(),
+        );
+        controller.add(progress);
+        unawaited(repository.cacheProgress(progress));
+      });
+
+  final StreamSubscription<UserProgress?> cacheSubscription = repository
+      .watchCachedProgress()
+      .listen((UserProgress? progress) {
+        if (progress != null) {
+          controller.add(progress);
+        }
+      });
+
+  ref.onDispose(() async {
+    await countSubscription.cancel();
+    await cacheSubscription.cancel();
+    await controller.close();
+  });
+
+  return controller.stream;
+}

--- a/lib/features/profile/presentation/controllers/user_progress_controller.g.dart
+++ b/lib/features/profile/presentation/controllers/user_progress_controller.g.dart
@@ -1,0 +1,85 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'user_progress_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(userProgress)
+const userProgressProvider = UserProgressFamily._();
+
+final class UserProgressProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<UserProgress>,
+          UserProgress,
+          Stream<UserProgress>
+        >
+    with $FutureModifier<UserProgress>, $StreamProvider<UserProgress> {
+  const UserProgressProvider._({
+    required UserProgressFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'userProgressProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$userProgressHash();
+
+  @override
+  String toString() {
+    return r'userProgressProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $StreamProviderElement<UserProgress> $createElement(
+    $ProviderPointer pointer,
+  ) => $StreamProviderElement(pointer);
+
+  @override
+  Stream<UserProgress> create(Ref ref) {
+    final argument = this.argument as String;
+    return userProgress(ref, argument);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is UserProgressProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$userProgressHash() => r'f7e56ecaddd4d85170bfc4ccfd43f702f0984668';
+
+final class UserProgressFamily extends $Family
+    with $FunctionalFamilyOverride<Stream<UserProgress>, String> {
+  const UserProgressFamily._()
+    : super(
+        retry: null,
+        name: r'userProgressProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  UserProgressProvider call(String uid) =>
+      UserProgressProvider._(argument: uid, from: this);
+
+  @override
+  String toString() => r'userProgressProvider';
+}

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -2,6 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:kopim/features/app_shell/presentation/models/navigation_tab_content.dart';
+import 'package:kopim/features/profile/domain/entities/auth_user.dart';
+import 'package:kopim/features/profile/presentation/controllers/auth_controller.dart';
+import 'package:kopim/features/profile/presentation/controllers/avatar_controller.dart';
 import 'package:kopim/features/profile/presentation/screens/general_settings_screen.dart';
 import 'package:kopim/features/profile/presentation/widgets/profile_management_body.dart';
 import 'package:kopim/l10n/app_localizations.dart';
@@ -33,9 +36,26 @@ NavigationTabContent buildProfileTabContent(
   return NavigationTabContent(
     appBarBuilder: (BuildContext context, WidgetRef ref) {
       final AppLocalizations strings = AppLocalizations.of(context)!;
+      final AuthUser? user = ref.watch(authControllerProvider).value;
       return AppBar(
         title: Text(strings.profileTitle),
         actions: <Widget>[
+          if (user != null)
+            PopupMenuButton<_ProfileMenuAction>(
+              icon: const Icon(Icons.more_vert),
+              onSelected: (_ProfileMenuAction action) {
+                if (action == _ProfileMenuAction.changeAvatar) {
+                  _showAvatarSourceSheet(context, ref, user.uid);
+                }
+              },
+              itemBuilder: (BuildContext context) =>
+                  <PopupMenuEntry<_ProfileMenuAction>>[
+                    PopupMenuItem<_ProfileMenuAction>(
+                      value: _ProfileMenuAction.changeAvatar,
+                      child: Text(strings.profileChangeAvatar),
+                    ),
+                  ],
+            ),
           IconButton(
             tooltip: strings.profileGeneralSettingsTooltip,
             icon: const Icon(Icons.tune),
@@ -48,5 +68,44 @@ NavigationTabContent buildProfileTabContent(
     },
     bodyBuilder: (BuildContext context, WidgetRef ref) =>
         const ProfileManagementBody(),
+  );
+}
+
+enum _ProfileMenuAction { changeAvatar }
+
+void _showAvatarSourceSheet(BuildContext context, WidgetRef ref, String uid) {
+  final AppLocalizations strings = AppLocalizations.of(context)!;
+  showModalBottomSheet<void>(
+    context: context,
+    showDragHandle: true,
+    builder: (BuildContext sheetContext) {
+      return SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            ListTile(
+              leading: const Icon(Icons.photo_library_outlined),
+              title: Text(strings.profileChangeAvatarGallery),
+              onTap: () async {
+                Navigator.of(sheetContext).pop();
+                await ref
+                    .read(avatarControllerProvider.notifier)
+                    .changeAvatar(source: AvatarUploadSource.gallery, uid: uid);
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.photo_camera_outlined),
+              title: Text(strings.profileChangeAvatarCamera),
+              onTap: () async {
+                Navigator.of(sheetContext).pop();
+                await ref
+                    .read(avatarControllerProvider.notifier)
+                    .changeAvatar(source: AvatarUploadSource.camera, uid: uid);
+              },
+            ),
+          ],
+        ),
+      );
+    },
   );
 }

--- a/lib/features/transactions/data/sources/local/transaction_dao.dart
+++ b/lib/features/transactions/data/sources/local/transaction_dao.dart
@@ -14,11 +14,31 @@ class TransactionDao {
     return query.watch();
   }
 
+  Stream<int> watchActiveCount() {
+    return _db
+        .customSelect(
+          'SELECT COUNT(*) AS count FROM transactions WHERE is_deleted = 0',
+          readsFrom: <TableInfo<dynamic, dynamic>>{_db.transactions},
+        )
+        .watchSingle()
+        .map((QueryRow row) => row.read<int>('count'));
+  }
+
   Future<List<db.TransactionRow>> getActiveTransactions() {
     final SimpleSelectStatement<db.$TransactionsTable, db.TransactionRow>
     query = _db.select(_db.transactions)
       ..where((db.$TransactionsTable tbl) => tbl.isDeleted.equals(false));
     return query.get();
+  }
+
+  Future<int> countActiveTransactions() async {
+    final QueryRow row = await _db
+        .customSelect(
+          'SELECT COUNT(*) AS count FROM transactions WHERE is_deleted = 0',
+          readsFrom: <TableInfo<dynamic, dynamic>>{_db.transactions},
+        )
+        .getSingle();
+    return row.read<int>('count');
   }
 
   Future<List<TransactionEntity>> getAllTransactions() async {

--- a/lib/features/transactions/domain/use_cases/add_transaction_use_case.dart
+++ b/lib/features/transactions/domain/use_cases/add_transaction_use_case.dart
@@ -4,16 +4,19 @@ import 'package:kopim/features/transactions/domain/entities/add_transaction_requ
 import 'package:kopim/features/transactions/domain/entities/transaction.dart';
 import 'package:kopim/features/transactions/domain/entities/transaction_type.dart';
 import 'package:kopim/features/transactions/domain/repositories/transaction_repository.dart';
+import 'package:kopim/features/profile/domain/usecases/on_transaction_created_use_case.dart';
 import 'package:uuid/uuid.dart';
 
 class AddTransactionUseCase {
   AddTransactionUseCase({
     required TransactionRepository transactionRepository,
     required AccountRepository accountRepository,
+    OnTransactionCreatedUseCase? onTransactionCreatedUseCase,
     String Function()? idGenerator,
     DateTime Function()? clock,
   }) : _transactionRepository = transactionRepository,
        _accountRepository = accountRepository,
+       _onTransactionCreatedUseCase = onTransactionCreatedUseCase,
        _generateId = idGenerator ?? _defaultIdGenerator,
        _clock = clock ?? _defaultClock;
 
@@ -23,6 +26,7 @@ class AddTransactionUseCase {
 
   final TransactionRepository _transactionRepository;
   final AccountRepository _accountRepository;
+  final OnTransactionCreatedUseCase? _onTransactionCreatedUseCase;
   final String Function() _generateId;
   final DateTime Function() _clock;
 
@@ -58,5 +62,7 @@ class AddTransactionUseCase {
       updatedAt: now,
     );
     await _accountRepository.upsert(updatedAccount);
+
+    await _onTransactionCreatedUseCase?.call();
   }
 }

--- a/lib/features/transactions/domain/use_cases/delete_transaction_use_case.dart
+++ b/lib/features/transactions/domain/use_cases/delete_transaction_use_case.dart
@@ -3,18 +3,22 @@ import 'package:kopim/features/accounts/domain/repositories/account_repository.d
 import 'package:kopim/features/transactions/domain/entities/transaction.dart';
 import 'package:kopim/features/transactions/domain/entities/transaction_type.dart';
 import 'package:kopim/features/transactions/domain/repositories/transaction_repository.dart';
+import 'package:kopim/features/profile/domain/usecases/on_transaction_deleted_use_case.dart';
 
 class DeleteTransactionUseCase {
   DeleteTransactionUseCase({
     required TransactionRepository transactionRepository,
     required AccountRepository accountRepository,
+    OnTransactionDeletedUseCase? onTransactionDeletedUseCase,
     DateTime Function()? clock,
   }) : _transactionRepository = transactionRepository,
        _accountRepository = accountRepository,
+       _onTransactionDeletedUseCase = onTransactionDeletedUseCase,
        _clock = clock ?? DateTime.now;
 
   final TransactionRepository _transactionRepository;
   final AccountRepository _accountRepository;
+  final OnTransactionDeletedUseCase? _onTransactionDeletedUseCase;
   final DateTime Function() _clock;
 
   Future<void> call(String transactionId) async {
@@ -44,6 +48,7 @@ class DeleteTransactionUseCase {
     await _accountRepository.upsert(updatedAccount);
 
     await _transactionRepository.softDelete(transactionId);
+    await _onTransactionDeletedUseCase?.call();
   }
 
   TransactionType _parseType(String raw) {

--- a/lib/features/transactions/presentation/widgets/transaction_form_view.dart
+++ b/lib/features/transactions/presentation/widgets/transaction_form_view.dart
@@ -61,6 +61,13 @@ class TransactionFormView extends ConsumerWidget {
       transactionFormControllerProvider(formArgs),
       (TransactionFormState? previous, TransactionFormState next) {
         if (next.isSuccess && previous?.isSuccess != next.isSuccess) {
+          if (formArgs.initialTransaction == null && context.mounted) {
+            ScaffoldMessenger.of(context)
+              ..hideCurrentSnackBar()
+              ..showSnackBar(
+                SnackBar(content: Text(strings.transactionXpGained)),
+              );
+          }
           ref
               .read(transactionFormControllerProvider(formArgs).notifier)
               .acknowledgeSuccess();

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -321,6 +321,85 @@
       }
     }
   },
+  "profileUnnamed": "Explorer",
+  "@profileUnnamed": {
+    "description": "Placeholder name when the user has not specified one"
+  },
+  "profileChangeAvatar": "Change avatar",
+  "@profileChangeAvatar": {
+    "description": "Menu item and button label for changing the avatar"
+  },
+  "profileChangeAvatarGallery": "Choose from gallery",
+  "@profileChangeAvatarGallery": {
+    "description": "Action label for selecting an avatar from the gallery"
+  },
+  "profileChangeAvatarCamera": "Take a photo",
+  "@profileChangeAvatarCamera": {
+    "description": "Action label for capturing an avatar with the camera"
+  },
+  "profileAvatarUploadError": "Couldn't update avatar. Please try again.",
+  "@profileAvatarUploadError": {
+    "description": "Snackbar shown when the avatar upload fails"
+  },
+  "profileAvatarUploadSuccess": "Avatar updated",
+  "@profileAvatarUploadSuccess": {
+    "description": "Snackbar shown when the avatar upload succeeds"
+  },
+  "profileLevelBadge": "Level {level} — {title}",
+  "@profileLevelBadge": {
+    "description": "Badge text combining the numeric level and the title",
+    "placeholders": {
+      "level": {
+        "type": "int"
+      },
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "profileXp": "XP: {current} / {next}",
+  "@profileXp": {
+    "description": "Label showing the current XP relative to the next threshold",
+    "placeholders": {
+      "current": {
+        "type": "int"
+      },
+      "next": {
+        "type": "int"
+      }
+    }
+  },
+  "profileXpMax": "XP: {current}",
+  "@profileXpMax": {
+    "description": "Label when the user reached the highest level",
+    "placeholders": {
+      "current": {
+        "type": "int"
+      }
+    }
+  },
+  "profileXpToNext": "{count} XP to the next level",
+  "@profileXpToNext": {
+    "description": "Caption indicating remaining XP to reach the next level",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "profileLevelMaxReached": "You have reached the highest rank!",
+  "@profileLevelMaxReached": {
+    "description": "Caption shown when the user is at the highest level"
+  },
+  "profileProgressError": "Unable to load progress: {error}",
+  "@profileProgressError": {
+    "description": "Error message displayed when progress cannot be loaded",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "profileSaveCta": "Save changes",
   "@profileSaveCta": {
     "description": "Label for the save button on profile form"
@@ -907,6 +986,10 @@
   "transactionDeleteSuccess": "Transaction deleted.",
   "@transactionDeleteSuccess": {
     "description": "Shown when a transaction is deleted successfully"
+  },
+  "transactionXpGained": "+1 XP",
+  "@transactionXpGained": {
+    "description": "Snackbar text shown after creating a new transaction"
   },
   "transactionDeleteConfirmTitle": "Delete transaction",
   "@transactionDeleteConfirmTitle": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -542,6 +542,78 @@ abstract class AppLocalizations {
   /// **'Unable to load profile: {error}'**
   String profileLoadError(String error);
 
+  /// Placeholder name when the user has not specified one
+  ///
+  /// In en, this message translates to:
+  /// **'Explorer'**
+  String get profileUnnamed;
+
+  /// Menu item and button label for changing the avatar
+  ///
+  /// In en, this message translates to:
+  /// **'Change avatar'**
+  String get profileChangeAvatar;
+
+  /// Action label for selecting an avatar from the gallery
+  ///
+  /// In en, this message translates to:
+  /// **'Choose from gallery'**
+  String get profileChangeAvatarGallery;
+
+  /// Action label for capturing an avatar with the camera
+  ///
+  /// In en, this message translates to:
+  /// **'Take a photo'**
+  String get profileChangeAvatarCamera;
+
+  /// Snackbar shown when the avatar upload fails
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t update avatar. Please try again.'**
+  String get profileAvatarUploadError;
+
+  /// Snackbar shown when the avatar upload succeeds
+  ///
+  /// In en, this message translates to:
+  /// **'Avatar updated'**
+  String get profileAvatarUploadSuccess;
+
+  /// Badge text combining the numeric level and the title
+  ///
+  /// In en, this message translates to:
+  /// **'Level {level} — {title}'**
+  String profileLevelBadge(int level, String title);
+
+  /// Label showing the current XP relative to the next threshold
+  ///
+  /// In en, this message translates to:
+  /// **'XP: {current} / {next}'**
+  String profileXp(int current, int next);
+
+  /// Label when the user reached the highest level
+  ///
+  /// In en, this message translates to:
+  /// **'XP: {current}'**
+  String profileXpMax(int current);
+
+  /// Caption indicating remaining XP to reach the next level
+  ///
+  /// In en, this message translates to:
+  /// **'{count} XP to the next level'**
+  String profileXpToNext(int count);
+
+  /// Caption shown when the user is at the highest level
+  ///
+  /// In en, this message translates to:
+  /// **'You have reached the highest rank!'**
+  String get profileLevelMaxReached;
+
+  /// Error message displayed when progress cannot be loaded
+  ///
+  /// In en, this message translates to:
+  /// **'Unable to load progress: {error}'**
+  String profileProgressError(String error);
+
   /// Label for the save button on profile form
   ///
   /// In en, this message translates to:
@@ -1303,6 +1375,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Transaction deleted.'**
   String get transactionDeleteSuccess;
+
+  /// Snackbar text shown after creating a new transaction
+  ///
+  /// In en, this message translates to:
+  /// **'+1 XP'**
+  String get transactionXpGained;
 
   /// Title for the transaction deletion confirmation dialog
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -242,6 +242,53 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get profileUnnamed => 'Explorer';
+
+  @override
+  String get profileChangeAvatar => 'Change avatar';
+
+  @override
+  String get profileChangeAvatarGallery => 'Choose from gallery';
+
+  @override
+  String get profileChangeAvatarCamera => 'Take a photo';
+
+  @override
+  String get profileAvatarUploadError =>
+      'Couldn\'t update avatar. Please try again.';
+
+  @override
+  String get profileAvatarUploadSuccess => 'Avatar updated';
+
+  @override
+  String profileLevelBadge(int level, String title) {
+    return 'Level $level — $title';
+  }
+
+  @override
+  String profileXp(int current, int next) {
+    return 'XP: $current / $next';
+  }
+
+  @override
+  String profileXpMax(int current) {
+    return 'XP: $current';
+  }
+
+  @override
+  String profileXpToNext(int count) {
+    return '$count XP to the next level';
+  }
+
+  @override
+  String get profileLevelMaxReached => 'You have reached the highest rank!';
+
+  @override
+  String profileProgressError(String error) {
+    return 'Unable to load progress: $error';
+  }
+
+  @override
   String get profileSaveCta => 'Save changes';
 
   @override
@@ -681,6 +728,9 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get transactionDeleteSuccess => 'Transaction deleted.';
+
+  @override
+  String get transactionXpGained => '+1 XP';
 
   @override
   String get transactionDeleteConfirmTitle => 'Delete transaction';

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -244,6 +244,53 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
+  String get profileUnnamed => 'Исследователь';
+
+  @override
+  String get profileChangeAvatar => 'Сменить аватар';
+
+  @override
+  String get profileChangeAvatarGallery => 'Выбрать из галереи';
+
+  @override
+  String get profileChangeAvatarCamera => 'Сделать фото';
+
+  @override
+  String get profileAvatarUploadError =>
+      'Не удалось обновить аватар. Попробуйте ещё раз.';
+
+  @override
+  String get profileAvatarUploadSuccess => 'Аватар обновлён';
+
+  @override
+  String profileLevelBadge(int level, String title) {
+    return 'Уровень $level — $title';
+  }
+
+  @override
+  String profileXp(int current, int next) {
+    return 'XP: $current / $next';
+  }
+
+  @override
+  String profileXpMax(int current) {
+    return 'XP: $current';
+  }
+
+  @override
+  String profileXpToNext(int count) {
+    return 'До следующего уровня: $count XP';
+  }
+
+  @override
+  String get profileLevelMaxReached => 'Вы достигли максимального ранга!';
+
+  @override
+  String profileProgressError(String error) {
+    return 'Не удалось загрузить прогресс: $error';
+  }
+
+  @override
   String get profileSaveCta => 'Сохранить изменения';
 
   @override
@@ -685,6 +732,9 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get transactionDeleteSuccess => 'Транзакция удалена.';
+
+  @override
+  String get transactionXpGained => '+1 XP';
 
   @override
   String get transactionDeleteConfirmTitle => 'Удалить операцию';

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -321,6 +321,85 @@
       }
     }
   },
+  "profileUnnamed": "Исследователь",
+  "@profileUnnamed": {
+    "description": "Имя по умолчанию, когда пользователь не указал своё"
+  },
+  "profileChangeAvatar": "Сменить аватар",
+  "@profileChangeAvatar": {
+    "description": "Пункт меню и кнопка для смены аватара"
+  },
+  "profileChangeAvatarGallery": "Выбрать из галереи",
+  "@profileChangeAvatarGallery": {
+    "description": "Действие для выбора аватара из галереи"
+  },
+  "profileChangeAvatarCamera": "Сделать фото",
+  "@profileChangeAvatarCamera": {
+    "description": "Действие для съёмки аватара на камеру"
+  },
+  "profileAvatarUploadError": "Не удалось обновить аватар. Попробуйте ещё раз.",
+  "@profileAvatarUploadError": {
+    "description": "Сообщение об ошибке при загрузке аватара"
+  },
+  "profileAvatarUploadSuccess": "Аватар обновлён",
+  "@profileAvatarUploadSuccess": {
+    "description": "Сообщение об успешном обновлении аватара"
+  },
+  "profileLevelBadge": "Уровень {level} — {title}",
+  "@profileLevelBadge": {
+    "description": "Надпись на бейдже с номером уровня и титулом",
+    "placeholders": {
+      "level": {
+        "type": "int"
+      },
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "profileXp": "XP: {current} / {next}",
+  "@profileXp": {
+    "description": "Подпись с текущим количеством XP и порогом следующего уровня",
+    "placeholders": {
+      "current": {
+        "type": "int"
+      },
+      "next": {
+        "type": "int"
+      }
+    }
+  },
+  "profileXpMax": "XP: {current}",
+  "@profileXpMax": {
+    "description": "Подпись, когда достигнут максимальный уровень",
+    "placeholders": {
+      "current": {
+        "type": "int"
+      }
+    }
+  },
+  "profileXpToNext": "До следующего уровня: {count} XP",
+  "@profileXpToNext": {
+    "description": "Сообщение с оставшимся количеством XP до нового уровня",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "profileLevelMaxReached": "Вы достигли максимального ранга!",
+  "@profileLevelMaxReached": {
+    "description": "Подпись, когда пользователь на максимальном уровне"
+  },
+  "profileProgressError": "Не удалось загрузить прогресс: {error}",
+  "@profileProgressError": {
+    "description": "Сообщение об ошибке при загрузке прогресса",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "profileSaveCta": "Сохранить изменения",
   "@profileSaveCta": {
     "description": "Кнопка сохранения профиля"
@@ -907,6 +986,10 @@
   "transactionDeleteSuccess": "Транзакция удалена.",
   "@transactionDeleteSuccess": {
     "description": "Сообщение об успешном удалении транзакции"
+  },
+  "transactionXpGained": "+1 XP",
+  "@transactionXpGained": {
+    "description": "Тост после создания новой транзакции"
   },
   "transactionDeleteConfirmTitle": "Удалить операцию",
   "@transactionDeleteConfirmTitle": {

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,10 +6,14 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <file_selector_linux/file_selector_plugin.h>
 #include <sentry_flutter/sentry_flutter_plugin.h>
 #include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
+  file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
   g_autoptr(FlPluginRegistrar) sentry_flutter_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "SentryFlutterPlugin");
   sentry_flutter_plugin_register_with_registrar(sentry_flutter_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  file_selector_linux
   sentry_flutter
   sqlite3_flutter_libs
 )

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   google_sign_in: ^7.2.0
   firebase_analytics: ^12.0.2
   firebase_crashlytics: ^5.0.2
+  firebase_storage: ^13.0.2
   riverpod_annotation: ^3.0.0
 
   # Logging and monitoring
@@ -47,6 +48,8 @@ dependencies:
   meta: ^1.16.0
   crypto: ^3.0.3
   shared_preferences: ^2.3.2
+  image_picker: ^1.2.0
+  image: ^4.5.4
 
 
   # Analytics UI (charts) - merged, use syncfusion as advanced alternative

--- a/test/features/profile/domain/policies/simple_level_policy_test.dart
+++ b/test/features/profile/domain/policies/simple_level_policy_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kopim/features/profile/domain/policies/level_policy.dart';
+
+void main() {
+  const SimpleLevelPolicy policy = SimpleLevelPolicy();
+
+  test('level boundaries are respected', () {
+    expect(policy.levelFor(0), 1);
+    expect(policy.levelFor(99), 1);
+    expect(policy.levelFor(100), 2);
+    expect(policy.levelFor(499), 2);
+    expect(policy.levelFor(500), 3);
+    expect(policy.levelFor(1999), 3);
+    expect(policy.levelFor(2000), 4);
+    expect(policy.levelFor(4999), 4);
+    expect(policy.levelFor(5000), 5);
+    expect(policy.levelFor(8000), 5);
+  });
+
+  test('titles correspond to levels', () {
+    expect(policy.titleFor(1), 'Птенец Тоторо');
+    expect(policy.titleFor(2), 'Ученик Кодамы');
+    expect(policy.titleFor(3), 'Путник по Небу Лапуты');
+    expect(policy.titleFor(4), 'Ходящий по Замкам');
+    expect(policy.titleFor(5), 'Дракон Реки');
+  });
+
+  test('next threshold returns closest boundary', () {
+    expect(policy.nextThreshold(0), 100);
+    expect(policy.nextThreshold(150), 500);
+    expect(policy.nextThreshold(1200), 2000);
+    expect(policy.nextThreshold(3200), 5000);
+    expect(policy.nextThreshold(6000), 6000);
+  });
+}

--- a/test/features/profile/presentation/profile_screen_test.dart
+++ b/test/features/profile/presentation/profile_screen_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod/src/framework.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kopim/core/di/injectors.dart';
 import 'package:kopim/features/categories/domain/entities/category_tree_node.dart';
@@ -159,8 +160,7 @@ void main() {
   ) async {
     await tester.pumpWidget(
       ProviderScope(
-        // ignore: always_specify_types
-        overrides: [
+        overrides: <Override>[
           authControllerProvider.overrideWith(
             () => _FakeAuthController(signedInUser),
           ),
@@ -211,8 +211,7 @@ void main() {
   ) async {
     await tester.pumpWidget(
       ProviderScope(
-        // ignore: always_specify_types
-        overrides: [
+        overrides: <Override>[
           authControllerProvider.overrideWith(() => _FakeAuthController(null)),
           updateProfileUseCaseProvider.overrideWith(
             (Ref ref) => _StubUpdateProfileUseCase(),
@@ -249,8 +248,7 @@ void main() {
 
     await tester.pumpWidget(
       ProviderScope(
-        // ignore: always_specify_types
-        overrides: [
+        overrides: <Override>[
           authControllerProvider.overrideWith(
             () => _FakeAuthController(signedInUser),
           ),
@@ -304,8 +302,7 @@ void main() {
 
     await tester.pumpWidget(
       ProviderScope(
-        // ignore: always_specify_types
-        overrides: [
+        overrides: <Override>[
           authControllerProvider.overrideWith(
             () => _SignOutSpyAuthController(
               signedInUser,
@@ -337,10 +334,13 @@ void main() {
 
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Account'));
-    await tester.pumpAndSettle();
+    final BuildContext context = tester.element(find.byType(ProfileScreen));
+    final AppLocalizations strings = AppLocalizations.of(context)!;
 
-    await tester.tap(find.text('Sign out'));
+    final Finder signOutButton = find.text(strings.profileSignOutCta);
+
+    await tester.ensureVisible(signOutButton);
+    await tester.tap(signOutButton, warnIfMissed: false);
     await tester.pump();
 
     expect(didSignOut, isTrue);

--- a/test/features/profile/presentation/widgets/profile_overview_card_test.dart
+++ b/test/features/profile/presentation/widgets/profile_overview_card_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:kopim/features/profile/domain/entities/profile.dart';
+import 'package:kopim/features/profile/domain/entities/user_progress.dart';
+import 'package:kopim/features/profile/presentation/widgets/profile_overview_card.dart';
+import 'package:kopim/l10n/app_localizations.dart';
+
+void main() {
+  testWidgets('renders avatar preview and level badge', (
+    WidgetTester tester,
+  ) async {
+    final Profile profile = Profile(
+      uid: 'test-user',
+      name: 'Totoro Fan',
+      currency: ProfileCurrency.rub,
+      locale: 'ru',
+      photoUrl: 'https://example.com/avatar.jpg',
+      updatedAt: DateTime.now(),
+    );
+
+    final UserProgress progress = UserProgress(
+      totalTx: 150,
+      level: 2,
+      title: 'Ученик Кодамы',
+      nextThreshold: 500,
+      updatedAt: DateTime.now(),
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: ProfileOverviewCard(
+              profile: profile,
+              progressAsync: AsyncValue<UserProgress>.data(progress),
+              uid: profile.uid,
+              avatarState: const AsyncData<void>(null),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.byType(CircleAvatar), findsOneWidget);
+    expect(find.textContaining('Level'), findsOneWidget);
+  });
+}

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -8,8 +8,10 @@
 
 #include <cloud_firestore/cloud_firestore_plugin_c_api.h>
 #include <connectivity_plus/connectivity_plus_windows_plugin.h>
+#include <file_selector_windows/file_selector_windows.h>
 #include <firebase_auth/firebase_auth_plugin_c_api.h>
 #include <firebase_core/firebase_core_plugin_c_api.h>
+#include <firebase_storage/firebase_storage_plugin_c_api.h>
 #include <sentry_flutter/sentry_flutter_plugin.h>
 #include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 
@@ -18,10 +20,14 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("CloudFirestorePluginCApi"));
   ConnectivityPlusWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("ConnectivityPlusWindowsPlugin"));
+  FileSelectorWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FileSelectorWindows"));
   FirebaseAuthPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FirebaseAuthPluginCApi"));
   FirebaseCorePluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FirebaseCorePluginCApi"));
+  FirebaseStoragePluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FirebaseStoragePluginCApi"));
   SentryFlutterPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("SentryFlutterPlugin"));
   Sqlite3FlutterLibsPluginRegisterWithRegistrar(


### PR DESCRIPTION
## Описание
- добавлены политика уровней, сущность UserProgress и репозитории с use case для пересчёта прогресса и синхронизации с Firestore
- реализован контроллер прогресса и виджеты профиля с отображением бейджа, прогресс-бара и сменой аватара через image_picker и Firebase Storage
- подключён пересчёт прогресса при создании/удалении транзакций, показ тоста «+1 XP» и покрывающие unit/widget тесты

## Тесты
- `dart format --set-exit-if-changed .`
- `flutter analyze`
- `dart run build_runner build --delete-conflicting-outputs`
- `flutter test --reporter expanded`
- `flutter pub outdated`


------
https://chatgpt.com/codex/tasks/task_e_68e2c0735cb0832e9409537d5b6036e1