### PR TITLE
Добавление удаления счёта и улучшение офлайн-режима профиля

### DIFF
--- a/lib/core/di/injectors.dart
+++ b/lib/core/di/injectors.dart
@@ -20,6 +20,7 @@ import 'package:kopim/features/accounts/data/sources/local/account_dao.dart';
 import 'package:kopim/features/accounts/data/sources/remote/account_remote_data_source.dart';
 import 'package:kopim/features/accounts/domain/repositories/account_repository.dart';
 import 'package:kopim/features/accounts/domain/use_cases/add_account_use_case.dart';
+import 'package:kopim/features/accounts/domain/use_cases/delete_account_use_case.dart';
 import 'package:kopim/features/accounts/domain/use_cases/watch_accounts_use_case.dart';
 import 'package:kopim/features/budgets/data/repositories/budget_repository_impl.dart';
 import 'package:kopim/features/budgets/data/sources/local/budget_dao.dart';
@@ -130,8 +131,12 @@ Connectivity connectivity(Ref ref) => Connectivity();
 @riverpod
 Uuid uuidGenerator(Ref ref) => const Uuid();
 
-@riverpod
-AppDatabase appDatabase(Ref ref) => AppDatabase();
+@Riverpod(keepAlive: true)
+AppDatabase appDatabase(Ref ref) {
+  final AppDatabase database = AppDatabase();
+  ref.onDispose(database.close);
+  return database;
+}
 
 @riverpod
 OutboxDao outboxDao(Ref ref) => OutboxDao(ref.watch(appDatabaseProvider));
@@ -244,6 +249,10 @@ AccountRepository accountRepository(Ref ref) => AccountRepositoryImpl(
 @riverpod
 AddAccountUseCase addAccountUseCase(Ref ref) =>
     AddAccountUseCase(ref.watch(accountRepositoryProvider));
+
+@riverpod
+DeleteAccountUseCase deleteAccountUseCase(Ref ref) =>
+    DeleteAccountUseCase(ref.watch(accountRepositoryProvider));
 
 @riverpod
 WatchAccountsUseCase watchAccountsUseCase(Ref ref) =>

--- a/lib/core/di/injectors.g.dart
+++ b/lib/core/di/injectors.g.dart
@@ -401,7 +401,7 @@ final class AppDatabaseProvider
         argument: null,
         retry: null,
         name: r'appDatabaseProvider',
-        isAutoDispose: true,
+        isAutoDispose: false,
         dependencies: null,
         $allTransitiveDependencies: null,
       );
@@ -428,7 +428,7 @@ final class AppDatabaseProvider
   }
 }
 
-String _$appDatabaseHash() => r'd45cc0b6c7795466b6a12d864805fefa097f39cd';
+String _$appDatabaseHash() => r'79fbc893ebdcc6adbd4c31ca4e8922a8f9832d4d';
 
 @ProviderFor(outboxDao)
 const outboxDaoProvider = OutboxDaoProvider._();
@@ -1756,6 +1756,54 @@ final class AddAccountUseCaseProvider
 }
 
 String _$addAccountUseCaseHash() => r'fa2b2563af599e8d07f320da1891e100d7ae6293';
+
+@ProviderFor(deleteAccountUseCase)
+const deleteAccountUseCaseProvider = DeleteAccountUseCaseProvider._();
+
+final class DeleteAccountUseCaseProvider
+    extends
+        $FunctionalProvider<
+          DeleteAccountUseCase,
+          DeleteAccountUseCase,
+          DeleteAccountUseCase
+        >
+    with $Provider<DeleteAccountUseCase> {
+  const DeleteAccountUseCaseProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'deleteAccountUseCaseProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$deleteAccountUseCaseHash();
+
+  @$internal
+  @override
+  $ProviderElement<DeleteAccountUseCase> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  DeleteAccountUseCase create(Ref ref) {
+    return deleteAccountUseCase(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(DeleteAccountUseCase value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<DeleteAccountUseCase>(value),
+    );
+  }
+}
+
+String _$deleteAccountUseCaseHash() =>
+    r'b2dc0b516807d5551b3e412819409a0f2a1b0604';
 
 @ProviderFor(watchAccountsUseCase)
 const watchAccountsUseCaseProvider = WatchAccountsUseCaseProvider._();

--- a/lib/features/accounts/domain/use_cases/delete_account_use_case.dart
+++ b/lib/features/accounts/domain/use_cases/delete_account_use_case.dart
@@ -1,0 +1,11 @@
+import 'package:kopim/features/accounts/domain/repositories/account_repository.dart';
+
+class DeleteAccountUseCase {
+  DeleteAccountUseCase(this._repository);
+
+  final AccountRepository _repository;
+
+  Future<void> call(String id) {
+    return _repository.softDelete(id);
+  }
+}

--- a/lib/features/accounts/presentation/account_details_screen.dart
+++ b/lib/features/accounts/presentation/account_details_screen.dart
@@ -200,11 +200,20 @@ class _AccountDetailsScreenState extends ConsumerState<AccountDetailsScreen> {
     );
   }
 
-  void _openEditScreen(BuildContext context, AccountEntity account) {
-    Navigator.of(context).pushNamed(
+  Future<void> _openEditScreen(
+    BuildContext context,
+    AccountEntity account,
+  ) async {
+    final Object? result = await Navigator.of(context).pushNamed(
       EditAccountScreen.routeName,
       arguments: EditAccountScreenArgs(account: account),
     );
+    if (!context.mounted) {
+      return;
+    }
+    if (result == AccountEditResult.deleted) {
+      Navigator.of(context).pop();
+    }
   }
 }
 

--- a/lib/features/accounts/presentation/controllers/add_account_form_controller.freezed.dart
+++ b/lib/features/accounts/presentation/controllers/add_account_form_controller.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$AddAccountFormState {
 
- String get name; String get balanceInput; String get currency; String get type; bool get isSaving; bool get submissionSuccess; AddAccountFieldError? get nameError; AddAccountFieldError? get balanceError; String? get errorMessage;
+ String get name; String get balanceInput; String get currency; String get type; bool get useCustomType; String get customType; bool get isSaving; bool get submissionSuccess; AddAccountFieldError? get nameError; AddAccountFieldError? get balanceError; AddAccountFieldError? get typeError; String? get errorMessage;
 /// Create a copy of AddAccountFormState
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -25,16 +25,16 @@ $AddAccountFormStateCopyWith<AddAccountFormState> get copyWith => _$AddAccountFo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is AddAccountFormState&&(identical(other.name, name) || other.name == name)&&(identical(other.balanceInput, balanceInput) || other.balanceInput == balanceInput)&&(identical(other.currency, currency) || other.currency == currency)&&(identical(other.type, type) || other.type == type)&&(identical(other.isSaving, isSaving) || other.isSaving == isSaving)&&(identical(other.submissionSuccess, submissionSuccess) || other.submissionSuccess == submissionSuccess)&&(identical(other.nameError, nameError) || other.nameError == nameError)&&(identical(other.balanceError, balanceError) || other.balanceError == balanceError)&&(identical(other.errorMessage, errorMessage) || other.errorMessage == errorMessage));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AddAccountFormState&&(identical(other.name, name) || other.name == name)&&(identical(other.balanceInput, balanceInput) || other.balanceInput == balanceInput)&&(identical(other.currency, currency) || other.currency == currency)&&(identical(other.type, type) || other.type == type)&&(identical(other.useCustomType, useCustomType) || other.useCustomType == useCustomType)&&(identical(other.customType, customType) || other.customType == customType)&&(identical(other.isSaving, isSaving) || other.isSaving == isSaving)&&(identical(other.submissionSuccess, submissionSuccess) || other.submissionSuccess == submissionSuccess)&&(identical(other.nameError, nameError) || other.nameError == nameError)&&(identical(other.balanceError, balanceError) || other.balanceError == balanceError)&&(identical(other.typeError, typeError) || other.typeError == typeError)&&(identical(other.errorMessage, errorMessage) || other.errorMessage == errorMessage));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,name,balanceInput,currency,type,isSaving,submissionSuccess,nameError,balanceError,errorMessage);
+int get hashCode => Object.hash(runtimeType,name,balanceInput,currency,type,useCustomType,customType,isSaving,submissionSuccess,nameError,balanceError,typeError,errorMessage);
 
 @override
 String toString() {
-  return 'AddAccountFormState(name: $name, balanceInput: $balanceInput, currency: $currency, type: $type, isSaving: $isSaving, submissionSuccess: $submissionSuccess, nameError: $nameError, balanceError: $balanceError, errorMessage: $errorMessage)';
+  return 'AddAccountFormState(name: $name, balanceInput: $balanceInput, currency: $currency, type: $type, useCustomType: $useCustomType, customType: $customType, isSaving: $isSaving, submissionSuccess: $submissionSuccess, nameError: $nameError, balanceError: $balanceError, typeError: $typeError, errorMessage: $errorMessage)';
 }
 
 
@@ -45,7 +45,7 @@ abstract mixin class $AddAccountFormStateCopyWith<$Res>  {
   factory $AddAccountFormStateCopyWith(AddAccountFormState value, $Res Function(AddAccountFormState) _then) = _$AddAccountFormStateCopyWithImpl;
 @useResult
 $Res call({
- String name, String balanceInput, String currency, String type, bool isSaving, bool submissionSuccess, AddAccountFieldError? nameError, AddAccountFieldError? balanceError, String? errorMessage
+ String name, String balanceInput, String currency, String type, bool useCustomType, String customType, bool isSaving, bool submissionSuccess, AddAccountFieldError? nameError, AddAccountFieldError? balanceError, AddAccountFieldError? typeError, String? errorMessage
 });
 
 
@@ -62,16 +62,19 @@ class _$AddAccountFormStateCopyWithImpl<$Res>
 
 /// Create a copy of AddAccountFormState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? name = null,Object? balanceInput = null,Object? currency = null,Object? type = null,Object? isSaving = null,Object? submissionSuccess = null,Object? nameError = freezed,Object? balanceError = freezed,Object? errorMessage = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? name = null,Object? balanceInput = null,Object? currency = null,Object? type = null,Object? useCustomType = null,Object? customType = null,Object? isSaving = null,Object? submissionSuccess = null,Object? nameError = freezed,Object? balanceError = freezed,Object? typeError = freezed,Object? errorMessage = freezed,}) {
   return _then(_self.copyWith(
 name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
 as String,balanceInput: null == balanceInput ? _self.balanceInput : balanceInput // ignore: cast_nullable_to_non_nullable
 as String,currency: null == currency ? _self.currency : currency // ignore: cast_nullable_to_non_nullable
 as String,type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as String,useCustomType: null == useCustomType ? _self.useCustomType : useCustomType // ignore: cast_nullable_to_non_nullable
+as bool,customType: null == customType ? _self.customType : customType // ignore: cast_nullable_to_non_nullable
 as String,isSaving: null == isSaving ? _self.isSaving : isSaving // ignore: cast_nullable_to_non_nullable
 as bool,submissionSuccess: null == submissionSuccess ? _self.submissionSuccess : submissionSuccess // ignore: cast_nullable_to_non_nullable
 as bool,nameError: freezed == nameError ? _self.nameError : nameError // ignore: cast_nullable_to_non_nullable
 as AddAccountFieldError?,balanceError: freezed == balanceError ? _self.balanceError : balanceError // ignore: cast_nullable_to_non_nullable
+as AddAccountFieldError?,typeError: freezed == typeError ? _self.typeError : typeError // ignore: cast_nullable_to_non_nullable
 as AddAccountFieldError?,errorMessage: freezed == errorMessage ? _self.errorMessage : errorMessage // ignore: cast_nullable_to_non_nullable
 as String?,
   ));
@@ -158,10 +161,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String name,  String balanceInput,  String currency,  String type,  bool isSaving,  bool submissionSuccess,  AddAccountFieldError? nameError,  AddAccountFieldError? balanceError,  String? errorMessage)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String name,  String balanceInput,  String currency,  String type,  bool useCustomType,  String customType,  bool isSaving,  bool submissionSuccess,  AddAccountFieldError? nameError,  AddAccountFieldError? balanceError,  AddAccountFieldError? typeError,  String? errorMessage)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _AddAccountFormState() when $default != null:
-return $default(_that.name,_that.balanceInput,_that.currency,_that.type,_that.isSaving,_that.submissionSuccess,_that.nameError,_that.balanceError,_that.errorMessage);case _:
+return $default(_that.name,_that.balanceInput,_that.currency,_that.type,_that.useCustomType,_that.customType,_that.isSaving,_that.submissionSuccess,_that.nameError,_that.balanceError,_that.typeError,_that.errorMessage);case _:
   return orElse();
 
 }
@@ -179,10 +182,10 @@ return $default(_that.name,_that.balanceInput,_that.currency,_that.type,_that.is
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String name,  String balanceInput,  String currency,  String type,  bool isSaving,  bool submissionSuccess,  AddAccountFieldError? nameError,  AddAccountFieldError? balanceError,  String? errorMessage)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String name,  String balanceInput,  String currency,  String type,  bool useCustomType,  String customType,  bool isSaving,  bool submissionSuccess,  AddAccountFieldError? nameError,  AddAccountFieldError? balanceError,  AddAccountFieldError? typeError,  String? errorMessage)  $default,) {final _that = this;
 switch (_that) {
 case _AddAccountFormState():
-return $default(_that.name,_that.balanceInput,_that.currency,_that.type,_that.isSaving,_that.submissionSuccess,_that.nameError,_that.balanceError,_that.errorMessage);case _:
+return $default(_that.name,_that.balanceInput,_that.currency,_that.type,_that.useCustomType,_that.customType,_that.isSaving,_that.submissionSuccess,_that.nameError,_that.balanceError,_that.typeError,_that.errorMessage);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -199,10 +202,10 @@ return $default(_that.name,_that.balanceInput,_that.currency,_that.type,_that.is
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String name,  String balanceInput,  String currency,  String type,  bool isSaving,  bool submissionSuccess,  AddAccountFieldError? nameError,  AddAccountFieldError? balanceError,  String? errorMessage)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String name,  String balanceInput,  String currency,  String type,  bool useCustomType,  String customType,  bool isSaving,  bool submissionSuccess,  AddAccountFieldError? nameError,  AddAccountFieldError? balanceError,  AddAccountFieldError? typeError,  String? errorMessage)?  $default,) {final _that = this;
 switch (_that) {
 case _AddAccountFormState() when $default != null:
-return $default(_that.name,_that.balanceInput,_that.currency,_that.type,_that.isSaving,_that.submissionSuccess,_that.nameError,_that.balanceError,_that.errorMessage);case _:
+return $default(_that.name,_that.balanceInput,_that.currency,_that.type,_that.useCustomType,_that.customType,_that.isSaving,_that.submissionSuccess,_that.nameError,_that.balanceError,_that.typeError,_that.errorMessage);case _:
   return null;
 
 }
@@ -214,17 +217,20 @@ return $default(_that.name,_that.balanceInput,_that.currency,_that.type,_that.is
 
 
 class _AddAccountFormState extends AddAccountFormState {
-  const _AddAccountFormState({this.name = '', this.balanceInput = '', this.currency = 'RUB', this.type = 'cash', this.isSaving = false, this.submissionSuccess = false, this.nameError, this.balanceError, this.errorMessage}): super._();
+  const _AddAccountFormState({this.name = '', this.balanceInput = '', this.currency = 'RUB', this.type = 'cash', this.useCustomType = false, this.customType = '', this.isSaving = false, this.submissionSuccess = false, this.nameError, this.balanceError, this.typeError, this.errorMessage}): super._();
   
 
 @override@JsonKey() final  String name;
 @override@JsonKey() final  String balanceInput;
 @override@JsonKey() final  String currency;
 @override@JsonKey() final  String type;
+@override@JsonKey() final  bool useCustomType;
+@override@JsonKey() final  String customType;
 @override@JsonKey() final  bool isSaving;
 @override@JsonKey() final  bool submissionSuccess;
 @override final  AddAccountFieldError? nameError;
 @override final  AddAccountFieldError? balanceError;
+@override final  AddAccountFieldError? typeError;
 @override final  String? errorMessage;
 
 /// Create a copy of AddAccountFormState
@@ -237,16 +243,16 @@ _$AddAccountFormStateCopyWith<_AddAccountFormState> get copyWith => __$AddAccoun
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AddAccountFormState&&(identical(other.name, name) || other.name == name)&&(identical(other.balanceInput, balanceInput) || other.balanceInput == balanceInput)&&(identical(other.currency, currency) || other.currency == currency)&&(identical(other.type, type) || other.type == type)&&(identical(other.isSaving, isSaving) || other.isSaving == isSaving)&&(identical(other.submissionSuccess, submissionSuccess) || other.submissionSuccess == submissionSuccess)&&(identical(other.nameError, nameError) || other.nameError == nameError)&&(identical(other.balanceError, balanceError) || other.balanceError == balanceError)&&(identical(other.errorMessage, errorMessage) || other.errorMessage == errorMessage));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AddAccountFormState&&(identical(other.name, name) || other.name == name)&&(identical(other.balanceInput, balanceInput) || other.balanceInput == balanceInput)&&(identical(other.currency, currency) || other.currency == currency)&&(identical(other.type, type) || other.type == type)&&(identical(other.useCustomType, useCustomType) || other.useCustomType == useCustomType)&&(identical(other.customType, customType) || other.customType == customType)&&(identical(other.isSaving, isSaving) || other.isSaving == isSaving)&&(identical(other.submissionSuccess, submissionSuccess) || other.submissionSuccess == submissionSuccess)&&(identical(other.nameError, nameError) || other.nameError == nameError)&&(identical(other.balanceError, balanceError) || other.balanceError == balanceError)&&(identical(other.typeError, typeError) || other.typeError == typeError)&&(identical(other.errorMessage, errorMessage) || other.errorMessage == errorMessage));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,name,balanceInput,currency,type,isSaving,submissionSuccess,nameError,balanceError,errorMessage);
+int get hashCode => Object.hash(runtimeType,name,balanceInput,currency,type,useCustomType,customType,isSaving,submissionSuccess,nameError,balanceError,typeError,errorMessage);
 
 @override
 String toString() {
-  return 'AddAccountFormState(name: $name, balanceInput: $balanceInput, currency: $currency, type: $type, isSaving: $isSaving, submissionSuccess: $submissionSuccess, nameError: $nameError, balanceError: $balanceError, errorMessage: $errorMessage)';
+  return 'AddAccountFormState(name: $name, balanceInput: $balanceInput, currency: $currency, type: $type, useCustomType: $useCustomType, customType: $customType, isSaving: $isSaving, submissionSuccess: $submissionSuccess, nameError: $nameError, balanceError: $balanceError, typeError: $typeError, errorMessage: $errorMessage)';
 }
 
 
@@ -257,7 +263,7 @@ abstract mixin class _$AddAccountFormStateCopyWith<$Res> implements $AddAccountF
   factory _$AddAccountFormStateCopyWith(_AddAccountFormState value, $Res Function(_AddAccountFormState) _then) = __$AddAccountFormStateCopyWithImpl;
 @override @useResult
 $Res call({
- String name, String balanceInput, String currency, String type, bool isSaving, bool submissionSuccess, AddAccountFieldError? nameError, AddAccountFieldError? balanceError, String? errorMessage
+ String name, String balanceInput, String currency, String type, bool useCustomType, String customType, bool isSaving, bool submissionSuccess, AddAccountFieldError? nameError, AddAccountFieldError? balanceError, AddAccountFieldError? typeError, String? errorMessage
 });
 
 
@@ -274,16 +280,19 @@ class __$AddAccountFormStateCopyWithImpl<$Res>
 
 /// Create a copy of AddAccountFormState
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? name = null,Object? balanceInput = null,Object? currency = null,Object? type = null,Object? isSaving = null,Object? submissionSuccess = null,Object? nameError = freezed,Object? balanceError = freezed,Object? errorMessage = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? name = null,Object? balanceInput = null,Object? currency = null,Object? type = null,Object? useCustomType = null,Object? customType = null,Object? isSaving = null,Object? submissionSuccess = null,Object? nameError = freezed,Object? balanceError = freezed,Object? typeError = freezed,Object? errorMessage = freezed,}) {
   return _then(_AddAccountFormState(
 name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
 as String,balanceInput: null == balanceInput ? _self.balanceInput : balanceInput // ignore: cast_nullable_to_non_nullable
 as String,currency: null == currency ? _self.currency : currency // ignore: cast_nullable_to_non_nullable
 as String,type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as String,useCustomType: null == useCustomType ? _self.useCustomType : useCustomType // ignore: cast_nullable_to_non_nullable
+as bool,customType: null == customType ? _self.customType : customType // ignore: cast_nullable_to_non_nullable
 as String,isSaving: null == isSaving ? _self.isSaving : isSaving // ignore: cast_nullable_to_non_nullable
 as bool,submissionSuccess: null == submissionSuccess ? _self.submissionSuccess : submissionSuccess // ignore: cast_nullable_to_non_nullable
 as bool,nameError: freezed == nameError ? _self.nameError : nameError // ignore: cast_nullable_to_non_nullable
 as AddAccountFieldError?,balanceError: freezed == balanceError ? _self.balanceError : balanceError // ignore: cast_nullable_to_non_nullable
+as AddAccountFieldError?,typeError: freezed == typeError ? _self.typeError : typeError // ignore: cast_nullable_to_non_nullable
 as AddAccountFieldError?,errorMessage: freezed == errorMessage ? _self.errorMessage : errorMessage // ignore: cast_nullable_to_non_nullable
 as String?,
   ));

--- a/lib/features/accounts/presentation/controllers/add_account_form_controller.g.dart
+++ b/lib/features/accounts/presentation/controllers/add_account_form_controller.g.dart
@@ -42,7 +42,7 @@ final class AddAccountFormControllerProvider
 }
 
 String _$addAccountFormControllerHash() =>
-    r'a24cb1ae208b959ec9356fddadf93c4a60ea10bd';
+    r'9d118da8b06291d4266231824ccefc868d47598d';
 
 abstract class _$AddAccountFormController
     extends $Notifier<AddAccountFormState> {

--- a/lib/features/accounts/presentation/controllers/edit_account_form_controller.freezed.dart
+++ b/lib/features/accounts/presentation/controllers/edit_account_form_controller.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$EditAccountFormState {
 
- AccountEntity get original; String get name; String get balanceInput; String get currency; bool get isSaving; bool get submissionSuccess; EditAccountFieldError? get nameError; EditAccountFieldError? get balanceError; String? get errorMessage;
+ AccountEntity get original; String get name; String get balanceInput; String get currency; String get type; bool get useCustomType; String get customType; bool get isSaving; bool get submissionSuccess; EditAccountFieldError? get nameError; EditAccountFieldError? get balanceError; EditAccountFieldError? get typeError; String? get errorMessage;
 /// Create a copy of EditAccountFormState
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -25,16 +25,16 @@ $EditAccountFormStateCopyWith<EditAccountFormState> get copyWith => _$EditAccoun
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is EditAccountFormState&&(identical(other.original, original) || other.original == original)&&(identical(other.name, name) || other.name == name)&&(identical(other.balanceInput, balanceInput) || other.balanceInput == balanceInput)&&(identical(other.currency, currency) || other.currency == currency)&&(identical(other.isSaving, isSaving) || other.isSaving == isSaving)&&(identical(other.submissionSuccess, submissionSuccess) || other.submissionSuccess == submissionSuccess)&&(identical(other.nameError, nameError) || other.nameError == nameError)&&(identical(other.balanceError, balanceError) || other.balanceError == balanceError)&&(identical(other.errorMessage, errorMessage) || other.errorMessage == errorMessage));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EditAccountFormState&&(identical(other.original, original) || other.original == original)&&(identical(other.name, name) || other.name == name)&&(identical(other.balanceInput, balanceInput) || other.balanceInput == balanceInput)&&(identical(other.currency, currency) || other.currency == currency)&&(identical(other.type, type) || other.type == type)&&(identical(other.useCustomType, useCustomType) || other.useCustomType == useCustomType)&&(identical(other.customType, customType) || other.customType == customType)&&(identical(other.isSaving, isSaving) || other.isSaving == isSaving)&&(identical(other.submissionSuccess, submissionSuccess) || other.submissionSuccess == submissionSuccess)&&(identical(other.nameError, nameError) || other.nameError == nameError)&&(identical(other.balanceError, balanceError) || other.balanceError == balanceError)&&(identical(other.typeError, typeError) || other.typeError == typeError)&&(identical(other.errorMessage, errorMessage) || other.errorMessage == errorMessage));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,original,name,balanceInput,currency,isSaving,submissionSuccess,nameError,balanceError,errorMessage);
+int get hashCode => Object.hash(runtimeType,original,name,balanceInput,currency,type,useCustomType,customType,isSaving,submissionSuccess,nameError,balanceError,typeError,errorMessage);
 
 @override
 String toString() {
-  return 'EditAccountFormState(original: $original, name: $name, balanceInput: $balanceInput, currency: $currency, isSaving: $isSaving, submissionSuccess: $submissionSuccess, nameError: $nameError, balanceError: $balanceError, errorMessage: $errorMessage)';
+  return 'EditAccountFormState(original: $original, name: $name, balanceInput: $balanceInput, currency: $currency, type: $type, useCustomType: $useCustomType, customType: $customType, isSaving: $isSaving, submissionSuccess: $submissionSuccess, nameError: $nameError, balanceError: $balanceError, typeError: $typeError, errorMessage: $errorMessage)';
 }
 
 
@@ -45,7 +45,7 @@ abstract mixin class $EditAccountFormStateCopyWith<$Res>  {
   factory $EditAccountFormStateCopyWith(EditAccountFormState value, $Res Function(EditAccountFormState) _then) = _$EditAccountFormStateCopyWithImpl;
 @useResult
 $Res call({
- AccountEntity original, String name, String balanceInput, String currency, bool isSaving, bool submissionSuccess, EditAccountFieldError? nameError, EditAccountFieldError? balanceError, String? errorMessage
+ AccountEntity original, String name, String balanceInput, String currency, String type, bool useCustomType, String customType, bool isSaving, bool submissionSuccess, EditAccountFieldError? nameError, EditAccountFieldError? balanceError, EditAccountFieldError? typeError, String? errorMessage
 });
 
 
@@ -62,16 +62,20 @@ class _$EditAccountFormStateCopyWithImpl<$Res>
 
 /// Create a copy of EditAccountFormState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? original = null,Object? name = null,Object? balanceInput = null,Object? currency = null,Object? isSaving = null,Object? submissionSuccess = null,Object? nameError = freezed,Object? balanceError = freezed,Object? errorMessage = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? original = null,Object? name = null,Object? balanceInput = null,Object? currency = null,Object? type = null,Object? useCustomType = null,Object? customType = null,Object? isSaving = null,Object? submissionSuccess = null,Object? nameError = freezed,Object? balanceError = freezed,Object? typeError = freezed,Object? errorMessage = freezed,}) {
   return _then(_self.copyWith(
 original: null == original ? _self.original : original // ignore: cast_nullable_to_non_nullable
 as AccountEntity,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
 as String,balanceInput: null == balanceInput ? _self.balanceInput : balanceInput // ignore: cast_nullable_to_non_nullable
 as String,currency: null == currency ? _self.currency : currency // ignore: cast_nullable_to_non_nullable
+as String,type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as String,useCustomType: null == useCustomType ? _self.useCustomType : useCustomType // ignore: cast_nullable_to_non_nullable
+as bool,customType: null == customType ? _self.customType : customType // ignore: cast_nullable_to_non_nullable
 as String,isSaving: null == isSaving ? _self.isSaving : isSaving // ignore: cast_nullable_to_non_nullable
 as bool,submissionSuccess: null == submissionSuccess ? _self.submissionSuccess : submissionSuccess // ignore: cast_nullable_to_non_nullable
 as bool,nameError: freezed == nameError ? _self.nameError : nameError // ignore: cast_nullable_to_non_nullable
 as EditAccountFieldError?,balanceError: freezed == balanceError ? _self.balanceError : balanceError // ignore: cast_nullable_to_non_nullable
+as EditAccountFieldError?,typeError: freezed == typeError ? _self.typeError : typeError // ignore: cast_nullable_to_non_nullable
 as EditAccountFieldError?,errorMessage: freezed == errorMessage ? _self.errorMessage : errorMessage // ignore: cast_nullable_to_non_nullable
 as String?,
   ));
@@ -167,10 +171,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( AccountEntity original,  String name,  String balanceInput,  String currency,  bool isSaving,  bool submissionSuccess,  EditAccountFieldError? nameError,  EditAccountFieldError? balanceError,  String? errorMessage)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( AccountEntity original,  String name,  String balanceInput,  String currency,  String type,  bool useCustomType,  String customType,  bool isSaving,  bool submissionSuccess,  EditAccountFieldError? nameError,  EditAccountFieldError? balanceError,  EditAccountFieldError? typeError,  String? errorMessage)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _EditAccountFormState() when $default != null:
-return $default(_that.original,_that.name,_that.balanceInput,_that.currency,_that.isSaving,_that.submissionSuccess,_that.nameError,_that.balanceError,_that.errorMessage);case _:
+return $default(_that.original,_that.name,_that.balanceInput,_that.currency,_that.type,_that.useCustomType,_that.customType,_that.isSaving,_that.submissionSuccess,_that.nameError,_that.balanceError,_that.typeError,_that.errorMessage);case _:
   return orElse();
 
 }
@@ -188,10 +192,10 @@ return $default(_that.original,_that.name,_that.balanceInput,_that.currency,_tha
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( AccountEntity original,  String name,  String balanceInput,  String currency,  bool isSaving,  bool submissionSuccess,  EditAccountFieldError? nameError,  EditAccountFieldError? balanceError,  String? errorMessage)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( AccountEntity original,  String name,  String balanceInput,  String currency,  String type,  bool useCustomType,  String customType,  bool isSaving,  bool submissionSuccess,  EditAccountFieldError? nameError,  EditAccountFieldError? balanceError,  EditAccountFieldError? typeError,  String? errorMessage)  $default,) {final _that = this;
 switch (_that) {
 case _EditAccountFormState():
-return $default(_that.original,_that.name,_that.balanceInput,_that.currency,_that.isSaving,_that.submissionSuccess,_that.nameError,_that.balanceError,_that.errorMessage);case _:
+return $default(_that.original,_that.name,_that.balanceInput,_that.currency,_that.type,_that.useCustomType,_that.customType,_that.isSaving,_that.submissionSuccess,_that.nameError,_that.balanceError,_that.typeError,_that.errorMessage);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -208,10 +212,10 @@ return $default(_that.original,_that.name,_that.balanceInput,_that.currency,_tha
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( AccountEntity original,  String name,  String balanceInput,  String currency,  bool isSaving,  bool submissionSuccess,  EditAccountFieldError? nameError,  EditAccountFieldError? balanceError,  String? errorMessage)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( AccountEntity original,  String name,  String balanceInput,  String currency,  String type,  bool useCustomType,  String customType,  bool isSaving,  bool submissionSuccess,  EditAccountFieldError? nameError,  EditAccountFieldError? balanceError,  EditAccountFieldError? typeError,  String? errorMessage)?  $default,) {final _that = this;
 switch (_that) {
 case _EditAccountFormState() when $default != null:
-return $default(_that.original,_that.name,_that.balanceInput,_that.currency,_that.isSaving,_that.submissionSuccess,_that.nameError,_that.balanceError,_that.errorMessage);case _:
+return $default(_that.original,_that.name,_that.balanceInput,_that.currency,_that.type,_that.useCustomType,_that.customType,_that.isSaving,_that.submissionSuccess,_that.nameError,_that.balanceError,_that.typeError,_that.errorMessage);case _:
   return null;
 
 }
@@ -223,17 +227,21 @@ return $default(_that.original,_that.name,_that.balanceInput,_that.currency,_tha
 
 
 class _EditAccountFormState extends EditAccountFormState {
-  const _EditAccountFormState({required this.original, required this.name, required this.balanceInput, required this.currency, this.isSaving = false, this.submissionSuccess = false, this.nameError, this.balanceError, this.errorMessage}): super._();
+  const _EditAccountFormState({required this.original, required this.name, required this.balanceInput, required this.currency, required this.type, this.useCustomType = false, this.customType = '', this.isSaving = false, this.submissionSuccess = false, this.nameError, this.balanceError, this.typeError, this.errorMessage}): super._();
   
 
 @override final  AccountEntity original;
 @override final  String name;
 @override final  String balanceInput;
 @override final  String currency;
+@override final  String type;
+@override@JsonKey() final  bool useCustomType;
+@override@JsonKey() final  String customType;
 @override@JsonKey() final  bool isSaving;
 @override@JsonKey() final  bool submissionSuccess;
 @override final  EditAccountFieldError? nameError;
 @override final  EditAccountFieldError? balanceError;
+@override final  EditAccountFieldError? typeError;
 @override final  String? errorMessage;
 
 /// Create a copy of EditAccountFormState
@@ -246,16 +254,16 @@ _$EditAccountFormStateCopyWith<_EditAccountFormState> get copyWith => __$EditAcc
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EditAccountFormState&&(identical(other.original, original) || other.original == original)&&(identical(other.name, name) || other.name == name)&&(identical(other.balanceInput, balanceInput) || other.balanceInput == balanceInput)&&(identical(other.currency, currency) || other.currency == currency)&&(identical(other.isSaving, isSaving) || other.isSaving == isSaving)&&(identical(other.submissionSuccess, submissionSuccess) || other.submissionSuccess == submissionSuccess)&&(identical(other.nameError, nameError) || other.nameError == nameError)&&(identical(other.balanceError, balanceError) || other.balanceError == balanceError)&&(identical(other.errorMessage, errorMessage) || other.errorMessage == errorMessage));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EditAccountFormState&&(identical(other.original, original) || other.original == original)&&(identical(other.name, name) || other.name == name)&&(identical(other.balanceInput, balanceInput) || other.balanceInput == balanceInput)&&(identical(other.currency, currency) || other.currency == currency)&&(identical(other.type, type) || other.type == type)&&(identical(other.useCustomType, useCustomType) || other.useCustomType == useCustomType)&&(identical(other.customType, customType) || other.customType == customType)&&(identical(other.isSaving, isSaving) || other.isSaving == isSaving)&&(identical(other.submissionSuccess, submissionSuccess) || other.submissionSuccess == submissionSuccess)&&(identical(other.nameError, nameError) || other.nameError == nameError)&&(identical(other.balanceError, balanceError) || other.balanceError == balanceError)&&(identical(other.typeError, typeError) || other.typeError == typeError)&&(identical(other.errorMessage, errorMessage) || other.errorMessage == errorMessage));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,original,name,balanceInput,currency,isSaving,submissionSuccess,nameError,balanceError,errorMessage);
+int get hashCode => Object.hash(runtimeType,original,name,balanceInput,currency,type,useCustomType,customType,isSaving,submissionSuccess,nameError,balanceError,typeError,errorMessage);
 
 @override
 String toString() {
-  return 'EditAccountFormState(original: $original, name: $name, balanceInput: $balanceInput, currency: $currency, isSaving: $isSaving, submissionSuccess: $submissionSuccess, nameError: $nameError, balanceError: $balanceError, errorMessage: $errorMessage)';
+  return 'EditAccountFormState(original: $original, name: $name, balanceInput: $balanceInput, currency: $currency, type: $type, useCustomType: $useCustomType, customType: $customType, isSaving: $isSaving, submissionSuccess: $submissionSuccess, nameError: $nameError, balanceError: $balanceError, typeError: $typeError, errorMessage: $errorMessage)';
 }
 
 
@@ -266,7 +274,7 @@ abstract mixin class _$EditAccountFormStateCopyWith<$Res> implements $EditAccoun
   factory _$EditAccountFormStateCopyWith(_EditAccountFormState value, $Res Function(_EditAccountFormState) _then) = __$EditAccountFormStateCopyWithImpl;
 @override @useResult
 $Res call({
- AccountEntity original, String name, String balanceInput, String currency, bool isSaving, bool submissionSuccess, EditAccountFieldError? nameError, EditAccountFieldError? balanceError, String? errorMessage
+ AccountEntity original, String name, String balanceInput, String currency, String type, bool useCustomType, String customType, bool isSaving, bool submissionSuccess, EditAccountFieldError? nameError, EditAccountFieldError? balanceError, EditAccountFieldError? typeError, String? errorMessage
 });
 
 
@@ -283,16 +291,20 @@ class __$EditAccountFormStateCopyWithImpl<$Res>
 
 /// Create a copy of EditAccountFormState
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? original = null,Object? name = null,Object? balanceInput = null,Object? currency = null,Object? isSaving = null,Object? submissionSuccess = null,Object? nameError = freezed,Object? balanceError = freezed,Object? errorMessage = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? original = null,Object? name = null,Object? balanceInput = null,Object? currency = null,Object? type = null,Object? useCustomType = null,Object? customType = null,Object? isSaving = null,Object? submissionSuccess = null,Object? nameError = freezed,Object? balanceError = freezed,Object? typeError = freezed,Object? errorMessage = freezed,}) {
   return _then(_EditAccountFormState(
 original: null == original ? _self.original : original // ignore: cast_nullable_to_non_nullable
 as AccountEntity,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
 as String,balanceInput: null == balanceInput ? _self.balanceInput : balanceInput // ignore: cast_nullable_to_non_nullable
 as String,currency: null == currency ? _self.currency : currency // ignore: cast_nullable_to_non_nullable
+as String,type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as String,useCustomType: null == useCustomType ? _self.useCustomType : useCustomType // ignore: cast_nullable_to_non_nullable
+as bool,customType: null == customType ? _self.customType : customType // ignore: cast_nullable_to_non_nullable
 as String,isSaving: null == isSaving ? _self.isSaving : isSaving // ignore: cast_nullable_to_non_nullable
 as bool,submissionSuccess: null == submissionSuccess ? _self.submissionSuccess : submissionSuccess // ignore: cast_nullable_to_non_nullable
 as bool,nameError: freezed == nameError ? _self.nameError : nameError // ignore: cast_nullable_to_non_nullable
 as EditAccountFieldError?,balanceError: freezed == balanceError ? _self.balanceError : balanceError // ignore: cast_nullable_to_non_nullable
+as EditAccountFieldError?,typeError: freezed == typeError ? _self.typeError : typeError // ignore: cast_nullable_to_non_nullable
 as EditAccountFieldError?,errorMessage: freezed == errorMessage ? _self.errorMessage : errorMessage // ignore: cast_nullable_to_non_nullable
 as String?,
   ));

--- a/lib/features/accounts/presentation/controllers/edit_account_form_controller.g.dart
+++ b/lib/features/accounts/presentation/controllers/edit_account_form_controller.g.dart
@@ -60,7 +60,7 @@ final class EditAccountFormControllerProvider
 }
 
 String _$editAccountFormControllerHash() =>
-    r'159ca8a7cf94783b469ea93c5488b5b52efe7b1a';
+    r'49b4dd242772dceed818fcfaa2162b506675c706';
 
 final class EditAccountFormControllerFamily extends $Family
     with

--- a/lib/features/profile/domain/entities/auth_user.dart
+++ b/lib/features/profile/domain/entities/auth_user.dart
@@ -31,4 +31,6 @@ abstract class AuthUser with _$AuthUser {
 
   factory AuthUser.fromJson(Map<String, dynamic> json) =>
       _$AuthUserFromJson(json);
+
+  bool get isGuest => isAnonymous && uid.startsWith('guest-');
 }

--- a/lib/features/profile/presentation/controllers/avatar_controller.dart
+++ b/lib/features/profile/presentation/controllers/avatar_controller.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:typed_data';
 
+import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:kopim/core/di/injectors.dart';
 import 'package:kopim/features/profile/domain/usecases/update_profile_avatar_use_case.dart';
@@ -23,6 +24,14 @@ class AvatarController extends _$AvatarController {
   }) async {
     state = const AsyncValue<void>.loading();
     try {
+      final Connectivity connectivity = ref.read(connectivityProvider);
+      final List<ConnectivityResult> results = await connectivity
+          .checkConnectivity();
+      final bool isOffline = results.every(
+        (ConnectivityResult result) => result == ConnectivityResult.none,
+      );
+      final bool storeOfflineOnly = isOffline || uid.startsWith('guest-');
+
       final XFile? file = await _picker.pickImage(
         source: source == AvatarUploadSource.gallery
             ? ImageSource.gallery
@@ -49,6 +58,7 @@ class AvatarController extends _$AvatarController {
           source: source == AvatarUploadSource.gallery
               ? AvatarImageSource.gallery
               : AvatarImageSource.camera,
+          storeOfflineOnly: storeOfflineOnly,
         ),
       );
       state = const AsyncValue<void>.data(null);

--- a/lib/features/profile/presentation/controllers/avatar_controller.g.dart
+++ b/lib/features/profile/presentation/controllers/avatar_controller.g.dart
@@ -41,7 +41,7 @@ final class AvatarControllerProvider
   }
 }
 
-String _$avatarControllerHash() => r'b79d8f13afd109f094f326191a54a8f50160406d';
+String _$avatarControllerHash() => r'908aa80f253ff7c8c4d473e77aecff5541be6849';
 
 abstract class _$AvatarController extends $Notifier<AsyncValue<void>> {
   AsyncValue<void> build();

--- a/lib/features/profile/presentation/screens/sign_in_screen.dart
+++ b/lib/features/profile/presentation/screens/sign_in_screen.dart
@@ -194,14 +194,6 @@ class _SignInScreenState extends ConsumerState<SignInScreen> {
                         : Text(strings.signInSubmitCta),
                   ),
                   const SizedBox(height: 12),
-                  OutlinedButton.icon(
-                    onPressed: formState.isSubmitting
-                        ? null
-                        : () => controller.signInWithGoogle(),
-                    icon: const Icon(Icons.login),
-                    label: Text(strings.signInGoogleCta),
-                  ),
-                  const SizedBox(height: 12),
                   TextButton.icon(
                     onPressed: formState.isSubmitting
                         ? null

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1059,6 +1059,18 @@
   "@addAccountTypeBank": {
     "description": "Option label for bank accounts"
   },
+  "addAccountTypeCustom": "Custom type",
+  "@addAccountTypeCustom": {
+    "description": "Option label for custom account types"
+  },
+  "addAccountCustomTypeLabel": "Custom account type",
+  "@addAccountCustomTypeLabel": {
+    "description": "Label for the custom account type text field"
+  },
+  "addAccountTypeRequired": "Please specify the account type.",
+  "@addAccountTypeRequired": {
+    "description": "Validation error shown when the account type is missing"
+  },
   "accountDetailsTitle": "Account details",
   "@accountDetailsTitle": {
     "description": "Title for the account details screen"
@@ -1220,6 +1232,18 @@
   "@editAccountTypeLabel": {
     "description": "Label for the account type row on edit screen"
   },
+  "editAccountTypeCustom": "Custom type",
+  "@editAccountTypeCustom": {
+    "description": "Option label for selecting a custom account type"
+  },
+  "editAccountCustomTypeLabel": "Custom account type",
+  "@editAccountCustomTypeLabel": {
+    "description": "Label for the custom account type input"
+  },
+  "editAccountTypeRequired": "Please specify the account type.",
+  "@editAccountTypeRequired": {
+    "description": "Validation error when the account type is missing"
+  },
   "editAccountSaveCta": "Save changes",
   "@editAccountSaveCta": {
     "description": "Button label for saving account edits"
@@ -1235,6 +1259,34 @@
   "editAccountGenericError": "Could not update account. Please try again.",
   "@editAccountGenericError": {
     "description": "Generic error shown when updating the account fails"
+  },
+  "editAccountDeleteCta": "Delete account",
+  "@editAccountDeleteCta": {
+    "description": "Button label for deleting the account"
+  },
+  "editAccountDeleteLoading": "Deleting...",
+  "@editAccountDeleteLoading": {
+    "description": "Button label shown while the account is being deleted"
+  },
+  "editAccountDeleteConfirmationTitle": "Delete account?",
+  "@editAccountDeleteConfirmationTitle": {
+    "description": "Confirmation dialog title before deleting an account"
+  },
+  "editAccountDeleteConfirmationMessage": "This account and its data will be removed. This action cannot be undone.",
+  "@editAccountDeleteConfirmationMessage": {
+    "description": "Confirmation dialog message before deleting an account"
+  },
+  "editAccountDeleteConfirmationCancel": "Cancel",
+  "@editAccountDeleteConfirmationCancel": {
+    "description": "Cancel button label in the delete confirmation dialog"
+  },
+  "editAccountDeleteConfirmationConfirm": "Delete",
+  "@editAccountDeleteConfirmationConfirm": {
+    "description": "Confirm button label in the delete confirmation dialog"
+  },
+  "editAccountDeleteError": "Failed to delete the account. Please try again.",
+  "@editAccountDeleteError": {
+    "description": "Error message shown when deleting an account fails"
   },
   "homeNavBudgets": "Budgets",
   "@homeNavBudgets": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1484,6 +1484,24 @@ abstract class AppLocalizations {
   /// **'Bank account'**
   String get addAccountTypeBank;
 
+  /// Option label for custom account types
+  ///
+  /// In en, this message translates to:
+  /// **'Custom type'**
+  String get addAccountTypeCustom;
+
+  /// Label for the custom account type text field
+  ///
+  /// In en, this message translates to:
+  /// **'Custom account type'**
+  String get addAccountCustomTypeLabel;
+
+  /// Validation error shown when the account type is missing
+  ///
+  /// In en, this message translates to:
+  /// **'Please specify the account type.'**
+  String get addAccountTypeRequired;
+
   /// Title for the account details screen
   ///
   /// In en, this message translates to:
@@ -1676,6 +1694,24 @@ abstract class AppLocalizations {
   /// **'Account type'**
   String get editAccountTypeLabel;
 
+  /// Option label for selecting a custom account type
+  ///
+  /// In en, this message translates to:
+  /// **'Custom type'**
+  String get editAccountTypeCustom;
+
+  /// Label for the custom account type input
+  ///
+  /// In en, this message translates to:
+  /// **'Custom account type'**
+  String get editAccountCustomTypeLabel;
+
+  /// Validation error when the account type is missing
+  ///
+  /// In en, this message translates to:
+  /// **'Please specify the account type.'**
+  String get editAccountTypeRequired;
+
   /// Button label for saving account edits
   ///
   /// In en, this message translates to:
@@ -1699,6 +1735,48 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Could not update account. Please try again.'**
   String get editAccountGenericError;
+
+  /// Button label for deleting the account
+  ///
+  /// In en, this message translates to:
+  /// **'Delete account'**
+  String get editAccountDeleteCta;
+
+  /// Button label shown while the account is being deleted
+  ///
+  /// In en, this message translates to:
+  /// **'Deleting...'**
+  String get editAccountDeleteLoading;
+
+  /// Confirmation dialog title before deleting an account
+  ///
+  /// In en, this message translates to:
+  /// **'Delete account?'**
+  String get editAccountDeleteConfirmationTitle;
+
+  /// Confirmation dialog message before deleting an account
+  ///
+  /// In en, this message translates to:
+  /// **'This account and its data will be removed. This action cannot be undone.'**
+  String get editAccountDeleteConfirmationMessage;
+
+  /// Cancel button label in the delete confirmation dialog
+  ///
+  /// In en, this message translates to:
+  /// **'Cancel'**
+  String get editAccountDeleteConfirmationCancel;
+
+  /// Confirm button label in the delete confirmation dialog
+  ///
+  /// In en, this message translates to:
+  /// **'Delete'**
+  String get editAccountDeleteConfirmationConfirm;
+
+  /// Error message shown when deleting an account fails
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to delete the account. Please try again.'**
+  String get editAccountDeleteError;
 
   /// Label for the budgets tab in the bottom navigation
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -785,6 +785,15 @@ class AppLocalizationsEn extends AppLocalizations {
   String get addAccountTypeBank => 'Bank account';
 
   @override
+  String get addAccountTypeCustom => 'Custom type';
+
+  @override
+  String get addAccountCustomTypeLabel => 'Custom account type';
+
+  @override
+  String get addAccountTypeRequired => 'Please specify the account type.';
+
+  @override
   String get accountDetailsTitle => 'Account details';
 
   @override
@@ -894,6 +903,15 @@ class AppLocalizationsEn extends AppLocalizations {
   String get editAccountTypeLabel => 'Account type';
 
   @override
+  String get editAccountTypeCustom => 'Custom type';
+
+  @override
+  String get editAccountCustomTypeLabel => 'Custom account type';
+
+  @override
+  String get editAccountTypeRequired => 'Please specify the account type.';
+
+  @override
   String get editAccountSaveCta => 'Save changes';
 
   @override
@@ -905,6 +923,29 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get editAccountGenericError =>
       'Could not update account. Please try again.';
+
+  @override
+  String get editAccountDeleteCta => 'Delete account';
+
+  @override
+  String get editAccountDeleteLoading => 'Deleting...';
+
+  @override
+  String get editAccountDeleteConfirmationTitle => 'Delete account?';
+
+  @override
+  String get editAccountDeleteConfirmationMessage =>
+      'This account and its data will be removed. This action cannot be undone.';
+
+  @override
+  String get editAccountDeleteConfirmationCancel => 'Cancel';
+
+  @override
+  String get editAccountDeleteConfirmationConfirm => 'Delete';
+
+  @override
+  String get editAccountDeleteError =>
+      'Failed to delete the account. Please try again.';
 
   @override
   String get homeNavBudgets => 'Budgets';

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -789,6 +789,15 @@ class AppLocalizationsRu extends AppLocalizations {
   String get addAccountTypeBank => 'Банковский счёт';
 
   @override
+  String get addAccountTypeCustom => 'Другой тип';
+
+  @override
+  String get addAccountCustomTypeLabel => 'Собственный тип счёта';
+
+  @override
+  String get addAccountTypeRequired => 'Укажите тип счёта.';
+
+  @override
   String get accountDetailsTitle => 'Счёт';
 
   @override
@@ -898,6 +907,15 @@ class AppLocalizationsRu extends AppLocalizations {
   String get editAccountTypeLabel => 'Тип счёта';
 
   @override
+  String get editAccountTypeCustom => 'Другой тип';
+
+  @override
+  String get editAccountCustomTypeLabel => 'Собственный тип счёта';
+
+  @override
+  String get editAccountTypeRequired => 'Укажите тип счёта.';
+
+  @override
   String get editAccountSaveCta => 'Сохранить изменения';
 
   @override
@@ -909,6 +927,29 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String get editAccountGenericError =>
       'Не удалось обновить счёт. Повторите попытку.';
+
+  @override
+  String get editAccountDeleteCta => 'Удалить счёт';
+
+  @override
+  String get editAccountDeleteLoading => 'Удаляем...';
+
+  @override
+  String get editAccountDeleteConfirmationTitle => 'Удалить счёт?';
+
+  @override
+  String get editAccountDeleteConfirmationMessage =>
+      'Счёт и связанные данные будут удалены. Это действие невозможно отменить.';
+
+  @override
+  String get editAccountDeleteConfirmationCancel => 'Отмена';
+
+  @override
+  String get editAccountDeleteConfirmationConfirm => 'Удалить';
+
+  @override
+  String get editAccountDeleteError =>
+      'Не удалось удалить счёт. Попробуйте ещё раз.';
 
   @override
   String get homeNavBudgets => 'Бюджеты';

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1059,6 +1059,18 @@
   "@addAccountTypeBank": {
     "description": "Вариант типа счёта для банковского счёта"
   },
+  "addAccountTypeCustom": "Другой тип",
+  "@addAccountTypeCustom": {
+    "description": "Вариант выбора пользовательского типа счёта"
+  },
+  "addAccountCustomTypeLabel": "Собственный тип счёта",
+  "@addAccountCustomTypeLabel": {
+    "description": "Подпись поля пользовательского типа счёта"
+  },
+  "addAccountTypeRequired": "Укажите тип счёта.",
+  "@addAccountTypeRequired": {
+    "description": "Сообщение валидации при отсутствии типа счёта"
+  },
   "accountDetailsTitle": "Счёт",
   "@accountDetailsTitle": {
     "description": "Заголовок экрана деталей счёта"
@@ -1220,6 +1232,18 @@
   "@editAccountTypeLabel": {
     "description": "Подпись строки с типом счёта"
   },
+  "editAccountTypeCustom": "Другой тип",
+  "@editAccountTypeCustom": {
+    "description": "Вариант выбора пользовательского типа счёта при редактировании"
+  },
+  "editAccountCustomTypeLabel": "Собственный тип счёта",
+  "@editAccountCustomTypeLabel": {
+    "description": "Подпись поля пользовательского типа счёта при редактировании"
+  },
+  "editAccountTypeRequired": "Укажите тип счёта.",
+  "@editAccountTypeRequired": {
+    "description": "Сообщение об ошибке при отсутствии типа счёта"
+  },
   "editAccountSaveCta": "Сохранить изменения",
   "@editAccountSaveCta": {
     "description": "Кнопка сохранения изменений"
@@ -1235,6 +1259,34 @@
   "editAccountGenericError": "Не удалось обновить счёт. Повторите попытку.",
   "@editAccountGenericError": {
     "description": "Общее сообщение об ошибке при обновлении счёта"
+  },
+  "editAccountDeleteCta": "Удалить счёт",
+  "@editAccountDeleteCta": {
+    "description": "Кнопка удаления счёта"
+  },
+  "editAccountDeleteLoading": "Удаляем...",
+  "@editAccountDeleteLoading": {
+    "description": "Подпись кнопки во время удаления счёта"
+  },
+  "editAccountDeleteConfirmationTitle": "Удалить счёт?",
+  "@editAccountDeleteConfirmationTitle": {
+    "description": "Заголовок диалога подтверждения удаления счёта"
+  },
+  "editAccountDeleteConfirmationMessage": "Счёт и связанные данные будут удалены. Это действие невозможно отменить.",
+  "@editAccountDeleteConfirmationMessage": {
+    "description": "Сообщение диалога подтверждения удаления счёта"
+  },
+  "editAccountDeleteConfirmationCancel": "Отмена",
+  "@editAccountDeleteConfirmationCancel": {
+    "description": "Подпись кнопки отмены в диалоге удаления счёта"
+  },
+  "editAccountDeleteConfirmationConfirm": "Удалить",
+  "@editAccountDeleteConfirmationConfirm": {
+    "description": "Подпись кнопки подтверждения удаления счёта"
+  },
+  "editAccountDeleteError": "Не удалось удалить счёт. Попробуйте ещё раз.",
+  "@editAccountDeleteError": {
+    "description": "Сообщение об ошибке при удалении счёта"
   },
   "homeNavBudgets": "Бюджеты",
   "@homeNavBudgets": {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -107,11 +107,15 @@ class _AppHome extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    ref.watch(syncServiceProvider);
-
     return authState.when(
-      data: (AuthUser? user) =>
-          user == null ? const SignInScreen() : const MainNavigationShell(),
+      data: (AuthUser? user) {
+        if (user != null && !user.isGuest) {
+          ref.watch(syncServiceProvider);
+        }
+        return user == null
+            ? const SignInScreen()
+            : const MainNavigationShell();
+      },
       loading: () =>
           const Scaffold(body: Center(child: CircularProgressIndicator())),
       error: (Object error, _) => Scaffold(


### PR DESCRIPTION
## Изменения
- добавил use case удаления счёта, поддержку пользовательского типа и диалог подтверждения на экранах создания/редактирования счёта
- обновил контроллеры профиля и репозиторий для сохранения аватара офлайн и отказа от синхронизации для гостевого режима
- ограничил запуск синхронизации только для не гостевых пользователей, расширил локализации и убрал кнопку входа через Google

## Тестирование
- `dart format --set-exit-if-changed .`
- `flutter analyze`
- `dart run build_runner build --delete-conflicting-outputs`
- `flutter test --reporter expanded`
- `flutter pub outdated`


------
https://chatgpt.com/codex/tasks/task_e_68e3b77301d4832ea9b8826051197e8e