### PR TITLE
Добавить настройку виджетов геймификации и бюджета на домашнем экране

### DIFF
--- a/lib/core/di/injectors.dart
+++ b/lib/core/di/injectors.dart
@@ -84,6 +84,8 @@ import 'package:kopim/features/transactions/domain/use_cases/update_transaction_
 import 'package:uuid/uuid.dart';
 import 'package:kopim/features/transactions/domain/use_cases/watch_account_transactions_use_case.dart';
 import 'package:kopim/features/transactions/domain/use_cases/watch_recent_transactions_use_case.dart';
+import 'package:kopim/features/home/data/repositories/home_dashboard_preferences_repository_impl.dart';
+import 'package:kopim/features/home/domain/repositories/home_dashboard_preferences_repository.dart';
 import 'package:kopim/features/home/domain/use_cases/group_transactions_by_day_use_case.dart';
 import 'package:kopim/features/recurring_transactions/data/repositories/recurring_transactions_repository_impl.dart';
 import 'package:kopim/features/recurring_transactions/data/services/recurring_notification_service.dart';
@@ -350,6 +352,11 @@ BudgetRepository budgetRepository(Ref ref) => BudgetRepositoryImpl(
   budgetInstanceDao: ref.watch(budgetInstanceDaoProvider),
   outboxDao: ref.watch(outboxDaoProvider),
 );
+
+@riverpod
+HomeDashboardPreferencesRepository homeDashboardPreferencesRepository(Ref ref) {
+  return HomeDashboardPreferencesRepositoryImpl();
+}
 
 @riverpod
 SavingGoalRepository savingGoalRepository(Ref ref) => SavingGoalRepositoryImpl(

--- a/lib/core/di/injectors.g.dart
+++ b/lib/core/di/injectors.g.dart
@@ -2571,6 +2571,58 @@ final class BudgetRepositoryProvider
 
 String _$budgetRepositoryHash() => r'04bad8edb2ea732d9f98e0e2c0bbcf28348162f3';
 
+@ProviderFor(homeDashboardPreferencesRepository)
+const homeDashboardPreferencesRepositoryProvider =
+    HomeDashboardPreferencesRepositoryProvider._();
+
+final class HomeDashboardPreferencesRepositoryProvider
+    extends
+        $FunctionalProvider<
+          HomeDashboardPreferencesRepository,
+          HomeDashboardPreferencesRepository,
+          HomeDashboardPreferencesRepository
+        >
+    with $Provider<HomeDashboardPreferencesRepository> {
+  const HomeDashboardPreferencesRepositoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'homeDashboardPreferencesRepositoryProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() =>
+      _$homeDashboardPreferencesRepositoryHash();
+
+  @$internal
+  @override
+  $ProviderElement<HomeDashboardPreferencesRepository> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  HomeDashboardPreferencesRepository create(Ref ref) {
+    return homeDashboardPreferencesRepository(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(HomeDashboardPreferencesRepository value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<HomeDashboardPreferencesRepository>(
+        value,
+      ),
+    );
+  }
+}
+
+String _$homeDashboardPreferencesRepositoryHash() =>
+    r'c155972af33f2c3b5f38f9d979afab318ef1300d';
+
 @ProviderFor(savingGoalRepository)
 const savingGoalRepositoryProvider = SavingGoalRepositoryProvider._();
 

--- a/lib/features/home/data/repositories/home_dashboard_preferences_repository_impl.dart
+++ b/lib/features/home/data/repositories/home_dashboard_preferences_repository_impl.dart
@@ -1,0 +1,39 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:kopim/features/home/domain/entities/home_dashboard_preferences.dart';
+import 'package:kopim/features/home/domain/repositories/home_dashboard_preferences_repository.dart';
+
+const String _kPreferencesKey = 'home.dashboard.preferences';
+
+class HomeDashboardPreferencesRepositoryImpl
+    implements HomeDashboardPreferencesRepository {
+  HomeDashboardPreferencesRepositoryImpl({
+    Future<SharedPreferences>? preferences,
+  }) : _preferencesFuture = preferences ?? SharedPreferences.getInstance();
+
+  final Future<SharedPreferences> _preferencesFuture;
+
+  @override
+  Future<HomeDashboardPreferences> load() async {
+    final SharedPreferences prefs = await _preferencesFuture;
+    final String? raw = prefs.getString(_kPreferencesKey);
+    if (raw == null) {
+      return const HomeDashboardPreferences();
+    }
+    try {
+      final Map<String, dynamic> json = jsonDecode(raw) as Map<String, dynamic>;
+      return HomeDashboardPreferences.fromJson(json);
+    } catch (_) {
+      return const HomeDashboardPreferences();
+    }
+  }
+
+  @override
+  Future<void> save(HomeDashboardPreferences preferences) async {
+    final SharedPreferences prefs = await _preferencesFuture;
+    final String raw = jsonEncode(preferences.toJson());
+    await prefs.setString(_kPreferencesKey, raw);
+  }
+}

--- a/lib/features/home/domain/entities/home_dashboard_preferences.dart
+++ b/lib/features/home/domain/entities/home_dashboard_preferences.dart
@@ -1,0 +1,16 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'home_dashboard_preferences.freezed.dart';
+part 'home_dashboard_preferences.g.dart';
+
+@freezed
+abstract class HomeDashboardPreferences with _$HomeDashboardPreferences {
+  const factory HomeDashboardPreferences({
+    @Default(false) bool showGamificationWidget,
+    @Default(false) bool showBudgetWidget,
+    String? budgetId,
+  }) = _HomeDashboardPreferences;
+
+  factory HomeDashboardPreferences.fromJson(Map<String, dynamic> json) =>
+      _$HomeDashboardPreferencesFromJson(json);
+}

--- a/lib/features/home/domain/entities/home_dashboard_preferences.freezed.dart
+++ b/lib/features/home/domain/entities/home_dashboard_preferences.freezed.dart
@@ -1,0 +1,283 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'home_dashboard_preferences.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$HomeDashboardPreferences {
+
+ bool get showGamificationWidget; bool get showBudgetWidget; String? get budgetId;
+/// Create a copy of HomeDashboardPreferences
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$HomeDashboardPreferencesCopyWith<HomeDashboardPreferences> get copyWith => _$HomeDashboardPreferencesCopyWithImpl<HomeDashboardPreferences>(this as HomeDashboardPreferences, _$identity);
+
+  /// Serializes this HomeDashboardPreferences to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is HomeDashboardPreferences&&(identical(other.showGamificationWidget, showGamificationWidget) || other.showGamificationWidget == showGamificationWidget)&&(identical(other.showBudgetWidget, showBudgetWidget) || other.showBudgetWidget == showBudgetWidget)&&(identical(other.budgetId, budgetId) || other.budgetId == budgetId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,showGamificationWidget,showBudgetWidget,budgetId);
+
+@override
+String toString() {
+  return 'HomeDashboardPreferences(showGamificationWidget: $showGamificationWidget, showBudgetWidget: $showBudgetWidget, budgetId: $budgetId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $HomeDashboardPreferencesCopyWith<$Res>  {
+  factory $HomeDashboardPreferencesCopyWith(HomeDashboardPreferences value, $Res Function(HomeDashboardPreferences) _then) = _$HomeDashboardPreferencesCopyWithImpl;
+@useResult
+$Res call({
+ bool showGamificationWidget, bool showBudgetWidget, String? budgetId
+});
+
+
+
+
+}
+/// @nodoc
+class _$HomeDashboardPreferencesCopyWithImpl<$Res>
+    implements $HomeDashboardPreferencesCopyWith<$Res> {
+  _$HomeDashboardPreferencesCopyWithImpl(this._self, this._then);
+
+  final HomeDashboardPreferences _self;
+  final $Res Function(HomeDashboardPreferences) _then;
+
+/// Create a copy of HomeDashboardPreferences
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? showGamificationWidget = null,Object? showBudgetWidget = null,Object? budgetId = freezed,}) {
+  return _then(_self.copyWith(
+showGamificationWidget: null == showGamificationWidget ? _self.showGamificationWidget : showGamificationWidget // ignore: cast_nullable_to_non_nullable
+as bool,showBudgetWidget: null == showBudgetWidget ? _self.showBudgetWidget : showBudgetWidget // ignore: cast_nullable_to_non_nullable
+as bool,budgetId: freezed == budgetId ? _self.budgetId : budgetId // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [HomeDashboardPreferences].
+extension HomeDashboardPreferencesPatterns on HomeDashboardPreferences {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _HomeDashboardPreferences value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _HomeDashboardPreferences() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _HomeDashboardPreferences value)  $default,){
+final _that = this;
+switch (_that) {
+case _HomeDashboardPreferences():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _HomeDashboardPreferences value)?  $default,){
+final _that = this;
+switch (_that) {
+case _HomeDashboardPreferences() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool showGamificationWidget,  bool showBudgetWidget,  String? budgetId)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _HomeDashboardPreferences() when $default != null:
+return $default(_that.showGamificationWidget,_that.showBudgetWidget,_that.budgetId);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool showGamificationWidget,  bool showBudgetWidget,  String? budgetId)  $default,) {final _that = this;
+switch (_that) {
+case _HomeDashboardPreferences():
+return $default(_that.showGamificationWidget,_that.showBudgetWidget,_that.budgetId);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool showGamificationWidget,  bool showBudgetWidget,  String? budgetId)?  $default,) {final _that = this;
+switch (_that) {
+case _HomeDashboardPreferences() when $default != null:
+return $default(_that.showGamificationWidget,_that.showBudgetWidget,_that.budgetId);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _HomeDashboardPreferences implements HomeDashboardPreferences {
+  const _HomeDashboardPreferences({this.showGamificationWidget = false, this.showBudgetWidget = false, this.budgetId});
+  factory _HomeDashboardPreferences.fromJson(Map<String, dynamic> json) => _$HomeDashboardPreferencesFromJson(json);
+
+@override@JsonKey() final  bool showGamificationWidget;
+@override@JsonKey() final  bool showBudgetWidget;
+@override final  String? budgetId;
+
+/// Create a copy of HomeDashboardPreferences
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$HomeDashboardPreferencesCopyWith<_HomeDashboardPreferences> get copyWith => __$HomeDashboardPreferencesCopyWithImpl<_HomeDashboardPreferences>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$HomeDashboardPreferencesToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _HomeDashboardPreferences&&(identical(other.showGamificationWidget, showGamificationWidget) || other.showGamificationWidget == showGamificationWidget)&&(identical(other.showBudgetWidget, showBudgetWidget) || other.showBudgetWidget == showBudgetWidget)&&(identical(other.budgetId, budgetId) || other.budgetId == budgetId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,showGamificationWidget,showBudgetWidget,budgetId);
+
+@override
+String toString() {
+  return 'HomeDashboardPreferences(showGamificationWidget: $showGamificationWidget, showBudgetWidget: $showBudgetWidget, budgetId: $budgetId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$HomeDashboardPreferencesCopyWith<$Res> implements $HomeDashboardPreferencesCopyWith<$Res> {
+  factory _$HomeDashboardPreferencesCopyWith(_HomeDashboardPreferences value, $Res Function(_HomeDashboardPreferences) _then) = __$HomeDashboardPreferencesCopyWithImpl;
+@override @useResult
+$Res call({
+ bool showGamificationWidget, bool showBudgetWidget, String? budgetId
+});
+
+
+
+
+}
+/// @nodoc
+class __$HomeDashboardPreferencesCopyWithImpl<$Res>
+    implements _$HomeDashboardPreferencesCopyWith<$Res> {
+  __$HomeDashboardPreferencesCopyWithImpl(this._self, this._then);
+
+  final _HomeDashboardPreferences _self;
+  final $Res Function(_HomeDashboardPreferences) _then;
+
+/// Create a copy of HomeDashboardPreferences
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? showGamificationWidget = null,Object? showBudgetWidget = null,Object? budgetId = freezed,}) {
+  return _then(_HomeDashboardPreferences(
+showGamificationWidget: null == showGamificationWidget ? _self.showGamificationWidget : showGamificationWidget // ignore: cast_nullable_to_non_nullable
+as bool,showBudgetWidget: null == showBudgetWidget ? _self.showBudgetWidget : showBudgetWidget // ignore: cast_nullable_to_non_nullable
+as bool,budgetId: freezed == budgetId ? _self.budgetId : budgetId // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/features/home/domain/entities/home_dashboard_preferences.g.dart
+++ b/lib/features/home/domain/entities/home_dashboard_preferences.g.dart
@@ -1,0 +1,23 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'home_dashboard_preferences.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_HomeDashboardPreferences _$HomeDashboardPreferencesFromJson(
+  Map<String, dynamic> json,
+) => _HomeDashboardPreferences(
+  showGamificationWidget: json['showGamificationWidget'] as bool? ?? false,
+  showBudgetWidget: json['showBudgetWidget'] as bool? ?? false,
+  budgetId: json['budgetId'] as String?,
+);
+
+Map<String, dynamic> _$HomeDashboardPreferencesToJson(
+  _HomeDashboardPreferences instance,
+) => <String, dynamic>{
+  'showGamificationWidget': instance.showGamificationWidget,
+  'showBudgetWidget': instance.showBudgetWidget,
+  'budgetId': instance.budgetId,
+};

--- a/lib/features/home/domain/repositories/home_dashboard_preferences_repository.dart
+++ b/lib/features/home/domain/repositories/home_dashboard_preferences_repository.dart
@@ -1,0 +1,10 @@
+import 'package:kopim/features/home/domain/entities/home_dashboard_preferences.dart';
+
+/// Контракт репозитория настроек домашнего экрана.
+abstract class HomeDashboardPreferencesRepository {
+  /// Загружает сохранённые предпочтения или возвращает значения по умолчанию.
+  Future<HomeDashboardPreferences> load();
+
+  /// Сохраняет предпочтения домашнего экрана.
+  Future<void> save(HomeDashboardPreferences preferences);
+}

--- a/lib/features/home/presentation/controllers/home_dashboard_preferences_controller.dart
+++ b/lib/features/home/presentation/controllers/home_dashboard_preferences_controller.dart
@@ -1,0 +1,61 @@
+import 'dart:async';
+
+import 'package:kopim/core/di/injectors.dart';
+import 'package:kopim/features/home/domain/entities/home_dashboard_preferences.dart';
+import 'package:kopim/features/home/domain/repositories/home_dashboard_preferences_repository.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'home_dashboard_preferences_controller.g.dart';
+
+@riverpod
+class HomeDashboardPreferencesController
+    extends _$HomeDashboardPreferencesController {
+  late final HomeDashboardPreferencesRepository _repository;
+
+  @override
+  FutureOr<HomeDashboardPreferences> build() async {
+    _repository = ref.watch(homeDashboardPreferencesRepositoryProvider);
+    return _repository.load();
+  }
+
+  Future<void> setShowGamification(bool value) async {
+    final HomeDashboardPreferences current = await future;
+    final HomeDashboardPreferences updated = current.copyWith(
+      showGamificationWidget: value,
+    );
+    await _persist(updated, previous: current);
+  }
+
+  Future<void> setShowBudget(bool value) async {
+    final HomeDashboardPreferences current = await future;
+    final HomeDashboardPreferences updated = current.copyWith(
+      showBudgetWidget: value,
+      budgetId: value ? current.budgetId : null,
+    );
+    await _persist(updated, previous: current);
+  }
+
+  Future<void> setBudgetId(String? budgetId) async {
+    final HomeDashboardPreferences current = await future;
+    final HomeDashboardPreferences updated = current.copyWith(
+      budgetId: budgetId,
+    );
+    await _persist(updated, previous: current);
+  }
+
+  Future<void> _persist(
+    HomeDashboardPreferences preferences, {
+    required HomeDashboardPreferences previous,
+  }) async {
+    state = AsyncValue<HomeDashboardPreferences>.data(preferences);
+    try {
+      await _repository.save(preferences);
+    } catch (error, stackTrace) {
+      state = AsyncValue<HomeDashboardPreferences>.data(previous);
+      ref
+          .read(loggerServiceProvider)
+          .logError('Failed to save home dashboard preferences', error);
+      Error.throwWithStackTrace(error, stackTrace);
+    }
+  }
+}

--- a/lib/features/home/presentation/controllers/home_dashboard_preferences_controller.g.dart
+++ b/lib/features/home/presentation/controllers/home_dashboard_preferences_controller.g.dart
@@ -1,0 +1,72 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'home_dashboard_preferences_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(HomeDashboardPreferencesController)
+const homeDashboardPreferencesControllerProvider =
+    HomeDashboardPreferencesControllerProvider._();
+
+final class HomeDashboardPreferencesControllerProvider
+    extends
+        $AsyncNotifierProvider<
+          HomeDashboardPreferencesController,
+          HomeDashboardPreferences
+        > {
+  const HomeDashboardPreferencesControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'homeDashboardPreferencesControllerProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() =>
+      _$homeDashboardPreferencesControllerHash();
+
+  @$internal
+  @override
+  HomeDashboardPreferencesController create() =>
+      HomeDashboardPreferencesController();
+}
+
+String _$homeDashboardPreferencesControllerHash() =>
+    r'01f60dfc6d328b865b8123ff3024213c2008ea2c';
+
+abstract class _$HomeDashboardPreferencesController
+    extends $AsyncNotifier<HomeDashboardPreferences> {
+  FutureOr<HomeDashboardPreferences> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build();
+    final ref =
+        this.ref
+            as $Ref<
+              AsyncValue<HomeDashboardPreferences>,
+              HomeDashboardPreferences
+            >;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<
+                AsyncValue<HomeDashboardPreferences>,
+                HomeDashboardPreferences
+              >,
+              AsyncValue<HomeDashboardPreferences>,
+              Object?,
+              Object?
+            >;
+    element.handleValue(ref, created);
+  }
+}

--- a/lib/features/home/presentation/widgets/home_budget_progress_card.dart
+++ b/lib/features/home/presentation/widgets/home_budget_progress_card.dart
@@ -1,0 +1,182 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+
+import 'package:kopim/features/budgets/domain/entities/budget_progress.dart';
+import 'package:kopim/features/budgets/presentation/controllers/budgets_providers.dart';
+import 'package:kopim/features/budgets/presentation/widgets/budget_progress_indicator.dart';
+import 'package:kopim/features/home/domain/entities/home_dashboard_preferences.dart';
+import 'package:kopim/l10n/app_localizations.dart';
+
+class HomeBudgetProgressCard extends ConsumerWidget {
+  const HomeBudgetProgressCard({
+    required this.preferences,
+    required this.onConfigure,
+    super.key,
+  });
+
+  final HomeDashboardPreferences preferences;
+  final VoidCallback onConfigure;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ThemeData theme = Theme.of(context);
+    final AppLocalizations strings = AppLocalizations.of(context)!;
+
+    final String? budgetId = preferences.budgetId;
+    if (budgetId == null) {
+      return Card(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Text(
+                strings.homeBudgetWidgetTitle,
+                style: theme.textTheme.titleMedium,
+              ),
+              const SizedBox(height: 4),
+              Text(
+                strings.homeBudgetWidgetEmpty,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+              const SizedBox(height: 16),
+              FilledButton.tonalIcon(
+                onPressed: onConfigure,
+                icon: const Icon(Icons.settings_outlined),
+                label: Text(strings.homeBudgetWidgetConfigureCta),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    final AsyncValue<BudgetProgress> progressAsync = ref.watch(
+      budgetProgressByIdProvider(budgetId),
+    );
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              strings.homeBudgetWidgetTitle,
+              style: theme.textTheme.titleMedium,
+            ),
+            const SizedBox(height: 4),
+            progressAsync.when(
+              data: (BudgetProgress progress) {
+                final NumberFormat currencyFormat = NumberFormat.simpleCurrency(
+                  locale: strings.localeName,
+                );
+                final double limit = progress.budget.amount;
+                final double spent = progress.spent;
+                final double remaining = progress.remaining;
+                final double ratio = progress.utilization.isFinite
+                    ? progress.utilization.clamp(0, 2)
+                    : 1.0;
+                final bool exceeded = progress.isExceeded;
+
+                return Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Text(
+                      progress.budget.title,
+                      style: theme.textTheme.titleMedium,
+                    ),
+                    const SizedBox(height: 12),
+                    BudgetProgressIndicator(value: ratio, exceeded: exceeded),
+                    const SizedBox(height: 12),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: <Widget>[
+                        _BudgetStat(
+                          label: strings.budgetsSpentLabel,
+                          value: currencyFormat.format(spent),
+                        ),
+                        _BudgetStat(
+                          label: strings.budgetsLimitLabel,
+                          value: currencyFormat.format(limit),
+                        ),
+                        _BudgetStat(
+                          label: exceeded
+                              ? strings.budgetsExceededLabel
+                              : strings.budgetsRemainingLabel,
+                          value: currencyFormat.format(
+                            exceeded ? (spent - limit) : remaining,
+                          ),
+                          valueStyle: exceeded
+                              ? theme.textTheme.bodyMedium?.copyWith(
+                                  color: theme.colorScheme.error,
+                                  fontWeight: FontWeight.w600,
+                                )
+                              : null,
+                        ),
+                      ],
+                    ),
+                  ],
+                );
+              },
+              loading: () => const Padding(
+                padding: EdgeInsets.symmetric(vertical: 8),
+                child: LinearProgressIndicator(),
+              ),
+              error: (Object error, _) => Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Text(
+                    strings.homeBudgetWidgetMissing,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.error,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  FilledButton.tonalIcon(
+                    onPressed: onConfigure,
+                    icon: const Icon(Icons.settings_outlined),
+                    label: Text(strings.homeBudgetWidgetConfigureCta),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _BudgetStat extends StatelessWidget {
+  const _BudgetStat({
+    required this.label,
+    required this.value,
+    this.valueStyle,
+  });
+
+  final String label;
+  final String value;
+  final TextStyle? valueStyle;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text(
+          label,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(value, style: valueStyle ?? theme.textTheme.bodyMedium),
+      ],
+    );
+  }
+}

--- a/lib/features/home/presentation/widgets/home_gamification_card.dart
+++ b/lib/features/home/presentation/widgets/home_gamification_card.dart
@@ -1,0 +1,108 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:kopim/core/di/injectors.dart';
+import 'package:kopim/features/profile/domain/entities/user_progress.dart';
+import 'package:kopim/features/profile/domain/policies/level_policy.dart';
+import 'package:kopim/features/profile/presentation/controllers/user_progress_controller.dart';
+import 'package:kopim/l10n/app_localizations.dart';
+
+class HomeGamificationCard extends ConsumerWidget {
+  const HomeGamificationCard({required this.userId, super.key});
+
+  final String userId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ThemeData theme = Theme.of(context);
+    final AppLocalizations strings = AppLocalizations.of(context)!;
+    final AsyncValue<UserProgress> progressAsync = ref.watch(
+      userProgressProvider(userId),
+    );
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              strings.homeGamificationTitle,
+              style: theme.textTheme.titleMedium,
+            ),
+            const SizedBox(height: 4),
+            Text(
+              strings.homeGamificationSubtitle,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: 16),
+            progressAsync.when(
+              data: (UserProgress progress) {
+                final LevelPolicy policy = ref.read(levelPolicyProvider);
+                final int previousThreshold = policy.previousThreshold(
+                  progress.level,
+                );
+                final int nextThreshold = progress.nextThreshold;
+                final double ratio = nextThreshold == previousThreshold
+                    ? 1.0
+                    : ((progress.totalTx - previousThreshold) /
+                              (nextThreshold - previousThreshold))
+                          .clamp(0.0, 1.0);
+                final int xpToNext = math.max(
+                  0,
+                  nextThreshold - progress.totalTx,
+                );
+                final bool maxedOut = nextThreshold == progress.totalTx;
+
+                return Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Chip(
+                      label: Text(
+                        strings.profileLevelBadge(
+                          progress.level,
+                          progress.title,
+                        ),
+                      ),
+                      avatar: const Icon(Icons.emoji_events_outlined),
+                    ),
+                    const SizedBox(height: 12),
+                    ClipRRect(
+                      borderRadius: const BorderRadius.all(Radius.circular(12)),
+                      child: LinearProgressIndicator(value: ratio),
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      maxedOut
+                          ? strings.profileLevelMaxReached
+                          : strings.profileXpToNext(xpToNext),
+                      style: theme.textTheme.bodyMedium,
+                    ),
+                  ],
+                );
+              },
+              loading: () => const Align(
+                alignment: Alignment.centerLeft,
+                child: SizedBox(
+                  width: 24,
+                  height: 24,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                ),
+              ),
+              error: (Object error, _) => Text(
+                strings.homeGamificationError(error.toString()),
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.error,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -33,6 +33,71 @@
   "@profileRecurringTransactionsCta": {
     "description": "Button label that opens the recurring transactions screen from the profile settings"
   },
+  "settingsHomeSectionTitle": "Home screen",
+  "@settingsHomeSectionTitle": {
+    "description": "Section header for home screen configuration"
+  },
+  "settingsHomeGamificationTitle": "Gamification widget",
+  "@settingsHomeGamificationTitle": {
+    "description": "Switch label for enabling the gamification widget"
+  },
+  "settingsHomeGamificationSubtitle": "Show level progress on the home screen.",
+  "@settingsHomeGamificationSubtitle": {
+    "description": "Helper text for the gamification toggle"
+  },
+  "settingsHomeBudgetTitle": "Budget widget",
+  "@settingsHomeBudgetTitle": {
+    "description": "Switch label for enabling the budget widget"
+  },
+  "settingsHomeBudgetSubtitle": "Track a selected budget without leaving the home screen.",
+  "@settingsHomeBudgetSubtitle": {
+    "description": "Helper text for the budget widget toggle"
+  },
+  "settingsHomeBudgetSelectedLabel": "Selected budget",
+  "@settingsHomeBudgetSelectedLabel": {
+    "description": "Title for the list tile showing the currently selected budget"
+  },
+  "settingsHomeBudgetNoBudgets": "Create a budget to enable this widget.",
+  "@settingsHomeBudgetNoBudgets": {
+    "description": "Message displayed when no budgets exist"
+  },
+  "settingsHomeBudgetSelectedNone": "No budget selected",
+  "@settingsHomeBudgetSelectedNone": {
+    "description": "Subtitle shown when no budget is selected"
+  },
+  "settingsHomeBudgetError": "Can't load budgets: {error}",
+  "@settingsHomeBudgetError": {
+    "description": "Error displayed when the budgets stream fails",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsHomeBudgetPickerTitle": "Choose budget",
+  "@settingsHomeBudgetPickerTitle": {
+    "description": "Title for the bottom sheet where the user selects a budget"
+  },
+  "settingsHomeBudgetPickerSubtitle": "{spent} of {limit} used",
+  "@settingsHomeBudgetPickerSubtitle": {
+    "description": "Subtitle summarizing budget usage in the picker",
+    "placeholders": {
+      "spent": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsHomeBudgetPickerHint": "You can also disable the widget in the list above.",
+  "@settingsHomeBudgetPickerHint": {
+    "description": "Helper text shown under the clear selection action"
+  },
+  "settingsHomeBudgetPickerClear": "Clear selection",
+  "@settingsHomeBudgetPickerClear": {
+    "description": "Action label for removing the selected budget"
+  },
   "profileManageCategoriesTitle": "Manage categories",
   "@profileManageCategoriesTitle": {
     "description": "Title for the category management screen"
@@ -746,6 +811,48 @@
     "placeholders": {
       "count": {
         "type": "int"
+      }
+    }
+  },
+  "homeGamificationTitle": "Level progress",
+  "@homeGamificationTitle": {
+    "description": "Title for the gamification widget on the home screen"
+  },
+  "homeGamificationSubtitle": "Complete transactions to earn XP and unlock new levels.",
+  "@homeGamificationSubtitle": {
+    "description": "Subtitle explaining how to gain experience"
+  },
+  "homeGamificationError": "Can't load progress: {error}",
+  "@homeGamificationError": {
+    "description": "Error message shown when gamification data fails to load",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "homeBudgetWidgetTitle": "Budget overview",
+  "@homeBudgetWidgetTitle": {
+    "description": "Title for the selected budget card on the home screen"
+  },
+  "homeBudgetWidgetEmpty": "Select a budget in settings to track it here.",
+  "@homeBudgetWidgetEmpty": {
+    "description": "Message shown when no budget is selected for the home widget"
+  },
+  "homeBudgetWidgetMissing": "The selected budget is no longer available.",
+  "@homeBudgetWidgetMissing": {
+    "description": "Error shown when the configured budget was deleted"
+  },
+  "homeBudgetWidgetConfigureCta": "Open settings",
+  "@homeBudgetWidgetConfigureCta": {
+    "description": "Button label that opens settings to configure the budget widget"
+  },
+  "homeDashboardPreferencesError": "Couldn't load home widgets: {error}",
+  "@homeDashboardPreferencesError": {
+    "description": "Error shown when dashboard preferences fail to load",
+    "placeholders": {
+      "error": {
+        "type": "String"
       }
     }
   },

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -152,6 +152,84 @@ abstract class AppLocalizations {
   /// **'Recurring transactions'**
   String get profileRecurringTransactionsCta;
 
+  /// Section header for home screen configuration
+  ///
+  /// In en, this message translates to:
+  /// **'Home screen'**
+  String get settingsHomeSectionTitle;
+
+  /// Switch label for enabling the gamification widget
+  ///
+  /// In en, this message translates to:
+  /// **'Gamification widget'**
+  String get settingsHomeGamificationTitle;
+
+  /// Helper text for the gamification toggle
+  ///
+  /// In en, this message translates to:
+  /// **'Show level progress on the home screen.'**
+  String get settingsHomeGamificationSubtitle;
+
+  /// Switch label for enabling the budget widget
+  ///
+  /// In en, this message translates to:
+  /// **'Budget widget'**
+  String get settingsHomeBudgetTitle;
+
+  /// Helper text for the budget widget toggle
+  ///
+  /// In en, this message translates to:
+  /// **'Track a selected budget without leaving the home screen.'**
+  String get settingsHomeBudgetSubtitle;
+
+  /// Title for the list tile showing the currently selected budget
+  ///
+  /// In en, this message translates to:
+  /// **'Selected budget'**
+  String get settingsHomeBudgetSelectedLabel;
+
+  /// Message displayed when no budgets exist
+  ///
+  /// In en, this message translates to:
+  /// **'Create a budget to enable this widget.'**
+  String get settingsHomeBudgetNoBudgets;
+
+  /// Subtitle shown when no budget is selected
+  ///
+  /// In en, this message translates to:
+  /// **'No budget selected'**
+  String get settingsHomeBudgetSelectedNone;
+
+  /// Error displayed when the budgets stream fails
+  ///
+  /// In en, this message translates to:
+  /// **'Can\'t load budgets: {error}'**
+  String settingsHomeBudgetError(String error);
+
+  /// Title for the bottom sheet where the user selects a budget
+  ///
+  /// In en, this message translates to:
+  /// **'Choose budget'**
+  String get settingsHomeBudgetPickerTitle;
+
+  /// Subtitle summarizing budget usage in the picker
+  ///
+  /// In en, this message translates to:
+  /// **'{spent} of {limit} used'**
+  String settingsHomeBudgetPickerSubtitle(String spent, String limit);
+
+  /// Helper text shown under the clear selection action
+  ///
+  /// In en, this message translates to:
+  /// **'You can also disable the widget in the list above.'**
+  String get settingsHomeBudgetPickerHint;
+
+  /// Action label for removing the selected budget
+  ///
+  /// In en, this message translates to:
+  /// **'Clear selection'**
+  String get settingsHomeBudgetPickerClear;
+
   /// Title for the category management screen
   ///
   /// In en, this message translates to:
@@ -1069,6 +1147,54 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'{count, plural, =0 {No scheduled payments} one {# upcoming payment} other {# upcoming payments}}'**
   String homeUpcomingPaymentsCountSemantics(int count);
+
+  /// Title for the gamification widget on the home screen
+  ///
+  /// In en, this message translates to:
+  /// **'Level progress'**
+  String get homeGamificationTitle;
+
+  /// Subtitle explaining how to gain experience
+  ///
+  /// In en, this message translates to:
+  /// **'Complete transactions to earn XP and unlock new levels.'**
+  String get homeGamificationSubtitle;
+
+  /// Error message shown when gamification data fails to load
+  ///
+  /// In en, this message translates to:
+  /// **'Can\'t load progress: {error}'**
+  String homeGamificationError(String error);
+
+  /// Title for the selected budget card on the home screen
+  ///
+  /// In en, this message translates to:
+  /// **'Budget overview'**
+  String get homeBudgetWidgetTitle;
+
+  /// Message shown when no budget is selected for the home widget
+  ///
+  /// In en, this message translates to:
+  /// **'Select a budget in settings to track it here.'**
+  String get homeBudgetWidgetEmpty;
+
+  /// Error shown when the configured budget was deleted
+  ///
+  /// In en, this message translates to:
+  /// **'The selected budget is no longer available.'**
+  String get homeBudgetWidgetMissing;
+
+  /// Button label that opens settings to configure the budget widget
+  ///
+  /// In en, this message translates to:
+  /// **'Open settings'**
+  String get homeBudgetWidgetConfigureCta;
+
+  /// Error shown when dashboard preferences fail to load
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t load home widgets: {error}'**
+  String homeDashboardPreferencesError(String error);
 
   /// Bottom navigation label for home
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -36,6 +36,53 @@ class AppLocalizationsEn extends AppLocalizations {
   String get profileRecurringTransactionsCta => 'Recurring transactions';
 
   @override
+  String get settingsHomeSectionTitle => 'Home screen';
+
+  @override
+  String get settingsHomeGamificationTitle => 'Gamification widget';
+
+  @override
+  String get settingsHomeGamificationSubtitle =>
+      'Show level progress on the home screen.';
+
+  @override
+  String get settingsHomeBudgetTitle => 'Budget widget';
+
+  @override
+  String get settingsHomeBudgetSubtitle =>
+      'Track a selected budget without leaving the home screen.';
+
+  @override
+  String get settingsHomeBudgetSelectedLabel => 'Selected budget';
+
+  @override
+  String get settingsHomeBudgetNoBudgets =>
+      'Create a budget to enable this widget.';
+
+  @override
+  String get settingsHomeBudgetSelectedNone => 'No budget selected';
+
+  @override
+  String settingsHomeBudgetError(String error) {
+    return 'Can\'t load budgets: $error';
+  }
+
+  @override
+  String get settingsHomeBudgetPickerTitle => 'Choose budget';
+
+  @override
+  String settingsHomeBudgetPickerSubtitle(String spent, String limit) {
+    return '$spent of $limit used';
+  }
+
+  @override
+  String get settingsHomeBudgetPickerHint =>
+      'You can also disable the widget in the list above.';
+
+  @override
+  String get settingsHomeBudgetPickerClear => 'Clear selection';
+
+  @override
   String get profileManageCategoriesTitle => 'Manage categories';
 
   @override
@@ -547,6 +594,37 @@ class AppLocalizationsEn extends AppLocalizations {
       zero: 'No scheduled payments',
     );
     return '$_temp0';
+  }
+
+  @override
+  String get homeGamificationTitle => 'Level progress';
+
+  @override
+  String get homeGamificationSubtitle =>
+      'Complete transactions to earn XP and unlock new levels.';
+
+  @override
+  String homeGamificationError(String error) {
+    return 'Can\'t load progress: $error';
+  }
+
+  @override
+  String get homeBudgetWidgetTitle => 'Budget overview';
+
+  @override
+  String get homeBudgetWidgetEmpty =>
+      'Select a budget in settings to track it here.';
+
+  @override
+  String get homeBudgetWidgetMissing =>
+      'The selected budget is no longer available.';
+
+  @override
+  String get homeBudgetWidgetConfigureCta => 'Open settings';
+
+  @override
+  String homeDashboardPreferencesError(String error) {
+    return 'Couldn\'t load home widgets: $error';
   }
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -37,6 +37,53 @@ class AppLocalizationsRu extends AppLocalizations {
   String get profileRecurringTransactionsCta => 'Повторяющиеся операции';
 
   @override
+  String get settingsHomeSectionTitle => 'Домашний экран';
+
+  @override
+  String get settingsHomeGamificationTitle => 'Виджет геймификации';
+
+  @override
+  String get settingsHomeGamificationSubtitle =>
+      'Показывать прогресс уровня на главном экране.';
+
+  @override
+  String get settingsHomeBudgetTitle => 'Виджет бюджета';
+
+  @override
+  String get settingsHomeBudgetSubtitle =>
+      'Отслеживайте выбранный бюджет прямо на главном экране.';
+
+  @override
+  String get settingsHomeBudgetSelectedLabel => 'Выбранный бюджет';
+
+  @override
+  String get settingsHomeBudgetNoBudgets =>
+      'Создайте бюджет, чтобы включить виджет.';
+
+  @override
+  String get settingsHomeBudgetSelectedNone => 'Бюджет не выбран';
+
+  @override
+  String settingsHomeBudgetError(String error) {
+    return 'Не удалось загрузить бюджеты: $error';
+  }
+
+  @override
+  String get settingsHomeBudgetPickerTitle => 'Выберите бюджет';
+
+  @override
+  String settingsHomeBudgetPickerSubtitle(String spent, String limit) {
+    return 'Использовано $spent из $limit';
+  }
+
+  @override
+  String get settingsHomeBudgetPickerHint =>
+      'Виджет можно отключить переключателем выше.';
+
+  @override
+  String get settingsHomeBudgetPickerClear => 'Сбросить выбор';
+
+  @override
   String get profileManageCategoriesTitle => 'Управление категориями';
 
   @override
@@ -551,6 +598,36 @@ class AppLocalizationsRu extends AppLocalizations {
       zero: 'Нет запланированных платежей',
     );
     return '$_temp0';
+  }
+
+  @override
+  String get homeGamificationTitle => 'Прогресс уровня';
+
+  @override
+  String get homeGamificationSubtitle =>
+      'Совершайте операции, чтобы получать опыт и повышать уровень.';
+
+  @override
+  String homeGamificationError(String error) {
+    return 'Не удалось загрузить прогресс: $error';
+  }
+
+  @override
+  String get homeBudgetWidgetTitle => 'Сводка бюджета';
+
+  @override
+  String get homeBudgetWidgetEmpty =>
+      'Выберите бюджет в настройках, чтобы отслеживать его здесь.';
+
+  @override
+  String get homeBudgetWidgetMissing => 'Выбранный бюджет недоступен.';
+
+  @override
+  String get homeBudgetWidgetConfigureCta => 'Открыть настройки';
+
+  @override
+  String homeDashboardPreferencesError(String error) {
+    return 'Не удалось загрузить виджеты: $error';
   }
 
   @override

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -33,6 +33,71 @@
   "@profileRecurringTransactionsCta": {
     "description": "Подпись кнопки, открывающей экран повторяющихся операций из настроек профиля"
   },
+  "settingsHomeSectionTitle": "Домашний экран",
+  "@settingsHomeSectionTitle": {
+    "description": "Заголовок секции настроек домашнего экрана"
+  },
+  "settingsHomeGamificationTitle": "Виджет геймификации",
+  "@settingsHomeGamificationTitle": {
+    "description": "Подпись переключателя виджета геймификации"
+  },
+  "settingsHomeGamificationSubtitle": "Показывать прогресс уровня на главном экране.",
+  "@settingsHomeGamificationSubtitle": {
+    "description": "Подсказка к переключателю виджета геймификации"
+  },
+  "settingsHomeBudgetTitle": "Виджет бюджета",
+  "@settingsHomeBudgetTitle": {
+    "description": "Подпись переключателя виджета бюджета"
+  },
+  "settingsHomeBudgetSubtitle": "Отслеживайте выбранный бюджет прямо на главном экране.",
+  "@settingsHomeBudgetSubtitle": {
+    "description": "Подсказка к переключателю виджета бюджета"
+  },
+  "settingsHomeBudgetSelectedLabel": "Выбранный бюджет",
+  "@settingsHomeBudgetSelectedLabel": {
+    "description": "Заголовок элемента со статусом выбранного бюджета"
+  },
+  "settingsHomeBudgetNoBudgets": "Создайте бюджет, чтобы включить виджет.",
+  "@settingsHomeBudgetNoBudgets": {
+    "description": "Сообщение, когда бюджетов ещё нет"
+  },
+  "settingsHomeBudgetSelectedNone": "Бюджет не выбран",
+  "@settingsHomeBudgetSelectedNone": {
+    "description": "Подпись, когда бюджет для виджета не выбран"
+  },
+  "settingsHomeBudgetError": "Не удалось загрузить бюджеты: {error}",
+  "@settingsHomeBudgetError": {
+    "description": "Ошибка при загрузке списка бюджетов",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsHomeBudgetPickerTitle": "Выберите бюджет",
+  "@settingsHomeBudgetPickerTitle": {
+    "description": "Заголовок нижнего листа выбора бюджета"
+  },
+  "settingsHomeBudgetPickerSubtitle": "Использовано {spent} из {limit}",
+  "@settingsHomeBudgetPickerSubtitle": {
+    "description": "Подпись с прогрессом бюджета в списке",
+    "placeholders": {
+      "spent": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsHomeBudgetPickerHint": "Виджет можно отключить переключателем выше.",
+  "@settingsHomeBudgetPickerHint": {
+    "description": "Подсказка к действию сброса выбора"
+  },
+  "settingsHomeBudgetPickerClear": "Сбросить выбор",
+  "@settingsHomeBudgetPickerClear": {
+    "description": "Подпись действия очистки выбранного бюджета"
+  },
   "profileManageCategoriesTitle": "Управление категориями",
   "@profileManageCategoriesTitle": {
     "description": "Заголовок экрана управления категориями"
@@ -746,6 +811,48 @@
     "placeholders": {
       "count": {
         "type": "int"
+      }
+    }
+  },
+  "homeGamificationTitle": "Прогресс уровня",
+  "@homeGamificationTitle": {
+    "description": "Заголовок виджета геймификации на главном экране"
+  },
+  "homeGamificationSubtitle": "Совершайте операции, чтобы получать опыт и повышать уровень.",
+  "@homeGamificationSubtitle": {
+    "description": "Подзаголовок с пояснением, как набрать опыт"
+  },
+  "homeGamificationError": "Не удалось загрузить прогресс: {error}",
+  "@homeGamificationError": {
+    "description": "Ошибка загрузки данных геймификации",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "homeBudgetWidgetTitle": "Сводка бюджета",
+  "@homeBudgetWidgetTitle": {
+    "description": "Заголовок карточки выбранного бюджета"
+  },
+  "homeBudgetWidgetEmpty": "Выберите бюджет в настройках, чтобы отслеживать его здесь.",
+  "@homeBudgetWidgetEmpty": {
+    "description": "Сообщение, когда для виджета не выбран бюджет"
+  },
+  "homeBudgetWidgetMissing": "Выбранный бюджет недоступен.",
+  "@homeBudgetWidgetMissing": {
+    "description": "Ошибка, если сохранённый бюджет удалён"
+  },
+  "homeBudgetWidgetConfigureCta": "Открыть настройки",
+  "@homeBudgetWidgetConfigureCta": {
+    "description": "Кнопка для перехода в настройки виджета бюджета"
+  },
+  "homeDashboardPreferencesError": "Не удалось загрузить виджеты: {error}",
+  "@homeDashboardPreferencesError": {
+    "description": "Ошибка загрузки настроек домашнего экрана",
+    "placeholders": {
+      "error": {
+        "type": "String"
       }
     }
   },

--- a/test/features/app_shell/presentation/main_navigation_shell_test.dart
+++ b/test/features/app_shell/presentation/main_navigation_shell_test.dart
@@ -20,6 +20,8 @@ import 'package:kopim/features/categories/domain/repositories/category_repositor
 import 'package:kopim/features/categories/domain/use_cases/watch_categories_use_case.dart';
 import 'package:kopim/features/categories/domain/use_cases/watch_category_tree_use_case.dart';
 import 'package:kopim/features/categories/presentation/controllers/categories_list_controller.dart';
+import 'package:kopim/features/home/domain/entities/home_dashboard_preferences.dart';
+import 'package:kopim/features/home/presentation/controllers/home_dashboard_preferences_controller.dart';
 import 'package:kopim/features/home/presentation/controllers/home_providers.dart';
 import 'package:kopim/features/home/domain/models/upcoming_payment.dart';
 import 'package:kopim/features/profile/domain/entities/auth_user.dart';
@@ -44,6 +46,16 @@ class _FakeAuthController extends AuthController {
 
   @override
   FutureOr<AuthUser?> build() => _user;
+}
+
+class _FakeHomeDashboardPreferencesController
+    extends HomeDashboardPreferencesController {
+  _FakeHomeDashboardPreferencesController();
+
+  @override
+  Future<HomeDashboardPreferences> build() async {
+    return const HomeDashboardPreferences();
+  }
 }
 
 class _StreamAccountRepository implements AccountRepository {
@@ -189,6 +201,9 @@ void main() {
       overrides: [
         authControllerProvider.overrideWith(
           () => _FakeAuthController(anonymousUser),
+        ),
+        homeDashboardPreferencesControllerProvider.overrideWith(
+          () => _FakeHomeDashboardPreferencesController(),
         ),
         watchAccountsUseCaseProvider.overrideWithValue(
           WatchAccountsUseCase(

--- a/test/features/home/data/home_dashboard_preferences_repository_impl_test.dart
+++ b/test/features/home/data/home_dashboard_preferences_repository_impl_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kopim/features/home/data/repositories/home_dashboard_preferences_repository_impl.dart';
+import 'package:kopim/features/home/domain/entities/home_dashboard_preferences.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('HomeDashboardPreferencesRepositoryImpl', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+    });
+
+    test('returns defaults when preferences are missing', () async {
+      final SharedPreferences prefs = await SharedPreferences.getInstance();
+      final HomeDashboardPreferencesRepositoryImpl repository =
+          HomeDashboardPreferencesRepositoryImpl(
+            preferences: Future<SharedPreferences>.value(prefs),
+          );
+
+      final HomeDashboardPreferences result = await repository.load();
+
+      expect(result, const HomeDashboardPreferences());
+    });
+
+    test('persists and restores preferences', () async {
+      final SharedPreferences prefs = await SharedPreferences.getInstance();
+      final HomeDashboardPreferencesRepositoryImpl repository =
+          HomeDashboardPreferencesRepositoryImpl(
+            preferences: Future<SharedPreferences>.value(prefs),
+          );
+      const HomeDashboardPreferences expected = HomeDashboardPreferences(
+        showGamificationWidget: true,
+        showBudgetWidget: true,
+        budgetId: 'budget-1',
+      );
+
+      await repository.save(expected);
+      final HomeDashboardPreferences loaded = await repository.load();
+
+      expect(loaded, expected);
+    });
+  });
+}

--- a/test/features/home/presentation/controllers/home_dashboard_preferences_controller_test.dart
+++ b/test/features/home/presentation/controllers/home_dashboard_preferences_controller_test.dart
@@ -1,0 +1,113 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kopim/core/di/injectors.dart';
+import 'package:kopim/features/home/domain/entities/home_dashboard_preferences.dart';
+import 'package:kopim/features/home/domain/repositories/home_dashboard_preferences_repository.dart';
+import 'package:kopim/features/home/presentation/controllers/home_dashboard_preferences_controller.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class _FakeRepository implements HomeDashboardPreferencesRepository {
+  HomeDashboardPreferences stored = const HomeDashboardPreferences();
+  HomeDashboardPreferences? lastSaved;
+
+  @override
+  Future<HomeDashboardPreferences> load() async {
+    return stored;
+  }
+
+  @override
+  Future<void> save(HomeDashboardPreferences preferences) async {
+    lastSaved = preferences;
+    stored = preferences;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('HomeDashboardPreferencesController', () {
+    late _FakeRepository repository;
+    late ProviderContainer container;
+
+    setUp(() {
+      repository = _FakeRepository();
+      container = ProviderContainer(
+        // ignore: always_specify_types
+        overrides: [
+          homeDashboardPreferencesRepositoryProvider.overrideWithValue(
+            repository,
+          ),
+        ],
+      );
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    test('loads preferences on first read', () async {
+      repository.stored = const HomeDashboardPreferences(
+        showGamificationWidget: true,
+      );
+
+      final HomeDashboardPreferences result = await container.read(
+        homeDashboardPreferencesControllerProvider.future,
+      );
+
+      expect(result.showGamificationWidget, isTrue);
+    });
+
+    test('setShowGamification updates state and saves', () async {
+      await container.read(homeDashboardPreferencesControllerProvider.future);
+      await container
+          .read(homeDashboardPreferencesControllerProvider.notifier)
+          .setShowGamification(true);
+
+      final HomeDashboardPreferences? state = container
+          .read(homeDashboardPreferencesControllerProvider)
+          .value;
+
+      expect(state?.showGamificationWidget, isTrue);
+      expect(repository.lastSaved?.showGamificationWidget, isTrue);
+    });
+
+    test(
+      'setShowBudget toggles flag and clears budget when disabled',
+      () async {
+        repository.stored = const HomeDashboardPreferences(
+          showBudgetWidget: true,
+          budgetId: 'budget-1',
+        );
+        await container.read(homeDashboardPreferencesControllerProvider.future);
+
+        await container
+            .read(homeDashboardPreferencesControllerProvider.notifier)
+            .setShowBudget(false);
+
+        final HomeDashboardPreferences? state = container
+            .read(homeDashboardPreferencesControllerProvider)
+            .value;
+
+        expect(state?.showBudgetWidget, isFalse);
+        expect(state?.budgetId, isNull);
+        expect(repository.lastSaved?.showBudgetWidget, isFalse);
+        expect(repository.lastSaved?.budgetId, isNull);
+      },
+    );
+
+    test('setBudgetId stores id without altering toggles', () async {
+      await container.read(homeDashboardPreferencesControllerProvider.future);
+
+      await container
+          .read(homeDashboardPreferencesControllerProvider.notifier)
+          .setBudgetId('budget-42');
+
+      final HomeDashboardPreferences? state = container
+          .read(homeDashboardPreferencesControllerProvider)
+          .value;
+
+      expect(state?.budgetId, 'budget-42');
+      expect(state?.showBudgetWidget, isFalse);
+      expect(repository.lastSaved?.budgetId, 'budget-42');
+    });
+  });
+}

--- a/test/features/home/presentation/widgets/home_gamification_card_test.dart
+++ b/test/features/home/presentation/widgets/home_gamification_card_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kopim/features/home/presentation/widgets/home_gamification_card.dart';
+import 'package:kopim/features/profile/domain/entities/user_progress.dart';
+import 'package:kopim/features/profile/presentation/controllers/user_progress_controller.dart';
+import 'package:kopim/l10n/app_localizations.dart';
+import 'package:riverpod/src/framework.dart' show Override;
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('HomeGamificationCard', () {
+    const String userId = 'user-123';
+
+    Future<void> pumpGamificationCard(
+      WidgetTester tester, {
+      List<Override> overrides = const <Override>[],
+    }) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: overrides,
+          child: const MaterialApp(
+            locale: Locale('en'),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: HomeGamificationCard(userId: userId)),
+          ),
+        ),
+      );
+
+      await tester.pump();
+    }
+
+    testWidgets('renders progress state when data is available', (
+      WidgetTester tester,
+    ) async {
+      final UserProgress progress = UserProgress(
+        totalTx: 150,
+        level: 2,
+        title: 'Apprentice',
+        nextThreshold: 500,
+        updatedAt: DateTime(2024, 1, 1),
+      );
+
+      await pumpGamificationCard(
+        tester,
+        overrides: <Override>[
+          userProgressProvider(
+            userId,
+          ).overrideWithValue(AsyncValue<UserProgress>.data(progress)),
+        ],
+      );
+
+      expect(find.text('Level progress'), findsOneWidget);
+      expect(find.text('Level 2 — Apprentice'), findsOneWidget);
+      expect(find.text('350 XP to the next level'), findsOneWidget);
+
+      final LinearProgressIndicator indicator = tester.widget(
+        find.byType(LinearProgressIndicator),
+      );
+      expect(indicator.value, closeTo(0.125, 0.001));
+    });
+
+    testWidgets('shows loading indicator while data loads', (
+      WidgetTester tester,
+    ) async {
+      await pumpGamificationCard(
+        tester,
+        overrides: <Override>[
+          userProgressProvider(
+            userId,
+          ).overrideWithValue(const AsyncValue<UserProgress>.loading()),
+        ],
+      );
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('renders error state message', (WidgetTester tester) async {
+      await pumpGamificationCard(
+        tester,
+        overrides: <Override>[
+          userProgressProvider(userId).overrideWithValue(
+            const AsyncValue<UserProgress>.error('boom', StackTrace.empty),
+          ),
+        ],
+      );
+
+      expect(find.text("Can't load progress: boom"), findsOneWidget);
+    });
+  });
+}

--- a/test/features/profile/presentation/general_settings_screen_test.dart
+++ b/test/features/profile/presentation/general_settings_screen_test.dart
@@ -1,9 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:kopim/features/budgets/domain/entities/budget_progress.dart';
+import 'package:kopim/features/budgets/presentation/controllers/budgets_providers.dart';
 import 'package:kopim/features/categories/presentation/screens/manage_categories_screen.dart';
+import 'package:kopim/features/home/domain/entities/home_dashboard_preferences.dart';
+import 'package:kopim/features/home/presentation/controllers/home_dashboard_preferences_controller.dart';
 import 'package:kopim/features/profile/presentation/screens/general_settings_screen.dart';
 import 'package:kopim/features/recurring_transactions/presentation/screens/recurring_transactions_screen.dart';
 import 'package:kopim/l10n/app_localizations.dart';
+import 'package:riverpod/src/framework.dart' show Override;
 
 class _RecordingNavigatorObserver extends NavigatorObserver {
   _RecordingNavigatorObserver(this.pushedRoutes);
@@ -20,12 +26,25 @@ class _RecordingNavigatorObserver extends NavigatorObserver {
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  final List<Override> overrides = <Override>[
+    homeDashboardPreferencesControllerProvider.overrideWith(
+      () => _FakeHomeDashboardPreferencesController(),
+    ),
+    budgetsWithProgressProvider.overrideWith(
+      (Ref ref) =>
+          const AsyncValue<List<BudgetProgress>>.data(<BudgetProgress>[]),
+    ),
+  ];
+
   testWidgets('displays management actions', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        home: GeneralSettingsScreen(),
+      ProviderScope(
+        overrides: overrides,
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: GeneralSettingsScreen(),
+        ),
       ),
     );
 
@@ -48,18 +67,21 @@ void main() {
     final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 
     await tester.pumpWidget(
-      MaterialApp(
-        navigatorKey: navigatorKey,
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        home: const GeneralSettingsScreen(),
-        routes: <String, WidgetBuilder>{
-          ManageCategoriesScreen.routeName: (_) =>
-              const _StubDestination(label: 'manage-categories-destination'),
-          RecurringTransactionsScreen.routeName: (_) =>
-              const _StubDestination(label: 'recurring-destination'),
-        },
-        navigatorObservers: <NavigatorObserver>[observer],
+      ProviderScope(
+        overrides: overrides,
+        child: MaterialApp(
+          navigatorKey: navigatorKey,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const GeneralSettingsScreen(),
+          routes: <String, WidgetBuilder>{
+            ManageCategoriesScreen.routeName: (_) =>
+                const _StubDestination(label: 'manage-categories-destination'),
+            RecurringTransactionsScreen.routeName: (_) =>
+                const _StubDestination(label: 'recurring-destination'),
+          },
+          navigatorObservers: <NavigatorObserver>[observer],
+        ),
       ),
     );
 
@@ -91,6 +113,16 @@ void main() {
     );
     expect(find.text('recurring-destination'), findsOneWidget);
   });
+}
+
+class _FakeHomeDashboardPreferencesController
+    extends HomeDashboardPreferencesController {
+  _FakeHomeDashboardPreferencesController();
+
+  @override
+  Future<HomeDashboardPreferences> build() async {
+    return const HomeDashboardPreferences();
+  }
 }
 
 class _StubDestination extends StatelessWidget {

--- a/test/features/profile/presentation/profile_screen_test.dart
+++ b/test/features/profile/presentation/profile_screen_test.dart
@@ -5,8 +5,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod/src/framework.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kopim/core/di/injectors.dart';
+import 'package:kopim/features/budgets/domain/entities/budget_progress.dart';
+import 'package:kopim/features/budgets/presentation/controllers/budgets_providers.dart';
 import 'package:kopim/features/categories/domain/entities/category_tree_node.dart';
 import 'package:kopim/features/categories/presentation/controllers/categories_list_controller.dart';
+import 'package:kopim/features/home/domain/entities/home_dashboard_preferences.dart';
+import 'package:kopim/features/home/presentation/controllers/home_dashboard_preferences_controller.dart';
 import 'package:kopim/features/profile/domain/entities/auth_user.dart';
 import 'package:kopim/features/profile/domain/entities/profile.dart';
 import 'package:kopim/features/profile/domain/usecases/update_profile_use_case.dart';
@@ -32,6 +36,16 @@ class _FakeAuthController extends AuthController {
 
   @override
   FutureOr<AuthUser?> build() => _user;
+}
+
+class _FakeHomeDashboardPreferencesController
+    extends HomeDashboardPreferencesController {
+  _FakeHomeDashboardPreferencesController();
+
+  @override
+  Future<HomeDashboardPreferences> build() async {
+    return const HomeDashboardPreferences();
+  }
 }
 
 class _SignOutSpyAuthController extends AuthController {
@@ -164,6 +178,13 @@ void main() {
           authControllerProvider.overrideWith(
             () => _FakeAuthController(signedInUser),
           ),
+          homeDashboardPreferencesControllerProvider.overrideWith(
+            () => _FakeHomeDashboardPreferencesController(),
+          ),
+          budgetsWithProgressProvider.overrideWith(
+            (Ref ref) =>
+                const AsyncValue<List<BudgetProgress>>.data(<BudgetProgress>[]),
+          ),
           profileControllerProvider(
             signedInUser.uid,
           ).overrideWith(() => _FakeProfileController(hydratedProfile)),
@@ -213,6 +234,13 @@ void main() {
       ProviderScope(
         overrides: <Override>[
           authControllerProvider.overrideWith(() => _FakeAuthController(null)),
+          homeDashboardPreferencesControllerProvider.overrideWith(
+            () => _FakeHomeDashboardPreferencesController(),
+          ),
+          budgetsWithProgressProvider.overrideWith(
+            (Ref ref) =>
+                const AsyncValue<List<BudgetProgress>>.data(<BudgetProgress>[]),
+          ),
           updateProfileUseCaseProvider.overrideWith(
             (Ref ref) => _StubUpdateProfileUseCase(),
           ),
@@ -251,6 +279,13 @@ void main() {
         overrides: <Override>[
           authControllerProvider.overrideWith(
             () => _FakeAuthController(signedInUser),
+          ),
+          homeDashboardPreferencesControllerProvider.overrideWith(
+            () => _FakeHomeDashboardPreferencesController(),
+          ),
+          budgetsWithProgressProvider.overrideWith(
+            (Ref ref) =>
+                const AsyncValue<List<BudgetProgress>>.data(<BudgetProgress>[]),
           ),
           profileControllerProvider(
             signedInUser.uid,
@@ -308,6 +343,13 @@ void main() {
               signedInUser,
               () => didSignOut = true,
             ),
+          ),
+          homeDashboardPreferencesControllerProvider.overrideWith(
+            () => _FakeHomeDashboardPreferencesController(),
+          ),
+          budgetsWithProgressProvider.overrideWith(
+            (Ref ref) =>
+                const AsyncValue<List<BudgetProgress>>.data(<BudgetProgress>[]),
           ),
           profileControllerProvider(
             signedInUser.uid,


### PR DESCRIPTION
## Summary
- добавлен репозиторий и контроллер для сохранения предпочтений домашнего экрана, интегрированы новые провайдеры DI
- реализованы карточки геймификации и бюджета на главном экране и настройки для их включения и выбора бюджета
- обновлены локализации и тесты для новых виджетов и настроек

## Testing
- `dart format --set-exit-if-changed .`
- `flutter analyze`
- `dart run build_runner build --delete-conflicting-outputs`
- `flutter test --reporter expanded`
- `flutter pub outdated`


------
https://chatgpt.com/codex/tasks/task_e_68e4200b7524832eb418ae743688230b