### PR TITLE
Добавлен экран всех транзакций и фильтры домашнего экрана

### DIFF
--- a/lib/features/categories/presentation/screens/manage_categories_screen.dart
+++ b/lib/features/categories/presentation/screens/manage_categories_screen.dart
@@ -500,6 +500,17 @@ class _CategoryEditorSheet extends ConsumerWidget {
       }
     }
 
+    Future<void> selectIcon() async {
+      final PhosphorIconDescriptor? selection = await showPhosphorIconPicker(
+        context: context,
+        labels: pickerLabels,
+        initial: state.icon,
+      );
+      if (selection != null) {
+        controller.updateIcon(selection.isEmpty ? null : selection);
+      }
+    }
+
     return Padding(
       padding: EdgeInsets.only(bottom: viewInsets.bottom),
       child: SingleChildScrollView(
@@ -558,6 +569,7 @@ class _CategoryEditorSheet extends ConsumerWidget {
               ),
               title: Text(strings.manageCategoriesIconLabel),
               subtitle: Text(iconSubtitle),
+              onTap: selectIcon,
               trailing: Wrap(
                 spacing: 8,
                 children: <Widget>[
@@ -570,19 +582,7 @@ class _CategoryEditorSheet extends ConsumerWidget {
                   IconButton(
                     icon: const Icon(Icons.grid_view),
                     tooltip: strings.manageCategoriesIconSelect,
-                    onPressed: () async {
-                      final PhosphorIconDescriptor? selection =
-                          await showPhosphorIconPicker(
-                            context: context,
-                            labels: pickerLabels,
-                            initial: state.icon,
-                          );
-                      if (selection != null) {
-                        controller.updateIcon(
-                          selection.isEmpty ? null : selection,
-                        );
-                      }
-                    },
+                    onPressed: selectIcon,
                   ),
                 ],
               ),

--- a/lib/features/home/domain/entities/home_dashboard_preferences.dart
+++ b/lib/features/home/domain/entities/home_dashboard_preferences.dart
@@ -8,6 +8,7 @@ abstract class HomeDashboardPreferences with _$HomeDashboardPreferences {
   const factory HomeDashboardPreferences({
     @Default(false) bool showGamificationWidget,
     @Default(false) bool showBudgetWidget,
+    @Default(false) bool showRecurringWidget,
     String? budgetId,
   }) = _HomeDashboardPreferences;
 

--- a/lib/features/home/domain/entities/home_dashboard_preferences.freezed.dart
+++ b/lib/features/home/domain/entities/home_dashboard_preferences.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$HomeDashboardPreferences {
 
- bool get showGamificationWidget; bool get showBudgetWidget; String? get budgetId;
+ bool get showGamificationWidget; bool get showBudgetWidget; bool get showRecurringWidget; String? get budgetId;
 /// Create a copy of HomeDashboardPreferences
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $HomeDashboardPreferencesCopyWith<HomeDashboardPreferences> get copyWith => _$Ho
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is HomeDashboardPreferences&&(identical(other.showGamificationWidget, showGamificationWidget) || other.showGamificationWidget == showGamificationWidget)&&(identical(other.showBudgetWidget, showBudgetWidget) || other.showBudgetWidget == showBudgetWidget)&&(identical(other.budgetId, budgetId) || other.budgetId == budgetId));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is HomeDashboardPreferences&&(identical(other.showGamificationWidget, showGamificationWidget) || other.showGamificationWidget == showGamificationWidget)&&(identical(other.showBudgetWidget, showBudgetWidget) || other.showBudgetWidget == showBudgetWidget)&&(identical(other.showRecurringWidget, showRecurringWidget) || other.showRecurringWidget == showRecurringWidget)&&(identical(other.budgetId, budgetId) || other.budgetId == budgetId));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,showGamificationWidget,showBudgetWidget,budgetId);
+int get hashCode => Object.hash(runtimeType,showGamificationWidget,showBudgetWidget,showRecurringWidget,budgetId);
 
 @override
 String toString() {
-  return 'HomeDashboardPreferences(showGamificationWidget: $showGamificationWidget, showBudgetWidget: $showBudgetWidget, budgetId: $budgetId)';
+  return 'HomeDashboardPreferences(showGamificationWidget: $showGamificationWidget, showBudgetWidget: $showBudgetWidget, showRecurringWidget: $showRecurringWidget, budgetId: $budgetId)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $HomeDashboardPreferencesCopyWith<$Res>  {
   factory $HomeDashboardPreferencesCopyWith(HomeDashboardPreferences value, $Res Function(HomeDashboardPreferences) _then) = _$HomeDashboardPreferencesCopyWithImpl;
 @useResult
 $Res call({
- bool showGamificationWidget, bool showBudgetWidget, String? budgetId
+ bool showGamificationWidget, bool showBudgetWidget, bool showRecurringWidget, String? budgetId
 });
 
 
@@ -65,10 +65,11 @@ class _$HomeDashboardPreferencesCopyWithImpl<$Res>
 
 /// Create a copy of HomeDashboardPreferences
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? showGamificationWidget = null,Object? showBudgetWidget = null,Object? budgetId = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? showGamificationWidget = null,Object? showBudgetWidget = null,Object? showRecurringWidget = null,Object? budgetId = freezed,}) {
   return _then(_self.copyWith(
 showGamificationWidget: null == showGamificationWidget ? _self.showGamificationWidget : showGamificationWidget // ignore: cast_nullable_to_non_nullable
 as bool,showBudgetWidget: null == showBudgetWidget ? _self.showBudgetWidget : showBudgetWidget // ignore: cast_nullable_to_non_nullable
+as bool,showRecurringWidget: null == showRecurringWidget ? _self.showRecurringWidget : showRecurringWidget // ignore: cast_nullable_to_non_nullable
 as bool,budgetId: freezed == budgetId ? _self.budgetId : budgetId // ignore: cast_nullable_to_non_nullable
 as String?,
   ));
@@ -155,10 +156,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool showGamificationWidget,  bool showBudgetWidget,  String? budgetId)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool showGamificationWidget,  bool showBudgetWidget,  bool showRecurringWidget,  String? budgetId)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _HomeDashboardPreferences() when $default != null:
-return $default(_that.showGamificationWidget,_that.showBudgetWidget,_that.budgetId);case _:
+return $default(_that.showGamificationWidget,_that.showBudgetWidget,_that.showRecurringWidget,_that.budgetId);case _:
   return orElse();
 
 }
@@ -176,10 +177,10 @@ return $default(_that.showGamificationWidget,_that.showBudgetWidget,_that.budget
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool showGamificationWidget,  bool showBudgetWidget,  String? budgetId)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool showGamificationWidget,  bool showBudgetWidget,  bool showRecurringWidget,  String? budgetId)  $default,) {final _that = this;
 switch (_that) {
 case _HomeDashboardPreferences():
-return $default(_that.showGamificationWidget,_that.showBudgetWidget,_that.budgetId);case _:
+return $default(_that.showGamificationWidget,_that.showBudgetWidget,_that.showRecurringWidget,_that.budgetId);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -196,10 +197,10 @@ return $default(_that.showGamificationWidget,_that.showBudgetWidget,_that.budget
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool showGamificationWidget,  bool showBudgetWidget,  String? budgetId)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool showGamificationWidget,  bool showBudgetWidget,  bool showRecurringWidget,  String? budgetId)?  $default,) {final _that = this;
 switch (_that) {
 case _HomeDashboardPreferences() when $default != null:
-return $default(_that.showGamificationWidget,_that.showBudgetWidget,_that.budgetId);case _:
+return $default(_that.showGamificationWidget,_that.showBudgetWidget,_that.showRecurringWidget,_that.budgetId);case _:
   return null;
 
 }
@@ -211,11 +212,12 @@ return $default(_that.showGamificationWidget,_that.showBudgetWidget,_that.budget
 @JsonSerializable()
 
 class _HomeDashboardPreferences implements HomeDashboardPreferences {
-  const _HomeDashboardPreferences({this.showGamificationWidget = false, this.showBudgetWidget = false, this.budgetId});
+  const _HomeDashboardPreferences({this.showGamificationWidget = false, this.showBudgetWidget = false, this.showRecurringWidget = false, this.budgetId});
   factory _HomeDashboardPreferences.fromJson(Map<String, dynamic> json) => _$HomeDashboardPreferencesFromJson(json);
 
 @override@JsonKey() final  bool showGamificationWidget;
 @override@JsonKey() final  bool showBudgetWidget;
+@override@JsonKey() final  bool showRecurringWidget;
 @override final  String? budgetId;
 
 /// Create a copy of HomeDashboardPreferences
@@ -231,16 +233,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _HomeDashboardPreferences&&(identical(other.showGamificationWidget, showGamificationWidget) || other.showGamificationWidget == showGamificationWidget)&&(identical(other.showBudgetWidget, showBudgetWidget) || other.showBudgetWidget == showBudgetWidget)&&(identical(other.budgetId, budgetId) || other.budgetId == budgetId));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _HomeDashboardPreferences&&(identical(other.showGamificationWidget, showGamificationWidget) || other.showGamificationWidget == showGamificationWidget)&&(identical(other.showBudgetWidget, showBudgetWidget) || other.showBudgetWidget == showBudgetWidget)&&(identical(other.showRecurringWidget, showRecurringWidget) || other.showRecurringWidget == showRecurringWidget)&&(identical(other.budgetId, budgetId) || other.budgetId == budgetId));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,showGamificationWidget,showBudgetWidget,budgetId);
+int get hashCode => Object.hash(runtimeType,showGamificationWidget,showBudgetWidget,showRecurringWidget,budgetId);
 
 @override
 String toString() {
-  return 'HomeDashboardPreferences(showGamificationWidget: $showGamificationWidget, showBudgetWidget: $showBudgetWidget, budgetId: $budgetId)';
+  return 'HomeDashboardPreferences(showGamificationWidget: $showGamificationWidget, showBudgetWidget: $showBudgetWidget, showRecurringWidget: $showRecurringWidget, budgetId: $budgetId)';
 }
 
 
@@ -251,7 +253,7 @@ abstract mixin class _$HomeDashboardPreferencesCopyWith<$Res> implements $HomeDa
   factory _$HomeDashboardPreferencesCopyWith(_HomeDashboardPreferences value, $Res Function(_HomeDashboardPreferences) _then) = __$HomeDashboardPreferencesCopyWithImpl;
 @override @useResult
 $Res call({
- bool showGamificationWidget, bool showBudgetWidget, String? budgetId
+ bool showGamificationWidget, bool showBudgetWidget, bool showRecurringWidget, String? budgetId
 });
 
 
@@ -268,10 +270,11 @@ class __$HomeDashboardPreferencesCopyWithImpl<$Res>
 
 /// Create a copy of HomeDashboardPreferences
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? showGamificationWidget = null,Object? showBudgetWidget = null,Object? budgetId = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? showGamificationWidget = null,Object? showBudgetWidget = null,Object? showRecurringWidget = null,Object? budgetId = freezed,}) {
   return _then(_HomeDashboardPreferences(
 showGamificationWidget: null == showGamificationWidget ? _self.showGamificationWidget : showGamificationWidget // ignore: cast_nullable_to_non_nullable
 as bool,showBudgetWidget: null == showBudgetWidget ? _self.showBudgetWidget : showBudgetWidget // ignore: cast_nullable_to_non_nullable
+as bool,showRecurringWidget: null == showRecurringWidget ? _self.showRecurringWidget : showRecurringWidget // ignore: cast_nullable_to_non_nullable
 as bool,budgetId: freezed == budgetId ? _self.budgetId : budgetId // ignore: cast_nullable_to_non_nullable
 as String?,
   ));

--- a/lib/features/home/domain/entities/home_dashboard_preferences.g.dart
+++ b/lib/features/home/domain/entities/home_dashboard_preferences.g.dart
@@ -11,6 +11,7 @@ _HomeDashboardPreferences _$HomeDashboardPreferencesFromJson(
 ) => _HomeDashboardPreferences(
   showGamificationWidget: json['showGamificationWidget'] as bool? ?? false,
   showBudgetWidget: json['showBudgetWidget'] as bool? ?? false,
+  showRecurringWidget: json['showRecurringWidget'] as bool? ?? false,
   budgetId: json['budgetId'] as String?,
 );
 
@@ -19,5 +20,6 @@ Map<String, dynamic> _$HomeDashboardPreferencesToJson(
 ) => <String, dynamic>{
   'showGamificationWidget': instance.showGamificationWidget,
   'showBudgetWidget': instance.showBudgetWidget,
+  'showRecurringWidget': instance.showRecurringWidget,
   'budgetId': instance.budgetId,
 };

--- a/lib/features/home/presentation/controllers/home_dashboard_preferences_controller.dart
+++ b/lib/features/home/presentation/controllers/home_dashboard_preferences_controller.dart
@@ -35,6 +35,14 @@ class HomeDashboardPreferencesController
     await _persist(updated, previous: current);
   }
 
+  Future<void> setShowRecurring(bool value) async {
+    final HomeDashboardPreferences current = await future;
+    final HomeDashboardPreferences updated = current.copyWith(
+      showRecurringWidget: value,
+    );
+    await _persist(updated, previous: current);
+  }
+
   Future<void> setBudgetId(String? budgetId) async {
     final HomeDashboardPreferences current = await future;
     final HomeDashboardPreferences updated = current.copyWith(

--- a/lib/features/home/presentation/controllers/home_dashboard_preferences_controller.g.dart
+++ b/lib/features/home/presentation/controllers/home_dashboard_preferences_controller.g.dart
@@ -41,7 +41,7 @@ final class HomeDashboardPreferencesControllerProvider
 }
 
 String _$homeDashboardPreferencesControllerHash() =>
-    r'01f60dfc6d328b865b8123ff3024213c2008ea2c';
+    r'de1525ec13d42d4b0459a7f0a7f56b005ff88e25';
 
 abstract class _$HomeDashboardPreferencesController
     extends $AsyncNotifier<HomeDashboardPreferences> {

--- a/lib/features/home/presentation/controllers/home_providers.g.dart
+++ b/lib/features/home/presentation/controllers/home_providers.g.dart
@@ -615,7 +615,7 @@ final class HomeGroupedTransactionsProvider
 }
 
 String _$homeGroupedTransactionsHash() =>
-    r'57e99e692effe5a35974908c34eff0a5b58ecb4d';
+    r'7f246cf20b77a3442fdced6c14a81c95cf54f9b6';
 
 @ProviderFor(homeAccountMonthlySummaries)
 const homeAccountMonthlySummariesProvider =

--- a/lib/features/home/presentation/controllers/home_transactions_filter_controller.dart
+++ b/lib/features/home/presentation/controllers/home_transactions_filter_controller.dart
@@ -1,0 +1,19 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'home_transactions_filter_controller.g.dart';
+
+enum HomeTransactionsFilter { all, income, expense }
+
+@riverpod
+class HomeTransactionsFilterController
+    extends _$HomeTransactionsFilterController {
+  @override
+  HomeTransactionsFilter build() => HomeTransactionsFilter.all;
+
+  void update(HomeTransactionsFilter filter) {
+    if (state == filter) {
+      return;
+    }
+    state = filter;
+  }
+}

--- a/lib/features/home/presentation/controllers/home_transactions_filter_controller.g.dart
+++ b/lib/features/home/presentation/controllers/home_transactions_filter_controller.g.dart
@@ -1,0 +1,72 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'home_transactions_filter_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(HomeTransactionsFilterController)
+const homeTransactionsFilterControllerProvider =
+    HomeTransactionsFilterControllerProvider._();
+
+final class HomeTransactionsFilterControllerProvider
+    extends
+        $NotifierProvider<
+          HomeTransactionsFilterController,
+          HomeTransactionsFilter
+        > {
+  const HomeTransactionsFilterControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'homeTransactionsFilterControllerProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$homeTransactionsFilterControllerHash();
+
+  @$internal
+  @override
+  HomeTransactionsFilterController create() =>
+      HomeTransactionsFilterController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(HomeTransactionsFilter value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<HomeTransactionsFilter>(value),
+    );
+  }
+}
+
+String _$homeTransactionsFilterControllerHash() =>
+    r'5a674dba38409b7a953d542f44cc160791609d5b';
+
+abstract class _$HomeTransactionsFilterController
+    extends $Notifier<HomeTransactionsFilter> {
+  HomeTransactionsFilter build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build();
+    final ref =
+        this.ref as $Ref<HomeTransactionsFilter, HomeTransactionsFilter>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<HomeTransactionsFilter, HomeTransactionsFilter>,
+              HomeTransactionsFilter,
+              Object?,
+              Object?
+            >;
+    element.handleValue(ref, created);
+  }
+}

--- a/lib/features/profile/presentation/screens/general_settings_screen.dart
+++ b/lib/features/profile/presentation/screens/general_settings_screen.dart
@@ -63,6 +63,9 @@ class GeneralSettingsScreen extends ConsumerWidget {
                   onToggleBudget: (bool value) => ref
                       .read(homeDashboardPreferencesControllerProvider.notifier)
                       .setShowBudget(value),
+                  onToggleRecurring: (bool value) => ref
+                      .read(homeDashboardPreferencesControllerProvider.notifier)
+                      .setShowRecurring(value),
                   onSelectBudget: (List<BudgetProgress> budgets) async {
                     await _showBudgetSelector(
                       context: context,
@@ -116,6 +119,7 @@ class _HomeDashboardSettingsCard extends StatelessWidget {
     required this.budgetsAsync,
     required this.onToggleGamification,
     required this.onToggleBudget,
+    required this.onToggleRecurring,
     required this.onSelectBudget,
   });
 
@@ -124,6 +128,7 @@ class _HomeDashboardSettingsCard extends StatelessWidget {
   final AsyncValue<List<BudgetProgress>> budgetsAsync;
   final ValueChanged<bool> onToggleGamification;
   final ValueChanged<bool> onToggleBudget;
+  final ValueChanged<bool> onToggleRecurring;
   final ValueChanged<List<BudgetProgress>> onSelectBudget;
 
   @override
@@ -131,17 +136,17 @@ class _HomeDashboardSettingsCard extends StatelessWidget {
     final ThemeData theme = Theme.of(context);
     return Card(
       margin: EdgeInsets.zero,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
+      child: ExpansionTile(
+        tilePadding: const EdgeInsets.symmetric(horizontal: 16),
+        childrenPadding: EdgeInsets.zero,
+        leading: Icon(Icons.home_outlined, color: theme.colorScheme.primary),
+        title: Text(
+          strings.settingsHomeSectionTitle,
+          style: theme.textTheme.titleMedium,
+        ),
         children: <Widget>[
-          Padding(
-            padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
-            child: Text(
-              strings.settingsHomeSectionTitle,
-              style: theme.textTheme.titleMedium,
-            ),
-          ),
           SwitchListTile.adaptive(
+            contentPadding: const EdgeInsets.symmetric(horizontal: 16),
             value: preferences.showGamificationWidget,
             onChanged: onToggleGamification,
             title: Text(strings.settingsHomeGamificationTitle),
@@ -149,6 +154,7 @@ class _HomeDashboardSettingsCard extends StatelessWidget {
           ),
           const Divider(height: 0),
           SwitchListTile.adaptive(
+            contentPadding: const EdgeInsets.symmetric(horizontal: 16),
             value: preferences.showBudgetWidget,
             onChanged: onToggleBudget,
             title: Text(strings.settingsHomeBudgetTitle),
@@ -159,6 +165,7 @@ class _HomeDashboardSettingsCard extends StatelessWidget {
               data: (List<BudgetProgress> budgets) {
                 if (budgets.isEmpty) {
                   return ListTile(
+                    contentPadding: const EdgeInsets.symmetric(horizontal: 16),
                     leading: const Icon(Icons.pie_chart_outline),
                     title: Text(strings.settingsHomeBudgetSelectedLabel),
                     subtitle: Text(strings.settingsHomeBudgetNoBudgets),
@@ -170,6 +177,7 @@ class _HomeDashboardSettingsCard extends StatelessWidget {
                       progress.budget.id == preferences.budgetId,
                 );
                 return ListTile(
+                  contentPadding: const EdgeInsets.symmetric(horizontal: 16),
                   leading: const Icon(Icons.pie_chart_outline),
                   title: Text(strings.settingsHomeBudgetSelectedLabel),
                   subtitle: Text(
@@ -190,6 +198,14 @@ class _HomeDashboardSettingsCard extends StatelessWidget {
                 enabled: false,
               ),
             ),
+          const Divider(height: 0),
+          SwitchListTile.adaptive(
+            contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+            value: preferences.showRecurringWidget,
+            onChanged: onToggleRecurring,
+            title: Text(strings.settingsHomeRecurringTitle),
+            subtitle: Text(strings.settingsHomeRecurringSubtitle),
+          ),
         ],
       ),
     );

--- a/lib/features/transactions/presentation/controllers/all_transactions_filter_controller.dart
+++ b/lib/features/transactions/presentation/controllers/all_transactions_filter_controller.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'all_transactions_filter_controller.freezed.dart';
+part 'all_transactions_filter_controller.g.dart';
+
+@freezed
+abstract class AllTransactionsFilterState with _$AllTransactionsFilterState {
+  const factory AllTransactionsFilterState({
+    DateTimeRange? dateRange,
+    String? accountId,
+    String? categoryId,
+  }) = _AllTransactionsFilterState;
+}
+
+extension AllTransactionsFilterStateX on AllTransactionsFilterState {
+  bool get hasFilters =>
+      dateRange != null || accountId != null || categoryId != null;
+}
+
+@riverpod
+class AllTransactionsFilterController
+    extends _$AllTransactionsFilterController {
+  @override
+  AllTransactionsFilterState build() => const AllTransactionsFilterState();
+
+  void setDateRange(DateTimeRange? range) {
+    state = state.copyWith(dateRange: range);
+  }
+
+  void setAccount(String? accountId) {
+    state = state.copyWith(accountId: accountId);
+  }
+
+  void setCategory(String? categoryId) {
+    state = state.copyWith(categoryId: categoryId);
+  }
+
+  void clear() {
+    state = const AllTransactionsFilterState();
+  }
+}

--- a/lib/features/transactions/presentation/controllers/all_transactions_filter_controller.freezed.dart
+++ b/lib/features/transactions/presentation/controllers/all_transactions_filter_controller.freezed.dart
@@ -1,0 +1,277 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'all_transactions_filter_controller.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$AllTransactionsFilterState {
+
+ DateTimeRange? get dateRange; String? get accountId; String? get categoryId;
+/// Create a copy of AllTransactionsFilterState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$AllTransactionsFilterStateCopyWith<AllTransactionsFilterState> get copyWith => _$AllTransactionsFilterStateCopyWithImpl<AllTransactionsFilterState>(this as AllTransactionsFilterState, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AllTransactionsFilterState&&(identical(other.dateRange, dateRange) || other.dateRange == dateRange)&&(identical(other.accountId, accountId) || other.accountId == accountId)&&(identical(other.categoryId, categoryId) || other.categoryId == categoryId));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,dateRange,accountId,categoryId);
+
+@override
+String toString() {
+  return 'AllTransactionsFilterState(dateRange: $dateRange, accountId: $accountId, categoryId: $categoryId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $AllTransactionsFilterStateCopyWith<$Res>  {
+  factory $AllTransactionsFilterStateCopyWith(AllTransactionsFilterState value, $Res Function(AllTransactionsFilterState) _then) = _$AllTransactionsFilterStateCopyWithImpl;
+@useResult
+$Res call({
+ DateTimeRange? dateRange, String? accountId, String? categoryId
+});
+
+
+
+
+}
+/// @nodoc
+class _$AllTransactionsFilterStateCopyWithImpl<$Res>
+    implements $AllTransactionsFilterStateCopyWith<$Res> {
+  _$AllTransactionsFilterStateCopyWithImpl(this._self, this._then);
+
+  final AllTransactionsFilterState _self;
+  final $Res Function(AllTransactionsFilterState) _then;
+
+/// Create a copy of AllTransactionsFilterState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? dateRange = freezed,Object? accountId = freezed,Object? categoryId = freezed,}) {
+  return _then(_self.copyWith(
+dateRange: freezed == dateRange ? _self.dateRange : dateRange // ignore: cast_nullable_to_non_nullable
+as DateTimeRange?,accountId: freezed == accountId ? _self.accountId : accountId // ignore: cast_nullable_to_non_nullable
+as String?,categoryId: freezed == categoryId ? _self.categoryId : categoryId // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [AllTransactionsFilterState].
+extension AllTransactionsFilterStatePatterns on AllTransactionsFilterState {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _AllTransactionsFilterState value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _AllTransactionsFilterState() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _AllTransactionsFilterState value)  $default,){
+final _that = this;
+switch (_that) {
+case _AllTransactionsFilterState():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _AllTransactionsFilterState value)?  $default,){
+final _that = this;
+switch (_that) {
+case _AllTransactionsFilterState() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( DateTimeRange? dateRange,  String? accountId,  String? categoryId)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _AllTransactionsFilterState() when $default != null:
+return $default(_that.dateRange,_that.accountId,_that.categoryId);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( DateTimeRange? dateRange,  String? accountId,  String? categoryId)  $default,) {final _that = this;
+switch (_that) {
+case _AllTransactionsFilterState():
+return $default(_that.dateRange,_that.accountId,_that.categoryId);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( DateTimeRange? dateRange,  String? accountId,  String? categoryId)?  $default,) {final _that = this;
+switch (_that) {
+case _AllTransactionsFilterState() when $default != null:
+return $default(_that.dateRange,_that.accountId,_that.categoryId);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _AllTransactionsFilterState implements AllTransactionsFilterState {
+  const _AllTransactionsFilterState({this.dateRange, this.accountId, this.categoryId});
+  
+
+@override final  DateTimeRange? dateRange;
+@override final  String? accountId;
+@override final  String? categoryId;
+
+/// Create a copy of AllTransactionsFilterState
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$AllTransactionsFilterStateCopyWith<_AllTransactionsFilterState> get copyWith => __$AllTransactionsFilterStateCopyWithImpl<_AllTransactionsFilterState>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AllTransactionsFilterState&&(identical(other.dateRange, dateRange) || other.dateRange == dateRange)&&(identical(other.accountId, accountId) || other.accountId == accountId)&&(identical(other.categoryId, categoryId) || other.categoryId == categoryId));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,dateRange,accountId,categoryId);
+
+@override
+String toString() {
+  return 'AllTransactionsFilterState(dateRange: $dateRange, accountId: $accountId, categoryId: $categoryId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$AllTransactionsFilterStateCopyWith<$Res> implements $AllTransactionsFilterStateCopyWith<$Res> {
+  factory _$AllTransactionsFilterStateCopyWith(_AllTransactionsFilterState value, $Res Function(_AllTransactionsFilterState) _then) = __$AllTransactionsFilterStateCopyWithImpl;
+@override @useResult
+$Res call({
+ DateTimeRange? dateRange, String? accountId, String? categoryId
+});
+
+
+
+
+}
+/// @nodoc
+class __$AllTransactionsFilterStateCopyWithImpl<$Res>
+    implements _$AllTransactionsFilterStateCopyWith<$Res> {
+  __$AllTransactionsFilterStateCopyWithImpl(this._self, this._then);
+
+  final _AllTransactionsFilterState _self;
+  final $Res Function(_AllTransactionsFilterState) _then;
+
+/// Create a copy of AllTransactionsFilterState
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? dateRange = freezed,Object? accountId = freezed,Object? categoryId = freezed,}) {
+  return _then(_AllTransactionsFilterState(
+dateRange: freezed == dateRange ? _self.dateRange : dateRange // ignore: cast_nullable_to_non_nullable
+as DateTimeRange?,accountId: freezed == accountId ? _self.accountId : accountId // ignore: cast_nullable_to_non_nullable
+as String?,categoryId: freezed == categoryId ? _self.categoryId : categoryId // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/features/transactions/presentation/controllers/all_transactions_filter_controller.g.dart
+++ b/lib/features/transactions/presentation/controllers/all_transactions_filter_controller.g.dart
@@ -1,0 +1,75 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'all_transactions_filter_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(AllTransactionsFilterController)
+const allTransactionsFilterControllerProvider =
+    AllTransactionsFilterControllerProvider._();
+
+final class AllTransactionsFilterControllerProvider
+    extends
+        $NotifierProvider<
+          AllTransactionsFilterController,
+          AllTransactionsFilterState
+        > {
+  const AllTransactionsFilterControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'allTransactionsFilterControllerProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$allTransactionsFilterControllerHash();
+
+  @$internal
+  @override
+  AllTransactionsFilterController create() => AllTransactionsFilterController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AllTransactionsFilterState value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AllTransactionsFilterState>(value),
+    );
+  }
+}
+
+String _$allTransactionsFilterControllerHash() =>
+    r'a2a6177ec02730ec5fc99b98ab2d4a82f2b969ba';
+
+abstract class _$AllTransactionsFilterController
+    extends $Notifier<AllTransactionsFilterState> {
+  AllTransactionsFilterState build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build();
+    final ref =
+        this.ref
+            as $Ref<AllTransactionsFilterState, AllTransactionsFilterState>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<
+                AllTransactionsFilterState,
+                AllTransactionsFilterState
+              >,
+              AllTransactionsFilterState,
+              Object?,
+              Object?
+            >;
+    element.handleValue(ref, created);
+  }
+}

--- a/lib/features/transactions/presentation/controllers/all_transactions_providers.dart
+++ b/lib/features/transactions/presentation/controllers/all_transactions_providers.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:kopim/core/di/injectors.dart';
+import 'package:kopim/features/accounts/domain/entities/account_entity.dart';
+import 'package:kopim/features/categories/domain/entities/category.dart';
+import 'package:kopim/features/transactions/domain/entities/transaction.dart';
+import 'package:kopim/features/transactions/presentation/controllers/all_transactions_filter_controller.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'all_transactions_providers.g.dart';
+
+@riverpod
+Stream<List<TransactionEntity>> allTransactionsStream(Ref ref) {
+  return ref.watch(watchRecentTransactionsUseCaseProvider).call(limit: 0);
+}
+
+@riverpod
+AsyncValue<List<TransactionEntity>> filteredTransactions(Ref ref) {
+  final AsyncValue<List<TransactionEntity>> transactionsAsync = ref.watch(
+    allTransactionsStreamProvider,
+  );
+  final AllTransactionsFilterState filters = ref.watch(
+    allTransactionsFilterControllerProvider,
+  );
+
+  return transactionsAsync.whenData(
+    (List<TransactionEntity> transactions) =>
+        _applyFilters(transactions, filters),
+  );
+}
+
+@riverpod
+Stream<List<AccountEntity>> allTransactionsAccounts(Ref ref) {
+  return ref.watch(watchAccountsUseCaseProvider).call();
+}
+
+@riverpod
+Stream<List<Category>> allTransactionsCategories(Ref ref) {
+  return ref.watch(watchCategoriesUseCaseProvider).call();
+}
+
+List<TransactionEntity> _applyFilters(
+  List<TransactionEntity> transactions,
+  AllTransactionsFilterState filters,
+) {
+  if (!filters.hasFilters) {
+    return transactions;
+  }
+  return transactions
+      .where((TransactionEntity transaction) {
+        if (filters.accountId != null &&
+            transaction.accountId != filters.accountId) {
+          return false;
+        }
+        if (filters.categoryId != null &&
+            transaction.categoryId != filters.categoryId) {
+          return false;
+        }
+        final DateTimeRange? range = filters.dateRange;
+        if (range != null) {
+          final DateTime start = DateUtils.dateOnly(range.start);
+          final DateTime end = DateUtils.dateOnly(range.end);
+          final DateTime date = DateUtils.dateOnly(transaction.date);
+          if (date.isBefore(start) || date.isAfter(end)) {
+            return false;
+          }
+        }
+        return true;
+      })
+      .toList(growable: false);
+}

--- a/lib/features/transactions/presentation/controllers/all_transactions_providers.g.dart
+++ b/lib/features/transactions/presentation/controllers/all_transactions_providers.g.dart
@@ -1,0 +1,184 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'all_transactions_providers.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(allTransactionsStream)
+const allTransactionsStreamProvider = AllTransactionsStreamProvider._();
+
+final class AllTransactionsStreamProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<TransactionEntity>>,
+          List<TransactionEntity>,
+          Stream<List<TransactionEntity>>
+        >
+    with
+        $FutureModifier<List<TransactionEntity>>,
+        $StreamProvider<List<TransactionEntity>> {
+  const AllTransactionsStreamProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'allTransactionsStreamProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$allTransactionsStreamHash();
+
+  @$internal
+  @override
+  $StreamProviderElement<List<TransactionEntity>> $createElement(
+    $ProviderPointer pointer,
+  ) => $StreamProviderElement(pointer);
+
+  @override
+  Stream<List<TransactionEntity>> create(Ref ref) {
+    return allTransactionsStream(ref);
+  }
+}
+
+String _$allTransactionsStreamHash() =>
+    r'40d34963e6d37b9bcf09198a1443256a8b34a2a7';
+
+@ProviderFor(filteredTransactions)
+const filteredTransactionsProvider = FilteredTransactionsProvider._();
+
+final class FilteredTransactionsProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<TransactionEntity>>,
+          AsyncValue<List<TransactionEntity>>,
+          AsyncValue<List<TransactionEntity>>
+        >
+    with $Provider<AsyncValue<List<TransactionEntity>>> {
+  const FilteredTransactionsProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'filteredTransactionsProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$filteredTransactionsHash();
+
+  @$internal
+  @override
+  $ProviderElement<AsyncValue<List<TransactionEntity>>> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  AsyncValue<List<TransactionEntity>> create(Ref ref) {
+    return filteredTransactions(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<List<TransactionEntity>> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AsyncValue<List<TransactionEntity>>>(
+        value,
+      ),
+    );
+  }
+}
+
+String _$filteredTransactionsHash() =>
+    r'5c8c432acc5112635da78e972a38da70a44cbd71';
+
+@ProviderFor(allTransactionsAccounts)
+const allTransactionsAccountsProvider = AllTransactionsAccountsProvider._();
+
+final class AllTransactionsAccountsProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<AccountEntity>>,
+          List<AccountEntity>,
+          Stream<List<AccountEntity>>
+        >
+    with
+        $FutureModifier<List<AccountEntity>>,
+        $StreamProvider<List<AccountEntity>> {
+  const AllTransactionsAccountsProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'allTransactionsAccountsProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$allTransactionsAccountsHash();
+
+  @$internal
+  @override
+  $StreamProviderElement<List<AccountEntity>> $createElement(
+    $ProviderPointer pointer,
+  ) => $StreamProviderElement(pointer);
+
+  @override
+  Stream<List<AccountEntity>> create(Ref ref) {
+    return allTransactionsAccounts(ref);
+  }
+}
+
+String _$allTransactionsAccountsHash() =>
+    r'8ef685e924219321d2fe549cc7c345a8cfc08579';
+
+@ProviderFor(allTransactionsCategories)
+const allTransactionsCategoriesProvider = AllTransactionsCategoriesProvider._();
+
+final class AllTransactionsCategoriesProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<Category>>,
+          List<Category>,
+          Stream<List<Category>>
+        >
+    with $FutureModifier<List<Category>>, $StreamProvider<List<Category>> {
+  const AllTransactionsCategoriesProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'allTransactionsCategoriesProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$allTransactionsCategoriesHash();
+
+  @$internal
+  @override
+  $StreamProviderElement<List<Category>> $createElement(
+    $ProviderPointer pointer,
+  ) => $StreamProviderElement(pointer);
+
+  @override
+  Stream<List<Category>> create(Ref ref) {
+    return allTransactionsCategories(ref);
+  }
+}
+
+String _$allTransactionsCategoriesHash() =>
+    r'e70776e0f387ef56b1d4067ce8a74bc7125b517e';

--- a/lib/features/transactions/presentation/screens/all_transactions_screen.dart
+++ b/lib/features/transactions/presentation/screens/all_transactions_screen.dart
@@ -1,0 +1,494 @@
+import 'package:collection/collection.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+import 'package:kopim/core/utils/helpers.dart';
+import 'package:kopim/core/widgets/phosphor_icon_utils.dart';
+import 'package:kopim/features/accounts/domain/entities/account_entity.dart';
+import 'package:kopim/features/categories/domain/entities/category.dart';
+import 'package:kopim/features/transactions/domain/entities/transaction.dart';
+import 'package:kopim/features/transactions/domain/entities/transaction_type.dart';
+import 'package:kopim/features/transactions/presentation/controllers/all_transactions_filter_controller.dart';
+import 'package:kopim/features/transactions/presentation/controllers/all_transactions_providers.dart';
+import 'package:kopim/features/transactions/presentation/widgets/transaction_editor.dart';
+import 'package:kopim/features/transactions/presentation/widgets/transaction_tile_formatters.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+import 'package:kopim/l10n/app_localizations.dart';
+
+class AllTransactionsScreen extends ConsumerWidget {
+  const AllTransactionsScreen({super.key});
+
+  static const String routeName = '/transactions/all';
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final AppLocalizations strings = AppLocalizations.of(context)!;
+    final AsyncValue<List<TransactionEntity>> transactionsAsync = ref.watch(
+      filteredTransactionsProvider,
+    );
+    final AsyncValue<List<AccountEntity>> accountsAsync = ref.watch(
+      allTransactionsAccountsProvider,
+    );
+    final AsyncValue<List<Category>> categoriesAsync = ref.watch(
+      allTransactionsCategoriesProvider,
+    );
+
+    final Map<String, AccountEntity> accountsMap = <String, AccountEntity>{
+      for (final AccountEntity account
+          in accountsAsync.asData?.value ?? const <AccountEntity>[])
+        account.id: account,
+    };
+    final Map<String, Category> categoriesMap = <String, Category>{
+      for (final Category category
+          in categoriesAsync.asData?.value ?? const <Category>[])
+        category.id: category,
+    };
+
+    return Scaffold(
+      appBar: AppBar(title: Text(strings.allTransactionsTitle)),
+      body: SafeArea(
+        child: Column(
+          children: <Widget>[
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: _FiltersPanel(
+                strings: strings,
+                accountsAsync: accountsAsync,
+                categoriesAsync: categoriesAsync,
+              ),
+            ),
+            const Divider(height: 0),
+            Expanded(
+              child: transactionsAsync.when(
+                data: (List<TransactionEntity> transactions) {
+                  if (transactions.isEmpty) {
+                    return _TransactionsEmpty(
+                      message: strings.allTransactionsEmpty,
+                    );
+                  }
+                  return _TransactionsList(
+                    transactions: transactions,
+                    strings: strings,
+                    accounts: accountsMap,
+                    categories: categoriesMap,
+                  );
+                },
+                loading: () => const Center(child: CircularProgressIndicator()),
+                error: (Object error, _) => _TransactionsError(
+                  message: strings.allTransactionsError(error.toString()),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _FiltersPanel extends ConsumerWidget {
+  const _FiltersPanel({
+    required this.strings,
+    required this.accountsAsync,
+    required this.categoriesAsync,
+  });
+
+  final AppLocalizations strings;
+  final AsyncValue<List<AccountEntity>> accountsAsync;
+  final AsyncValue<List<Category>> categoriesAsync;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ThemeData theme = Theme.of(context);
+    final AllTransactionsFilterState filters = ref.watch(
+      allTransactionsFilterControllerProvider,
+    );
+    final DateFormat dateFormat = DateFormat.yMMMd(strings.localeName);
+    final List<AccountEntity> accounts =
+        accountsAsync.asData?.value ?? const <AccountEntity>[];
+    final List<Category> categories =
+        categoriesAsync.asData?.value ?? const <Category>[];
+
+    final String dateSubtitle = filters.dateRange == null
+        ? strings.allTransactionsFiltersDateAny
+        : '${dateFormat.format(filters.dateRange!.start)} — '
+              '${dateFormat.format(filters.dateRange!.end)}';
+
+    final String accountSubtitle = accountsAsync.when(
+      data: (List<AccountEntity> data) {
+        if (filters.accountId == null) {
+          return strings.allTransactionsFiltersAccountAny;
+        }
+        final AccountEntity? match = data.firstWhereOrNull(
+          (AccountEntity a) => a.id == filters.accountId,
+        );
+        return match?.name ?? strings.allTransactionsFiltersAccountAny;
+      },
+      loading: () => strings.allTransactionsFiltersLoading,
+      error: (Object error, _) => strings.allTransactionsFiltersAccountAny,
+    );
+
+    final String categorySubtitle = categoriesAsync.when(
+      data: (List<Category> data) {
+        if (filters.categoryId == null) {
+          return strings.allTransactionsFiltersCategoryAny;
+        }
+        final Category? match = data.firstWhereOrNull(
+          (Category c) => c.id == filters.categoryId,
+        );
+        return match?.name ?? strings.allTransactionsFiltersCategoryAny;
+      },
+      loading: () => strings.allTransactionsFiltersLoading,
+      error: (Object error, _) => strings.allTransactionsFiltersCategoryAny,
+    );
+
+    Future<void> selectDateRange() async {
+      final DateTimeRange? range = await showDateRangePicker(
+        context: context,
+        firstDate: DateTime(2000),
+        lastDate: DateTime.now().add(const Duration(days: 365)),
+        currentDate: DateTime.now(),
+        initialDateRange: filters.dateRange,
+        locale: Locale(strings.localeName),
+      );
+      if (!context.mounted) {
+        return;
+      }
+      ref
+          .read(allTransactionsFilterControllerProvider.notifier)
+          .setDateRange(range);
+    }
+
+    Future<void> selectAccount() async {
+      if (accounts.isEmpty) {
+        return;
+      }
+      final String? selection = await showModalBottomSheet<String>(
+        context: context,
+        builder: (BuildContext sheetContext) {
+          return SafeArea(
+            child: ListView(
+              shrinkWrap: true,
+              children: <Widget>[
+                ListTile(
+                  leading: const Icon(Icons.clear),
+                  title: Text(strings.allTransactionsFiltersAccountAny),
+                  selected: filters.accountId == null,
+                  onTap: () => Navigator.of(sheetContext).pop(null),
+                ),
+                ...accounts.map(
+                  (AccountEntity account) => ListTile(
+                    title: Text(account.name),
+                    selected: filters.accountId == account.id,
+                    onTap: () => Navigator.of(sheetContext).pop(account.id),
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+      );
+      if (!context.mounted) {
+        return;
+      }
+      ref
+          .read(allTransactionsFilterControllerProvider.notifier)
+          .setAccount(selection);
+    }
+
+    Future<void> selectCategory() async {
+      if (categories.isEmpty) {
+        return;
+      }
+      final String? selection = await showModalBottomSheet<String>(
+        context: context,
+        builder: (BuildContext sheetContext) {
+          return SafeArea(
+            child: ListView(
+              shrinkWrap: true,
+              children: <Widget>[
+                ListTile(
+                  leading: const Icon(Icons.clear),
+                  title: Text(strings.allTransactionsFiltersCategoryAny),
+                  selected: filters.categoryId == null,
+                  onTap: () => Navigator.of(sheetContext).pop(null),
+                ),
+                ...categories.map(
+                  (Category category) => ListTile(
+                    title: Text(category.name),
+                    selected: filters.categoryId == category.id,
+                    onTap: () => Navigator.of(sheetContext).pop(category.id),
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+      );
+      if (!context.mounted) {
+        return;
+      }
+      ref
+          .read(allTransactionsFilterControllerProvider.notifier)
+          .setCategory(selection);
+    }
+
+    return Card(
+      margin: EdgeInsets.zero,
+      elevation: 0,
+      surfaceTintColor: Colors.transparent,
+      child: ExpansionTile(
+        tilePadding: const EdgeInsets.symmetric(horizontal: 16),
+        leading: Icon(
+          Icons.filter_alt_outlined,
+          color: theme.colorScheme.primary,
+        ),
+        title: Text(
+          strings.allTransactionsFiltersTitle,
+          style: theme.textTheme.titleMedium,
+        ),
+        children: <Widget>[
+          ListTile(
+            leading: const Icon(Icons.date_range_outlined),
+            title: Text(strings.allTransactionsFiltersDate),
+            subtitle: Text(dateSubtitle),
+            onTap: selectDateRange,
+          ),
+          ListTile(
+            leading: const Icon(Icons.account_balance_wallet_outlined),
+            title: Text(strings.allTransactionsFiltersAccount),
+            subtitle: Text(accountSubtitle),
+            enabled: accounts.isNotEmpty,
+            onTap: accounts.isNotEmpty ? selectAccount : null,
+          ),
+          ListTile(
+            leading: const Icon(Icons.category_outlined),
+            title: Text(strings.allTransactionsFiltersCategory),
+            subtitle: Text(categorySubtitle),
+            enabled: categories.isNotEmpty,
+            onTap: categories.isNotEmpty ? selectCategory : null,
+          ),
+          Align(
+            alignment: Alignment.centerRight,
+            child: TextButton.icon(
+              onPressed: filters.hasFilters
+                  ? () => ref
+                        .read(allTransactionsFilterControllerProvider.notifier)
+                        .clear()
+                  : null,
+              icon: const Icon(Icons.refresh),
+              label: Text(strings.allTransactionsFiltersClear),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TransactionsList extends StatelessWidget {
+  const _TransactionsList({
+    required this.transactions,
+    required this.strings,
+    required this.accounts,
+    required this.categories,
+  });
+
+  final List<TransactionEntity> transactions;
+  final AppLocalizations strings;
+  final Map<String, AccountEntity> accounts;
+  final Map<String, Category> categories;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.separated(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
+      itemCount: transactions.length,
+      separatorBuilder: (BuildContext context, int index) =>
+          const SizedBox(height: 12),
+      itemBuilder: (BuildContext context, int index) {
+        final TransactionEntity transaction = transactions[index];
+        final AccountEntity? account = accounts[transaction.accountId];
+        final Category? category = transaction.categoryId == null
+            ? null
+            : categories[transaction.categoryId!];
+        return _TransactionListTile(
+          transaction: transaction,
+          account: account,
+          category: category,
+          strings: strings,
+        );
+      },
+    );
+  }
+}
+
+class _TransactionListTile extends ConsumerWidget {
+  const _TransactionListTile({
+    required this.transaction,
+    required this.account,
+    required this.category,
+    required this.strings,
+  });
+
+  final TransactionEntity transaction;
+  final AccountEntity? account;
+  final Category? category;
+  final AppLocalizations strings;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ThemeData theme = Theme.of(context);
+    final String currencySymbol =
+        account?.currency.toUpperCase() ??
+        TransactionTileFormatters.fallbackCurrencySymbol(strings.localeName);
+    final NumberFormat moneyFormat = TransactionTileFormatters.currency(
+      strings.localeName,
+      currencySymbol,
+    );
+    final bool isExpense =
+        transaction.type == TransactionType.expense.storageValue;
+    final Color amountColor = isExpense
+        ? theme.colorScheme.error
+        : theme.colorScheme.primary;
+    final PhosphorIconData? iconData = resolvePhosphorIconData(category?.icon);
+    final Color? categoryColor = parseHexColor(category?.color);
+    final Color avatarForeground = categoryColor != null
+        ? (ThemeData.estimateBrightnessForColor(categoryColor) ==
+                  Brightness.dark
+              ? Colors.white
+              : Colors.black87)
+        : theme.colorScheme.onSurfaceVariant;
+    final String categoryName =
+        category?.name ?? strings.homeTransactionsUncategorized;
+    final String? note = transaction.note?.trim();
+    final DateFormat dateFormat = DateFormat.yMMMd(strings.localeName);
+    final String? accountName = account?.name;
+    final List<String> subtitleParts = <String>[
+      if (accountName != null) accountName,
+      dateFormat.format(transaction.date),
+    ];
+    final String subtitle = subtitleParts.join(' • ');
+
+    return Dismissible(
+      key: ValueKey<String>(transaction.id),
+      direction: DismissDirection.endToStart,
+      background: buildDeleteBackground(theme.colorScheme.error),
+      confirmDismiss: (DismissDirection direction) =>
+          deleteTransactionWithFeedback(
+            context: context,
+            ref: ref,
+            transactionId: transaction.id,
+            strings: strings,
+          ),
+      child: Card(
+        elevation: 0,
+        margin: EdgeInsets.zero,
+        surfaceTintColor: Colors.transparent,
+        child: InkWell(
+          borderRadius: const BorderRadius.all(Radius.circular(12)),
+          onTap: () => showTransactionEditorSheet(
+            context: context,
+            ref: ref,
+            transaction: transaction,
+            submitLabel: strings.editTransactionSubmit,
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(12),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                CircleAvatar(
+                  backgroundColor:
+                      categoryColor ??
+                      theme.colorScheme.surfaceContainerHighest,
+                  foregroundColor: avatarForeground,
+                  child: iconData != null
+                      ? Icon(iconData)
+                      : const Icon(Icons.category_outlined),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      Text(categoryName, style: theme.textTheme.bodyMedium),
+                      if (note != null && note.isNotEmpty)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 4),
+                          child: Text(
+                            note,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: theme.textTheme.bodySmall,
+                          ),
+                        ),
+                      Padding(
+                        padding: const EdgeInsets.only(top: 4),
+                        child: Text(
+                          subtitle,
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: theme.colorScheme.onSurfaceVariant,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Text(
+                  moneyFormat.format(transaction.amount.abs()),
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    color: amountColor,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _TransactionsEmpty extends StatelessWidget {
+  const _TransactionsEmpty({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Text(
+          message,
+          textAlign: TextAlign.center,
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
+      ),
+    );
+  }
+}
+
+class _TransactionsError extends StatelessWidget {
+  const _TransactionsError({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Text(
+          message,
+          textAlign: TextAlign.center,
+          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+            color: Theme.of(context).colorScheme.error,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/transactions/presentation/widgets/transaction_tile_formatters.dart
+++ b/lib/features/transactions/presentation/widgets/transaction_tile_formatters.dart
@@ -1,0 +1,29 @@
+import 'package:intl/intl.dart';
+
+class TransactionTileFormatters {
+  const TransactionTileFormatters._();
+
+  static final Map<String, NumberFormat> _currencyCache =
+      <String, NumberFormat>{};
+  static final Map<String, String> _fallbackSymbols = <String, String>{};
+  static final Map<String, DateFormat> _dayHeaderCache = <String, DateFormat>{};
+
+  static DateFormat dayHeader(String locale) {
+    return _dayHeaderCache.putIfAbsent(locale, () => DateFormat.yMMMMd(locale));
+  }
+
+  static NumberFormat currency(String locale, String symbol) {
+    final String cacheKey = '$locale|$symbol';
+    return _currencyCache.putIfAbsent(
+      cacheKey,
+      () => NumberFormat.currency(locale: locale, symbol: symbol),
+    );
+  }
+
+  static String fallbackCurrencySymbol(String locale) {
+    return _fallbackSymbols.putIfAbsent(
+      locale,
+      () => NumberFormat.simpleCurrency(locale: locale).currencySymbol,
+    );
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -53,6 +53,14 @@
   "@settingsHomeBudgetSubtitle": {
     "description": "Helper text for the budget widget toggle"
   },
+  "settingsHomeRecurringTitle": "Recurring widget",
+  "@settingsHomeRecurringTitle": {
+    "description": "Toggle title for the recurring operations widget"
+  },
+  "settingsHomeRecurringSubtitle": "Show upcoming recurring operations on the home screen.",
+  "@settingsHomeRecurringSubtitle": {
+    "description": "Helper text for the recurring operations widget toggle"
+  },
   "settingsHomeBudgetSelectedLabel": "Selected budget",
   "@settingsHomeBudgetSelectedLabel": {
     "description": "Title for the list tile showing the currently selected budget"
@@ -781,6 +789,22 @@
   "homeTransactionsSection": "Recent transactions",
   "@homeTransactionsSection": {
     "description": "Section header for transactions list"
+  },
+  "homeTransactionsFilterAll": "All",
+  "@homeTransactionsFilterAll": {
+    "description": "Label for the all transactions filter on the home screen"
+  },
+  "homeTransactionsFilterIncome": "Income",
+  "@homeTransactionsFilterIncome": {
+    "description": "Label for the income-only filter on the home screen"
+  },
+  "homeTransactionsFilterExpense": "Expenses",
+  "@homeTransactionsFilterExpense": {
+    "description": "Label for the expense-only filter on the home screen"
+  },
+  "homeTransactionsSeeAll": "All transactions",
+  "@homeTransactionsSeeAll": {
+    "description": "Button label that opens the all transactions screen"
   },
   "homeTransactionsEmpty": "No transactions recorded yet.",
   "@homeTransactionsEmpty": {
@@ -1722,5 +1746,60 @@
   "transactionDefaultTitle": "Transaction",
   "@transactionDefaultTitle": {
     "description": "Fallback title for transactions without a note"
+  },
+
+  "allTransactionsTitle": "All transactions",
+  "@allTransactionsTitle": {
+    "description": "Title for the screen listing all transactions"
+  },
+  "allTransactionsFiltersTitle": "Transaction filters",
+  "@allTransactionsFiltersTitle": {
+    "description": "Header for the collapsible filters panel"
+  },
+  "allTransactionsFiltersDate": "Period",
+  "@allTransactionsFiltersDate": {
+    "description": "Label for the date range picker"
+  },
+  "allTransactionsFiltersDateAny": "Any date",
+  "@allTransactionsFiltersDateAny": {
+    "description": "Helper text when no date range is selected"
+  },
+  "allTransactionsFiltersAccount": "Account",
+  "@allTransactionsFiltersAccount": {
+    "description": "Label for the account filter"
+  },
+  "allTransactionsFiltersAccountAny": "All accounts",
+  "@allTransactionsFiltersAccountAny": {
+    "description": "Helper text when no account is selected"
+  },
+  "allTransactionsFiltersCategory": "Category",
+  "@allTransactionsFiltersCategory": {
+    "description": "Label for the category filter"
+  },
+  "allTransactionsFiltersCategoryAny": "All categories",
+  "@allTransactionsFiltersCategoryAny": {
+    "description": "Helper text when no category is selected"
+  },
+  "allTransactionsFiltersLoading": "Loading…",
+  "@allTransactionsFiltersLoading": {
+    "description": "Subtitle shown while filter data is loading"
+  },
+  "allTransactionsFiltersClear": "Reset filters",
+  "@allTransactionsFiltersClear": {
+    "description": "Button label for clearing all filters"
+  },
+  "allTransactionsEmpty": "No transactions match the selected filters.",
+  "@allTransactionsEmpty": {
+    "description": "Empty state message for the all transactions screen"
+  },
+  "allTransactionsError": "Failed to load transactions: {error}",
+  "@allTransactionsError": {
+    "description": "Error message shown when fetching transactions fails",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
   }
+
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -182,6 +182,18 @@ abstract class AppLocalizations {
   /// **'Track a selected budget without leaving the home screen.'**
   String get settingsHomeBudgetSubtitle;
 
+  /// Toggle title for the recurring operations widget
+  ///
+  /// In en, this message translates to:
+  /// **'Recurring widget'**
+  String get settingsHomeRecurringTitle;
+
+  /// Helper text for the recurring operations widget toggle
+  ///
+  /// In en, this message translates to:
+  /// **'Show upcoming recurring operations on the home screen.'**
+  String get settingsHomeRecurringSubtitle;
+
   /// Title for the list tile showing the currently selected budget
   ///
   /// In en, this message translates to:
@@ -1129,6 +1141,30 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Recent transactions'**
   String get homeTransactionsSection;
+
+  /// Label for the all transactions filter on the home screen
+  ///
+  /// In en, this message translates to:
+  /// **'All'**
+  String get homeTransactionsFilterAll;
+
+  /// Label for the income-only filter on the home screen
+  ///
+  /// In en, this message translates to:
+  /// **'Income'**
+  String get homeTransactionsFilterIncome;
+
+  /// Label for the expense-only filter on the home screen
+  ///
+  /// In en, this message translates to:
+  /// **'Expenses'**
+  String get homeTransactionsFilterExpense;
+
+  /// Button label that opens the all transactions screen
+  ///
+  /// In en, this message translates to:
+  /// **'All transactions'**
+  String get homeTransactionsSeeAll;
 
   /// Empty state for transactions list
   ///
@@ -2353,6 +2389,78 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Transaction'**
   String get transactionDefaultTitle;
+
+  /// Title for the screen listing all transactions
+  ///
+  /// In en, this message translates to:
+  /// **'All transactions'**
+  String get allTransactionsTitle;
+
+  /// Header for the collapsible filters panel
+  ///
+  /// In en, this message translates to:
+  /// **'Transaction filters'**
+  String get allTransactionsFiltersTitle;
+
+  /// Label for the date range picker
+  ///
+  /// In en, this message translates to:
+  /// **'Period'**
+  String get allTransactionsFiltersDate;
+
+  /// Helper text when no date range is selected
+  ///
+  /// In en, this message translates to:
+  /// **'Any date'**
+  String get allTransactionsFiltersDateAny;
+
+  /// Label for the account filter
+  ///
+  /// In en, this message translates to:
+  /// **'Account'**
+  String get allTransactionsFiltersAccount;
+
+  /// Helper text when no account is selected
+  ///
+  /// In en, this message translates to:
+  /// **'All accounts'**
+  String get allTransactionsFiltersAccountAny;
+
+  /// Label for the category filter
+  ///
+  /// In en, this message translates to:
+  /// **'Category'**
+  String get allTransactionsFiltersCategory;
+
+  /// Helper text when no category is selected
+  ///
+  /// In en, this message translates to:
+  /// **'All categories'**
+  String get allTransactionsFiltersCategoryAny;
+
+  /// Subtitle shown while filter data is loading
+  ///
+  /// In en, this message translates to:
+  /// **'Loading…'**
+  String get allTransactionsFiltersLoading;
+
+  /// Button label for clearing all filters
+  ///
+  /// In en, this message translates to:
+  /// **'Reset filters'**
+  String get allTransactionsFiltersClear;
+
+  /// Empty state message for the all transactions screen
+  ///
+  /// In en, this message translates to:
+  /// **'No transactions match the selected filters.'**
+  String get allTransactionsEmpty;
+
+  /// Error message shown when fetching transactions fails
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to load transactions: {error}'**
+  String allTransactionsError(String error);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -53,6 +53,13 @@ class AppLocalizationsEn extends AppLocalizations {
       'Track a selected budget without leaving the home screen.';
 
   @override
+  String get settingsHomeRecurringTitle => 'Recurring widget';
+
+  @override
+  String get settingsHomeRecurringSubtitle =>
+      'Show upcoming recurring operations on the home screen.';
+
+  @override
   String get settingsHomeBudgetSelectedLabel => 'Selected budget';
 
   @override
@@ -572,6 +579,18 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get homeTransactionsSection => 'Recent transactions';
+
+  @override
+  String get homeTransactionsFilterAll => 'All';
+
+  @override
+  String get homeTransactionsFilterIncome => 'Income';
+
+  @override
+  String get homeTransactionsFilterExpense => 'Expenses';
+
+  @override
+  String get homeTransactionsSeeAll => 'All transactions';
 
   @override
   String get homeTransactionsEmpty => 'No transactions recorded yet.';
@@ -1265,4 +1284,43 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get transactionDefaultTitle => 'Transaction';
+
+  @override
+  String get allTransactionsTitle => 'All transactions';
+
+  @override
+  String get allTransactionsFiltersTitle => 'Transaction filters';
+
+  @override
+  String get allTransactionsFiltersDate => 'Period';
+
+  @override
+  String get allTransactionsFiltersDateAny => 'Any date';
+
+  @override
+  String get allTransactionsFiltersAccount => 'Account';
+
+  @override
+  String get allTransactionsFiltersAccountAny => 'All accounts';
+
+  @override
+  String get allTransactionsFiltersCategory => 'Category';
+
+  @override
+  String get allTransactionsFiltersCategoryAny => 'All categories';
+
+  @override
+  String get allTransactionsFiltersLoading => 'Loading…';
+
+  @override
+  String get allTransactionsFiltersClear => 'Reset filters';
+
+  @override
+  String get allTransactionsEmpty =>
+      'No transactions match the selected filters.';
+
+  @override
+  String allTransactionsError(String error) {
+    return 'Failed to load transactions: $error';
+  }
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -54,6 +54,13 @@ class AppLocalizationsRu extends AppLocalizations {
       'Отслеживайте выбранный бюджет прямо на главном экране.';
 
   @override
+  String get settingsHomeRecurringTitle => 'Виджет повторяющихся операций';
+
+  @override
+  String get settingsHomeRecurringSubtitle =>
+      'Показывать ближайшие повторяющиеся операции на главном экране.';
+
+  @override
   String get settingsHomeBudgetSelectedLabel => 'Выбранный бюджет';
 
   @override
@@ -574,6 +581,18 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get homeTransactionsSection => 'Последние транзакции';
+
+  @override
+  String get homeTransactionsFilterAll => 'Все';
+
+  @override
+  String get homeTransactionsFilterIncome => 'Доходы';
+
+  @override
+  String get homeTransactionsFilterExpense => 'Расходы';
+
+  @override
+  String get homeTransactionsSeeAll => 'Все транзакции';
 
   @override
   String get homeTransactionsEmpty => 'Транзакций пока нет.';
@@ -1268,4 +1287,43 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get transactionDefaultTitle => 'Транзакция';
+
+  @override
+  String get allTransactionsTitle => 'Все транзакции';
+
+  @override
+  String get allTransactionsFiltersTitle => 'Настройка фильтров';
+
+  @override
+  String get allTransactionsFiltersDate => 'Период';
+
+  @override
+  String get allTransactionsFiltersDateAny => 'Любая дата';
+
+  @override
+  String get allTransactionsFiltersAccount => 'Счёт';
+
+  @override
+  String get allTransactionsFiltersAccountAny => 'Все счета';
+
+  @override
+  String get allTransactionsFiltersCategory => 'Категория';
+
+  @override
+  String get allTransactionsFiltersCategoryAny => 'Все категории';
+
+  @override
+  String get allTransactionsFiltersLoading => 'Загрузка…';
+
+  @override
+  String get allTransactionsFiltersClear => 'Сбросить фильтры';
+
+  @override
+  String get allTransactionsEmpty =>
+      'Транзакций по заданным условиям не найдено.';
+
+  @override
+  String allTransactionsError(String error) {
+    return 'Не удалось загрузить транзакции: $error';
+  }
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -53,6 +53,14 @@
   "@settingsHomeBudgetSubtitle": {
     "description": "Подсказка к переключателю виджета бюджета"
   },
+  "settingsHomeRecurringTitle": "Виджет повторяющихся операций",
+  "@settingsHomeRecurringTitle": {
+    "description": "Подпись переключателя виджета повторяющихся операций"
+  },
+  "settingsHomeRecurringSubtitle": "Показывать ближайшие повторяющиеся операции на главном экране.",
+  "@settingsHomeRecurringSubtitle": {
+    "description": "Подсказка к переключателю виджета повторяющихся операций"
+  },
   "settingsHomeBudgetSelectedLabel": "Выбранный бюджет",
   "@settingsHomeBudgetSelectedLabel": {
     "description": "Заголовок элемента со статусом выбранного бюджета"
@@ -781,6 +789,22 @@
   "homeTransactionsSection": "Последние транзакции",
   "@homeTransactionsSection": {
     "description": "Заголовок списка транзакций"
+  },
+  "homeTransactionsFilterAll": "Все",
+  "@homeTransactionsFilterAll": {
+    "description": "Подпись фильтра всех транзакций на домашнем экране"
+  },
+  "homeTransactionsFilterIncome": "Доходы",
+  "@homeTransactionsFilterIncome": {
+    "description": "Подпись фильтра доходов на домашнем экране"
+  },
+  "homeTransactionsFilterExpense": "Расходы",
+  "@homeTransactionsFilterExpense": {
+    "description": "Подпись фильтра расходов на домашнем экране"
+  },
+  "homeTransactionsSeeAll": "Все транзакции",
+  "@homeTransactionsSeeAll": {
+    "description": "Подпись кнопки перехода ко всем транзакциям"
   },
   "homeTransactionsEmpty": "Транзакций пока нет.",
   "@homeTransactionsEmpty": {
@@ -1722,5 +1746,60 @@
   "transactionDefaultTitle": "Транзакция",
   "@transactionDefaultTitle": {
     "description": "Резервный заголовок транзакции без примечания"
+  },
+
+  "allTransactionsTitle": "Все транзакции",
+  "@allTransactionsTitle": {
+    "description": "Заголовок экрана со всеми транзакциями"
+  },
+  "allTransactionsFiltersTitle": "Настройка фильтров",
+  "@allTransactionsFiltersTitle": {
+    "description": "Заголовок сворачиваемой панели фильтров"
+  },
+  "allTransactionsFiltersDate": "Период",
+  "@allTransactionsFiltersDate": {
+    "description": "Подпись пункта выбора даты"
+  },
+  "allTransactionsFiltersDateAny": "Любая дата",
+  "@allTransactionsFiltersDateAny": {
+    "description": "Подсказка когда диапазон дат не выбран"
+  },
+  "allTransactionsFiltersAccount": "Счёт",
+  "@allTransactionsFiltersAccount": {
+    "description": "Подпись пункта выбора счёта"
+  },
+  "allTransactionsFiltersAccountAny": "Все счета",
+  "@allTransactionsFiltersAccountAny": {
+    "description": "Подсказка когда счёт не выбран"
+  },
+  "allTransactionsFiltersCategory": "Категория",
+  "@allTransactionsFiltersCategory": {
+    "description": "Подпись пункта выбора категории"
+  },
+  "allTransactionsFiltersCategoryAny": "Все категории",
+  "@allTransactionsFiltersCategoryAny": {
+    "description": "Подсказка когда категория не выбрана"
+  },
+  "allTransactionsFiltersLoading": "Загрузка…",
+  "@allTransactionsFiltersLoading": {
+    "description": "Подсказка при загрузке данных для фильтров"
+  },
+  "allTransactionsFiltersClear": "Сбросить фильтры",
+  "@allTransactionsFiltersClear": {
+    "description": "Подпись кнопки сброса фильтров"
+  },
+  "allTransactionsEmpty": "Транзакций по заданным условиям не найдено.",
+  "@allTransactionsEmpty": {
+    "description": "Сообщение пустого состояния экрана всех транзакций"
+  },
+  "allTransactionsError": "Не удалось загрузить транзакции: {error}",
+  "@allTransactionsError": {
+    "description": "Ошибка загрузки на экране всех транзакций",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
   }
+
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,6 +19,7 @@ import 'features/profile/presentation/screens/profile_management_screen.dart';
 import 'features/profile/presentation/screens/profile_screen.dart';
 import 'features/profile/presentation/screens/sign_in_screen.dart';
 import 'features/transactions/presentation/add_transaction_screen.dart';
+import 'features/transactions/presentation/screens/all_transactions_screen.dart';
 import 'features/recurring_transactions/presentation/screens/add_recurring_rule_screen.dart';
 import 'features/recurring_transactions/presentation/screens/recurring_transactions_screen.dart';
 
@@ -89,6 +90,7 @@ class _MyAppState extends ConsumerState<MyApp> {
         RecurringTransactionsScreen.routeName: (_) =>
             const RecurringTransactionsScreen(),
         AddRecurringRuleScreen.routeName: (_) => const AddRecurringRuleScreen(),
+        AllTransactionsScreen.routeName: (_) => const AllTransactionsScreen(),
       },
       home: startupState.when(
         data: (_) => _AppHome(authState: ref.watch(authControllerProvider)),

--- a/test/features/home/data/home_dashboard_preferences_repository_impl_test.dart
+++ b/test/features/home/data/home_dashboard_preferences_repository_impl_test.dart
@@ -32,6 +32,7 @@ void main() {
       const HomeDashboardPreferences expected = HomeDashboardPreferences(
         showGamificationWidget: true,
         showBudgetWidget: true,
+        showRecurringWidget: true,
         budgetId: 'budget-1',
       );
 

--- a/test/features/home/presentation/controllers/home_dashboard_preferences_controller_test.dart
+++ b/test/features/home/presentation/controllers/home_dashboard_preferences_controller_test.dart
@@ -47,6 +47,7 @@ void main() {
     test('loads preferences on first read', () async {
       repository.stored = const HomeDashboardPreferences(
         showGamificationWidget: true,
+        showRecurringWidget: true,
       );
 
       final HomeDashboardPreferences result = await container.read(
@@ -54,6 +55,7 @@ void main() {
       );
 
       expect(result.showGamificationWidget, isTrue);
+      expect(result.showRecurringWidget, isTrue);
     });
 
     test('setShowGamification updates state and saves', () async {
@@ -68,6 +70,21 @@ void main() {
 
       expect(state?.showGamificationWidget, isTrue);
       expect(repository.lastSaved?.showGamificationWidget, isTrue);
+    });
+
+    test('setShowRecurring updates state and saves', () async {
+      await container.read(homeDashboardPreferencesControllerProvider.future);
+
+      await container
+          .read(homeDashboardPreferencesControllerProvider.notifier)
+          .setShowRecurring(true);
+
+      final HomeDashboardPreferences? state = container
+          .read(homeDashboardPreferencesControllerProvider)
+          .value;
+
+      expect(state?.showRecurringWidget, isTrue);
+      expect(repository.lastSaved?.showRecurringWidget, isTrue);
     });
 
     test(


### PR DESCRIPTION
## Резюме
- добавил переключатель виджета повторяющихся операций и вынес настройки домашнего экрана в отдельную раскрывающуюся карточку
- реализовал фильтрацию последних транзакций по типу и обновил локализации
- создал экран "Все транзакции" с фильтрами по дате, счёту и категории и подключил его к маршрутизации

## Тесты
- `dart format --set-exit-if-changed .`
- `flutter analyze`
- `dart run build_runner build --delete-conflicting-outputs`
- `flutter test --reporter expanded`
- `flutter pub outdated`


------
https://chatgpt.com/codex/tasks/task_e_68e4ff42ef30832ea2a47e23fef6478a