### PR TITLE
Доработка домашней геймификации и повторяющихся операций

### DIFF
--- a/lib/features/home/presentation/widgets/home_budget_progress_card.dart
+++ b/lib/features/home/presentation/widgets/home_budget_progress_card.dart
@@ -2,11 +2,17 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 
+import 'package:kopim/core/utils/helpers.dart';
+import 'package:kopim/core/widgets/phosphor_icon_utils.dart';
 import 'package:kopim/features/budgets/domain/entities/budget_progress.dart';
+import 'package:kopim/features/budgets/presentation/budget_detail_screen.dart';
 import 'package:kopim/features/budgets/presentation/controllers/budgets_providers.dart';
 import 'package:kopim/features/budgets/presentation/widgets/budget_progress_indicator.dart';
+import 'package:kopim/features/categories/domain/entities/category.dart';
 import 'package:kopim/features/home/domain/entities/home_dashboard_preferences.dart';
+import 'package:kopim/features/transactions/domain/entities/transaction.dart';
 import 'package:kopim/l10n/app_localizations.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 class HomeBudgetProgressCard extends ConsumerWidget {
   const HomeBudgetProgressCard({
@@ -57,94 +63,119 @@ class HomeBudgetProgressCard extends ConsumerWidget {
     final AsyncValue<BudgetProgress> progressAsync = ref.watch(
       budgetProgressByIdProvider(budgetId),
     );
+    final AsyncValue<List<Category>> categoriesAsync = ref.watch(
+      budgetCategoriesStreamProvider,
+    );
+    final AsyncValue<List<TransactionEntity>> transactionsAsync = ref.watch(
+      budgetTransactionsByIdProvider(budgetId),
+    );
 
     return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            Text(
-              strings.homeBudgetWidgetTitle,
-              style: theme.textTheme.titleMedium,
-            ),
-            const SizedBox(height: 4),
-            progressAsync.when(
-              data: (BudgetProgress progress) {
-                final NumberFormat currencyFormat = NumberFormat.simpleCurrency(
-                  locale: strings.localeName,
-                );
-                final double limit = progress.budget.amount;
-                final double spent = progress.spent;
-                final double remaining = progress.remaining;
-                final double ratio = progress.utilization.isFinite
-                    ? progress.utilization.clamp(0, 2)
-                    : 1.0;
-                final bool exceeded = progress.isExceeded;
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: progressAsync.maybeWhen(
+          data: (BudgetProgress progress) => () {
+            Navigator.of(context).push(
+              MaterialPageRoute<void>(
+                builder: (_) =>
+                    BudgetDetailScreen(budgetId: progress.budget.id),
+              ),
+            );
+          },
+          orElse: () => null,
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Text(
+                strings.homeBudgetWidgetTitle,
+                style: theme.textTheme.titleMedium,
+              ),
+              const SizedBox(height: 4),
+              progressAsync.when(
+                data: (BudgetProgress progress) {
+                  final NumberFormat currencyFormat =
+                      NumberFormat.simpleCurrency(locale: strings.localeName);
+                  final double limit = progress.budget.amount;
+                  final double spent = progress.spent;
+                  final double remaining = progress.remaining;
+                  final double ratio = progress.utilization.isFinite
+                      ? progress.utilization.clamp(0, 2)
+                      : 1.0;
+                  final bool exceeded = progress.isExceeded;
 
-                return Column(
+                  return Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      Text(
+                        progress.budget.title,
+                        style: theme.textTheme.titleMedium,
+                      ),
+                      const SizedBox(height: 12),
+                      BudgetProgressIndicator(value: ratio, exceeded: exceeded),
+                      const SizedBox(height: 12),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: <Widget>[
+                          _BudgetStat(
+                            label: strings.budgetsSpentLabel,
+                            value: currencyFormat.format(spent),
+                          ),
+                          _BudgetStat(
+                            label: strings.budgetsLimitLabel,
+                            value: currencyFormat.format(limit),
+                          ),
+                          _BudgetStat(
+                            label: exceeded
+                                ? strings.budgetsExceededLabel
+                                : strings.budgetsRemainingLabel,
+                            value: currencyFormat.format(
+                              exceeded ? (spent - limit) : remaining,
+                            ),
+                            valueStyle: exceeded
+                                ? theme.textTheme.bodyMedium?.copyWith(
+                                    color: theme.colorScheme.error,
+                                    fontWeight: FontWeight.w600,
+                                  )
+                                : null,
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 16),
+                      _BudgetCategoriesBreakdown(
+                        progress: progress,
+                        categoriesAsync: categoriesAsync,
+                        transactionsAsync: transactionsAsync,
+                      ),
+                    ],
+                  );
+                },
+                loading: () => const Padding(
+                  padding: EdgeInsets.symmetric(vertical: 8),
+                  child: LinearProgressIndicator(),
+                ),
+                error: (Object error, _) => Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: <Widget>[
                     Text(
-                      progress.budget.title,
-                      style: theme.textTheme.titleMedium,
+                      strings.homeBudgetWidgetMissing,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.error,
+                      ),
                     ),
-                    const SizedBox(height: 12),
-                    BudgetProgressIndicator(value: ratio, exceeded: exceeded),
-                    const SizedBox(height: 12),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: <Widget>[
-                        _BudgetStat(
-                          label: strings.budgetsSpentLabel,
-                          value: currencyFormat.format(spent),
-                        ),
-                        _BudgetStat(
-                          label: strings.budgetsLimitLabel,
-                          value: currencyFormat.format(limit),
-                        ),
-                        _BudgetStat(
-                          label: exceeded
-                              ? strings.budgetsExceededLabel
-                              : strings.budgetsRemainingLabel,
-                          value: currencyFormat.format(
-                            exceeded ? (spent - limit) : remaining,
-                          ),
-                          valueStyle: exceeded
-                              ? theme.textTheme.bodyMedium?.copyWith(
-                                  color: theme.colorScheme.error,
-                                  fontWeight: FontWeight.w600,
-                                )
-                              : null,
-                        ),
-                      ],
+                    const SizedBox(height: 8),
+                    FilledButton.tonalIcon(
+                      onPressed: onConfigure,
+                      icon: const Icon(Icons.settings_outlined),
+                      label: Text(strings.homeBudgetWidgetConfigureCta),
                     ),
                   ],
-                );
-              },
-              loading: () => const Padding(
-                padding: EdgeInsets.symmetric(vertical: 8),
-                child: LinearProgressIndicator(),
+                ),
               ),
-              error: (Object error, _) => Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  Text(
-                    strings.homeBudgetWidgetMissing,
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      color: theme.colorScheme.error,
-                    ),
-                  ),
-                  const SizedBox(height: 8),
-                  FilledButton.tonalIcon(
-                    onPressed: onConfigure,
-                    icon: const Icon(Icons.settings_outlined),
-                    label: Text(strings.homeBudgetWidgetConfigureCta),
-                  ),
-                ],
-              ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );
@@ -177,6 +208,193 @@ class _BudgetStat extends StatelessWidget {
         const SizedBox(height: 4),
         Text(value, style: valueStyle ?? theme.textTheme.bodyMedium),
       ],
+    );
+  }
+}
+
+class _BudgetCategoriesBreakdown extends ConsumerWidget {
+  const _BudgetCategoriesBreakdown({
+    required this.progress,
+    required this.categoriesAsync,
+    required this.transactionsAsync,
+  });
+
+  final BudgetProgress progress;
+  final AsyncValue<List<Category>> categoriesAsync;
+  final AsyncValue<List<TransactionEntity>> transactionsAsync;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ThemeData theme = Theme.of(context);
+    final AppLocalizations strings = AppLocalizations.of(context)!;
+
+    return categoriesAsync.when(
+      data: (List<Category> categories) {
+        return transactionsAsync.when(
+          data: (List<TransactionEntity> transactions) {
+            final Map<String, Category> categoryMap = <String, Category>{
+              for (final Category category in categories) category.id: category,
+            };
+            final Map<String, double> spentByCategory = <String, double>{};
+            for (final TransactionEntity tx in transactions) {
+              final String? categoryId = tx.categoryId;
+              if (categoryId == null) continue;
+              spentByCategory.update(
+                categoryId,
+                (double value) => value + tx.amount.abs(),
+                ifAbsent: () => tx.amount.abs(),
+              );
+            }
+            final Iterable<String> ids = progress.budget.categories.isNotEmpty
+                ? progress.budget.categories
+                : spentByCategory.keys;
+            final List<_CategoryBreakdown> breakdowns = <_CategoryBreakdown>[];
+            double denominator = progress.budget.amount > 0
+                ? progress.budget.amount
+                : spentByCategory.values.fold<double>(
+                    0,
+                    (double sum, double value) => sum + value,
+                  );
+            if (denominator <= 0) {
+              denominator = 0;
+            }
+            for (final String id in ids) {
+              final Category? category = categoryMap[id];
+              if (category == null) {
+                continue;
+              }
+              final double rawValue = spentByCategory[id] ?? 0;
+              final double percent = denominator <= 0
+                  ? 0
+                  : (rawValue / denominator * 100).clamp(0, 100);
+              breakdowns.add(
+                _CategoryBreakdown(
+                  category: category,
+                  percent: percent.isFinite ? percent : 0,
+                ),
+              );
+            }
+            breakdowns.sort(
+              (_CategoryBreakdown a, _CategoryBreakdown b) =>
+                  b.percent.compareTo(a.percent),
+            );
+            if (breakdowns.isEmpty) {
+              return Text(
+                strings.homeBudgetWidgetCategoriesEmpty,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              );
+            }
+            return Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: breakdowns
+                  .map(
+                    (_CategoryBreakdown breakdown) =>
+                        _BudgetCategoryChip(breakdown: breakdown),
+                  )
+                  .toList(growable: false),
+            );
+          },
+          loading: () => const _BudgetChipsSkeleton(),
+          error: (Object error, _) => Text(
+            strings.genericErrorMessage,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.error,
+            ),
+          ),
+        );
+      },
+      loading: () => const _BudgetChipsSkeleton(),
+      error: (Object error, _) => Text(
+        strings.genericErrorMessage,
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.error,
+        ),
+      ),
+    );
+  }
+}
+
+class _BudgetChipsSkeleton extends StatelessWidget {
+  const _BudgetChipsSkeleton();
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox(
+      height: 32,
+      child: Align(
+        alignment: Alignment.centerLeft,
+        child: SizedBox(
+          width: 24,
+          height: 24,
+          child: CircularProgressIndicator(strokeWidth: 2),
+        ),
+      ),
+    );
+  }
+}
+
+class _CategoryBreakdown {
+  const _CategoryBreakdown({required this.category, required this.percent});
+
+  final Category category;
+  final double percent;
+}
+
+class _BudgetCategoryChip extends StatelessWidget {
+  const _BudgetCategoryChip({required this.breakdown});
+
+  final _CategoryBreakdown breakdown;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Category category = breakdown.category;
+    final Color? baseColor = parseHexColor(category.color);
+    final Color backgroundColor =
+        baseColor ?? theme.colorScheme.surfaceContainerHighest;
+    final Brightness brightness = ThemeData.estimateBrightnessForColor(
+      backgroundColor,
+    );
+    final Color foregroundColor = brightness == Brightness.dark
+        ? Colors.white
+        : Colors.black87;
+    final PhosphorIconData? iconData = resolvePhosphorIconData(category.icon);
+    final AppLocalizations strings = AppLocalizations.of(context)!;
+    final NumberFormat percentFormat = NumberFormat.decimalPattern(
+      strings.localeName,
+    );
+    final String percentText = '${percentFormat.format(breakdown.percent)}%';
+
+    return Chip(
+      avatar: Icon(
+        iconData ?? PhosphorIconsLight.tag,
+        size: 16,
+        color: foregroundColor,
+      ),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      backgroundColor: backgroundColor,
+      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+      side: BorderSide.none,
+      labelPadding: const EdgeInsets.symmetric(horizontal: 8),
+      label: DefaultTextStyle.merge(
+        style: theme.textTheme.labelLarge?.copyWith(
+          color: foregroundColor,
+          fontWeight: FontWeight.w600,
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Flexible(
+              child: Text(category.name, overflow: TextOverflow.ellipsis),
+            ),
+            const SizedBox(width: 4),
+            Text(percentText),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/features/home/presentation/widgets/home_gamification_card.dart
+++ b/lib/features/home/presentation/widgets/home_gamification_card.dart
@@ -7,102 +7,295 @@ import 'package:kopim/core/di/injectors.dart';
 import 'package:kopim/features/profile/domain/entities/user_progress.dart';
 import 'package:kopim/features/profile/domain/policies/level_policy.dart';
 import 'package:kopim/features/profile/presentation/controllers/user_progress_controller.dart';
+import 'package:kopim/features/profile/presentation/screens/profile_management_screen.dart';
 import 'package:kopim/l10n/app_localizations.dart';
 
-class HomeGamificationCard extends ConsumerWidget {
+class HomeGamificationCard extends ConsumerStatefulWidget {
   const HomeGamificationCard({required this.userId, super.key});
 
   final String userId;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<HomeGamificationCard> createState() =>
+      _HomeGamificationCardState();
+}
+
+class _HomeGamificationCardState extends ConsumerState<HomeGamificationCard> {
+  static const List<String> _phrases = <String>[
+    'Ты экономишь как супергерой!',
+    'Каждая транзакция приближает к мечте!',
+    'Бюджет под контролем – ты молодец!',
+    'Финансы слушаются только тебя!',
+    'Продолжай в том же духе, кошелёк улыбается!',
+  ];
+
+  static const double _minHeight = 168;
+  static const double _maxHeight = 260;
+
+  double _currentHeight = _minHeight;
+
+  bool get _isExpanded => _currentHeight > (_minHeight + 8);
+
+  String _phraseForDate(DateTime date) {
+    final DateTime anchor = DateTime.utc(2024, 1, 1);
+    final int dayIndex = date.toUtc().difference(anchor).inDays;
+    final int normalized = dayIndex % _phrases.length;
+    final int safeIndex = normalized < 0
+        ? normalized + _phrases.length
+        : normalized;
+    return _phrases[safeIndex];
+  }
+
+  void _handleDragUpdate(DragUpdateDetails details) {
+    final double delta = details.primaryDelta ?? 0;
+    if (delta.abs() < 0.5) {
+      return;
+    }
+    setState(() {
+      _currentHeight = (_currentHeight + delta).clamp(_minHeight, _maxHeight);
+    });
+  }
+
+  void _handleDragEnd(DragEndDetails details) {
+    const double midpoint = (_minHeight + _maxHeight) / 2;
+    final bool shouldExpand = _currentHeight >= midpoint;
+    setState(() {
+      _currentHeight = shouldExpand ? _maxHeight : _minHeight;
+    });
+  }
+
+  void _toggleExpanded() {
+    setState(() {
+      _currentHeight = _isExpanded ? _minHeight : _maxHeight;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final AppLocalizations strings = AppLocalizations.of(context)!;
     final AsyncValue<UserProgress> progressAsync = ref.watch(
-      userProgressProvider(userId),
+      userProgressProvider(widget.userId),
     );
+    final String headline = _phraseForDate(DateTime.now());
 
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            Text(
-              strings.homeGamificationTitle,
-              style: theme.textTheme.titleMedium,
-            ),
-            const SizedBox(height: 4),
-            Text(
-              strings.homeGamificationSubtitle,
-              style: theme.textTheme.bodySmall?.copyWith(
-                color: theme.colorScheme.onSurfaceVariant,
-              ),
-            ),
-            const SizedBox(height: 16),
-            progressAsync.when(
-              data: (UserProgress progress) {
-                final LevelPolicy policy = ref.read(levelPolicyProvider);
-                final int previousThreshold = policy.previousThreshold(
-                  progress.level,
-                );
-                final int nextThreshold = progress.nextThreshold;
-                final double ratio = nextThreshold == previousThreshold
-                    ? 1.0
-                    : ((progress.totalTx - previousThreshold) /
-                              (nextThreshold - previousThreshold))
-                          .clamp(0.0, 1.0);
-                final int xpToNext = math.max(
-                  0,
-                  nextThreshold - progress.totalTx,
-                );
-                final bool maxedOut = nextThreshold == progress.totalTx;
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 250),
+      curve: Curves.easeInOut,
+      height: _currentHeight,
+      child: Material(
+        elevation: 6,
+        color: theme.colorScheme.surface,
+        surfaceTintColor: theme.colorScheme.surfaceTint,
+        borderRadius: const BorderRadius.only(
+          topLeft: Radius.circular(28),
+          topRight: Radius.circular(28),
+          bottomLeft: Radius.circular(20),
+          bottomRight: Radius.circular(20),
+        ),
+        clipBehavior: Clip.antiAlias,
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onVerticalDragUpdate: _handleDragUpdate,
+          onVerticalDragEnd: _handleDragEnd,
+          child: InkWell(
+            key: const Key('homeGamificationCard.toggle'),
+            onTap: _toggleExpanded,
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+              child: progressAsync.when(
+                data: (UserProgress progress) {
+                  final LevelPolicy policy = ref.read(levelPolicyProvider);
+                  final int previousThreshold = policy.previousThreshold(
+                    progress.level,
+                  );
+                  final int nextThreshold = progress.nextThreshold;
+                  final double ratio = nextThreshold == previousThreshold
+                      ? 1.0
+                      : ((progress.totalTx - previousThreshold) /
+                                (nextThreshold - previousThreshold))
+                            .clamp(0.0, 1.0);
+                  final int xpToNext = math.max(
+                    0,
+                    nextThreshold - progress.totalTx,
+                  );
+                  final bool maxedOut = nextThreshold == progress.totalTx;
+                  final TextTheme textTheme = theme.textTheme;
 
-                return Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: <Widget>[
-                    Chip(
-                      label: Text(
-                        strings.profileLevelBadge(
-                          progress.level,
-                          progress.title,
-                        ),
+                  return Stack(
+                    children: <Widget>[
+                      Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: <Widget>[
+                          Align(
+                            alignment: Alignment.topCenter,
+                            child: Container(
+                              width: 40,
+                              height: 4,
+                              decoration: BoxDecoration(
+                                color:
+                                    theme.colorScheme.surfaceContainerHighest,
+                                borderRadius: BorderRadius.circular(999),
+                              ),
+                            ),
+                          ),
+                          const SizedBox(height: 12),
+                          Row(
+                            children: <Widget>[
+                              Expanded(
+                                child: Text(
+                                  headline,
+                                  style: textTheme.titleMedium?.copyWith(
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                              ),
+                              IconButton(
+                                tooltip: strings.homeProfileTooltip,
+                                icon: const Icon(Icons.account_circle_outlined),
+                                onPressed: () {
+                                  Navigator.of(context).pushNamed(
+                                    ProfileManagementScreen.routeName,
+                                  );
+                                },
+                              ),
+                            ],
+                          ),
+                          const SizedBox(height: 16),
+                          ClipRRect(
+                            borderRadius: const BorderRadius.all(
+                              Radius.circular(12),
+                            ),
+                            child: LinearProgressIndicator(value: ratio),
+                          ),
+                          const SizedBox(height: 8),
+                          Text(
+                            maxedOut
+                                ? strings.profileLevelMaxReached
+                                : strings.profileXpToNext(xpToNext),
+                            style: textTheme.bodyMedium,
+                          ),
+                          const Spacer(),
+                          IgnorePointer(
+                            ignoring: !_isExpanded,
+                            child: AnimatedOpacity(
+                              opacity: _isExpanded ? 1.0 : 0.0,
+                              duration: const Duration(milliseconds: 200),
+                              curve: Curves.easeInOut,
+                              child: _GamificationDetails(
+                                level: progress.level,
+                                title: progress.title,
+                                badgeText: strings.profileLevelBadge(
+                                  progress.level,
+                                  progress.title,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ],
                       ),
-                      avatar: const Icon(Icons.emoji_events_outlined),
-                    ),
-                    const SizedBox(height: 12),
-                    ClipRRect(
-                      borderRadius: const BorderRadius.all(Radius.circular(12)),
-                      child: LinearProgressIndicator(value: ratio),
-                    ),
-                    const SizedBox(height: 8),
-                    Text(
-                      maxedOut
-                          ? strings.profileLevelMaxReached
-                          : strings.profileXpToNext(xpToNext),
-                      style: theme.textTheme.bodyMedium,
-                    ),
-                  ],
-                );
-              },
-              loading: () => const Align(
-                alignment: Alignment.centerLeft,
-                child: SizedBox(
-                  width: 24,
-                  height: 24,
-                  child: CircularProgressIndicator(strokeWidth: 2),
+                      if (!_isExpanded)
+                        Positioned(
+                          bottom: 0,
+                          left: 0,
+                          right: 0,
+                          child: IgnorePointer(
+                            child: DecoratedBox(
+                              decoration: BoxDecoration(
+                                gradient: LinearGradient(
+                                  begin: Alignment.topCenter,
+                                  end: Alignment.bottomCenter,
+                                  colors: <Color>[
+                                    theme.colorScheme.surface.withValues(
+                                      alpha: 0.0,
+                                    ),
+                                    theme.colorScheme.surface,
+                                  ],
+                                ),
+                              ),
+                              child: const SizedBox(height: 28),
+                            ),
+                          ),
+                        ),
+                    ],
+                  );
+                },
+                loading: () => const Center(
+                  child: SizedBox(
+                    width: 24,
+                    height: 24,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
                 ),
-              ),
-              error: (Object error, _) => Text(
-                strings.homeGamificationError(error.toString()),
-                style: theme.textTheme.bodySmall?.copyWith(
-                  color: theme.colorScheme.error,
+                error: (Object error, _) => Align(
+                  alignment: Alignment.topLeft,
+                  child: Text(
+                    strings.homeGamificationError(error.toString()),
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.error,
+                    ),
+                  ),
                 ),
               ),
             ),
-          ],
+          ),
         ),
       ),
+    );
+  }
+}
+
+class _GamificationDetails extends StatelessWidget {
+  const _GamificationDetails({
+    required this.level,
+    required this.title,
+    required this.badgeText,
+  });
+
+  final int level;
+  final String title;
+  final String badgeText;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final TextTheme textTheme = theme.textTheme;
+
+    return Row(
+      children: <Widget>[
+        CircleAvatar(
+          radius: 24,
+          backgroundColor: theme.colorScheme.primaryContainer,
+          foregroundColor: theme.colorScheme.onPrimaryContainer,
+          child: Text(
+            level.toString(),
+            style: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+          ),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Text(
+                title,
+                style: textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                badgeText,
+                style: textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/features/recurring_transactions/presentation/controllers/recurring_rule_form_controller.dart
+++ b/lib/features/recurring_transactions/presentation/controllers/recurring_rule_form_controller.dart
@@ -25,6 +25,7 @@ abstract class RecurringRuleFormState with _$RecurringRuleFormState {
   const factory RecurringRuleFormState({
     @Default('') String title,
     @Default('') String amountInput,
+    @Default('') String notes,
     AccountEntity? account,
     String? accountId,
     Category? category,
@@ -75,6 +76,7 @@ class RecurringRuleFormController extends _$RecurringRuleFormController {
       return RecurringRuleFormState(
         title: initialRule.title,
         amountInput: _formatAmountInput(absoluteAmount),
+        notes: initialRule.notes ?? '',
         accountId: initialRule.accountId,
         categoryId: initialRule.categoryId,
         type: initialType,
@@ -112,6 +114,14 @@ class RecurringRuleFormController extends _$RecurringRuleFormController {
     state = state.copyWith(
       amountInput: value,
       amountError: null,
+      submissionSuccess: false,
+      generalErrorMessage: null,
+    );
+  }
+
+  void updateNotes(String value) {
+    state = state.copyWith(
+      notes: value,
       submissionSuccess: false,
       generalErrorMessage: null,
     );
@@ -238,6 +248,8 @@ class RecurringRuleFormController extends _$RecurringRuleFormController {
         : -parsedAmount!;
     final DateTime now = DateTime.now().toUtc();
     final RecurringRule? existingRule = state.initialRule;
+    final String trimmedNotes = state.notes.trim();
+    final String? noteToPersist = trimmedNotes.isEmpty ? null : trimmedNotes;
     final RecurringRule rule;
     if (existingRule == null) {
       rule = RecurringRule(
@@ -250,7 +262,7 @@ class RecurringRuleFormController extends _$RecurringRuleFormController {
         startAt: startAtUtc,
         timezone: 'Europe/Helsinki',
         rrule: 'FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=${startDate.day}',
-        notes: null,
+        notes: noteToPersist,
         dayOfMonth: startDate.day,
         applyAtLocalHour: state.applyHour,
         applyAtLocalMinute: state.applyMinute,
@@ -279,6 +291,7 @@ class RecurringRuleFormController extends _$RecurringRuleFormController {
         nextDueLocalDate: startDateTimeLocal,
         autoPost: state.autoPost,
         updatedAt: now,
+        notes: noteToPersist,
       );
     }
 

--- a/lib/features/recurring_transactions/presentation/controllers/recurring_rule_form_controller.freezed.dart
+++ b/lib/features/recurring_transactions/presentation/controllers/recurring_rule_form_controller.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$RecurringRuleFormState {
 
- String get title; String get amountInput; AccountEntity? get account; String? get accountId; Category? get category; String? get categoryId; TransactionType get type; DateTime get startDate; int get applyHour; int get applyMinute; bool get autoPost; bool get isSubmitting; bool get submissionSuccess; bool get isEditing; RecurringRule? get initialRule; RecurringRuleTitleError? get titleError; RecurringRuleAmountError? get amountError; RecurringRuleAccountError? get accountError; RecurringRuleCategoryError? get categoryError; String? get generalErrorMessage;
+ String get title; String get amountInput; String get notes; AccountEntity? get account; String? get accountId; Category? get category; String? get categoryId; TransactionType get type; DateTime get startDate; int get applyHour; int get applyMinute; bool get autoPost; bool get isSubmitting; bool get submissionSuccess; bool get isEditing; RecurringRule? get initialRule; RecurringRuleTitleError? get titleError; RecurringRuleAmountError? get amountError; RecurringRuleAccountError? get accountError; RecurringRuleCategoryError? get categoryError; String? get generalErrorMessage;
 /// Create a copy of RecurringRuleFormState
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -25,16 +25,16 @@ $RecurringRuleFormStateCopyWith<RecurringRuleFormState> get copyWith => _$Recurr
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is RecurringRuleFormState&&(identical(other.title, title) || other.title == title)&&(identical(other.amountInput, amountInput) || other.amountInput == amountInput)&&(identical(other.account, account) || other.account == account)&&(identical(other.accountId, accountId) || other.accountId == accountId)&&(identical(other.category, category) || other.category == category)&&(identical(other.categoryId, categoryId) || other.categoryId == categoryId)&&(identical(other.type, type) || other.type == type)&&(identical(other.startDate, startDate) || other.startDate == startDate)&&(identical(other.applyHour, applyHour) || other.applyHour == applyHour)&&(identical(other.applyMinute, applyMinute) || other.applyMinute == applyMinute)&&(identical(other.autoPost, autoPost) || other.autoPost == autoPost)&&(identical(other.isSubmitting, isSubmitting) || other.isSubmitting == isSubmitting)&&(identical(other.submissionSuccess, submissionSuccess) || other.submissionSuccess == submissionSuccess)&&(identical(other.isEditing, isEditing) || other.isEditing == isEditing)&&(identical(other.initialRule, initialRule) || other.initialRule == initialRule)&&(identical(other.titleError, titleError) || other.titleError == titleError)&&(identical(other.amountError, amountError) || other.amountError == amountError)&&(identical(other.accountError, accountError) || other.accountError == accountError)&&(identical(other.categoryError, categoryError) || other.categoryError == categoryError)&&(identical(other.generalErrorMessage, generalErrorMessage) || other.generalErrorMessage == generalErrorMessage));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RecurringRuleFormState&&(identical(other.title, title) || other.title == title)&&(identical(other.amountInput, amountInput) || other.amountInput == amountInput)&&(identical(other.notes, notes) || other.notes == notes)&&(identical(other.account, account) || other.account == account)&&(identical(other.accountId, accountId) || other.accountId == accountId)&&(identical(other.category, category) || other.category == category)&&(identical(other.categoryId, categoryId) || other.categoryId == categoryId)&&(identical(other.type, type) || other.type == type)&&(identical(other.startDate, startDate) || other.startDate == startDate)&&(identical(other.applyHour, applyHour) || other.applyHour == applyHour)&&(identical(other.applyMinute, applyMinute) || other.applyMinute == applyMinute)&&(identical(other.autoPost, autoPost) || other.autoPost == autoPost)&&(identical(other.isSubmitting, isSubmitting) || other.isSubmitting == isSubmitting)&&(identical(other.submissionSuccess, submissionSuccess) || other.submissionSuccess == submissionSuccess)&&(identical(other.isEditing, isEditing) || other.isEditing == isEditing)&&(identical(other.initialRule, initialRule) || other.initialRule == initialRule)&&(identical(other.titleError, titleError) || other.titleError == titleError)&&(identical(other.amountError, amountError) || other.amountError == amountError)&&(identical(other.accountError, accountError) || other.accountError == accountError)&&(identical(other.categoryError, categoryError) || other.categoryError == categoryError)&&(identical(other.generalErrorMessage, generalErrorMessage) || other.generalErrorMessage == generalErrorMessage));
 }
 
 
 @override
-int get hashCode => Object.hashAll([runtimeType,title,amountInput,account,accountId,category,categoryId,type,startDate,applyHour,applyMinute,autoPost,isSubmitting,submissionSuccess,isEditing,initialRule,titleError,amountError,accountError,categoryError,generalErrorMessage]);
+int get hashCode => Object.hashAll([runtimeType,title,amountInput,notes,account,accountId,category,categoryId,type,startDate,applyHour,applyMinute,autoPost,isSubmitting,submissionSuccess,isEditing,initialRule,titleError,amountError,accountError,categoryError,generalErrorMessage]);
 
 @override
 String toString() {
-  return 'RecurringRuleFormState(title: $title, amountInput: $amountInput, account: $account, accountId: $accountId, category: $category, categoryId: $categoryId, type: $type, startDate: $startDate, applyHour: $applyHour, applyMinute: $applyMinute, autoPost: $autoPost, isSubmitting: $isSubmitting, submissionSuccess: $submissionSuccess, isEditing: $isEditing, initialRule: $initialRule, titleError: $titleError, amountError: $amountError, accountError: $accountError, categoryError: $categoryError, generalErrorMessage: $generalErrorMessage)';
+  return 'RecurringRuleFormState(title: $title, amountInput: $amountInput, notes: $notes, account: $account, accountId: $accountId, category: $category, categoryId: $categoryId, type: $type, startDate: $startDate, applyHour: $applyHour, applyMinute: $applyMinute, autoPost: $autoPost, isSubmitting: $isSubmitting, submissionSuccess: $submissionSuccess, isEditing: $isEditing, initialRule: $initialRule, titleError: $titleError, amountError: $amountError, accountError: $accountError, categoryError: $categoryError, generalErrorMessage: $generalErrorMessage)';
 }
 
 
@@ -45,7 +45,7 @@ abstract mixin class $RecurringRuleFormStateCopyWith<$Res>  {
   factory $RecurringRuleFormStateCopyWith(RecurringRuleFormState value, $Res Function(RecurringRuleFormState) _then) = _$RecurringRuleFormStateCopyWithImpl;
 @useResult
 $Res call({
- String title, String amountInput, AccountEntity? account, String? accountId, Category? category, String? categoryId, TransactionType type, DateTime startDate, int applyHour, int applyMinute, bool autoPost, bool isSubmitting, bool submissionSuccess, bool isEditing, RecurringRule? initialRule, RecurringRuleTitleError? titleError, RecurringRuleAmountError? amountError, RecurringRuleAccountError? accountError, RecurringRuleCategoryError? categoryError, String? generalErrorMessage
+ String title, String amountInput, String notes, AccountEntity? account, String? accountId, Category? category, String? categoryId, TransactionType type, DateTime startDate, int applyHour, int applyMinute, bool autoPost, bool isSubmitting, bool submissionSuccess, bool isEditing, RecurringRule? initialRule, RecurringRuleTitleError? titleError, RecurringRuleAmountError? amountError, RecurringRuleAccountError? accountError, RecurringRuleCategoryError? categoryError, String? generalErrorMessage
 });
 
 
@@ -62,10 +62,11 @@ class _$RecurringRuleFormStateCopyWithImpl<$Res>
 
 /// Create a copy of RecurringRuleFormState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? title = null,Object? amountInput = null,Object? account = freezed,Object? accountId = freezed,Object? category = freezed,Object? categoryId = freezed,Object? type = null,Object? startDate = null,Object? applyHour = null,Object? applyMinute = null,Object? autoPost = null,Object? isSubmitting = null,Object? submissionSuccess = null,Object? isEditing = null,Object? initialRule = freezed,Object? titleError = freezed,Object? amountError = freezed,Object? accountError = freezed,Object? categoryError = freezed,Object? generalErrorMessage = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? title = null,Object? amountInput = null,Object? notes = null,Object? account = freezed,Object? accountId = freezed,Object? category = freezed,Object? categoryId = freezed,Object? type = null,Object? startDate = null,Object? applyHour = null,Object? applyMinute = null,Object? autoPost = null,Object? isSubmitting = null,Object? submissionSuccess = null,Object? isEditing = null,Object? initialRule = freezed,Object? titleError = freezed,Object? amountError = freezed,Object? accountError = freezed,Object? categoryError = freezed,Object? generalErrorMessage = freezed,}) {
   return _then(_self.copyWith(
 title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
 as String,amountInput: null == amountInput ? _self.amountInput : amountInput // ignore: cast_nullable_to_non_nullable
+as String,notes: null == notes ? _self.notes : notes // ignore: cast_nullable_to_non_nullable
 as String,account: freezed == account ? _self.account : account // ignore: cast_nullable_to_non_nullable
 as AccountEntity?,accountId: freezed == accountId ? _self.accountId : accountId // ignore: cast_nullable_to_non_nullable
 as String?,category: freezed == category ? _self.category : category // ignore: cast_nullable_to_non_nullable
@@ -205,10 +206,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String title,  String amountInput,  AccountEntity? account,  String? accountId,  Category? category,  String? categoryId,  TransactionType type,  DateTime startDate,  int applyHour,  int applyMinute,  bool autoPost,  bool isSubmitting,  bool submissionSuccess,  bool isEditing,  RecurringRule? initialRule,  RecurringRuleTitleError? titleError,  RecurringRuleAmountError? amountError,  RecurringRuleAccountError? accountError,  RecurringRuleCategoryError? categoryError,  String? generalErrorMessage)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String title,  String amountInput,  String notes,  AccountEntity? account,  String? accountId,  Category? category,  String? categoryId,  TransactionType type,  DateTime startDate,  int applyHour,  int applyMinute,  bool autoPost,  bool isSubmitting,  bool submissionSuccess,  bool isEditing,  RecurringRule? initialRule,  RecurringRuleTitleError? titleError,  RecurringRuleAmountError? amountError,  RecurringRuleAccountError? accountError,  RecurringRuleCategoryError? categoryError,  String? generalErrorMessage)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _RecurringRuleFormState() when $default != null:
-return $default(_that.title,_that.amountInput,_that.account,_that.accountId,_that.category,_that.categoryId,_that.type,_that.startDate,_that.applyHour,_that.applyMinute,_that.autoPost,_that.isSubmitting,_that.submissionSuccess,_that.isEditing,_that.initialRule,_that.titleError,_that.amountError,_that.accountError,_that.categoryError,_that.generalErrorMessage);case _:
+return $default(_that.title,_that.amountInput,_that.notes,_that.account,_that.accountId,_that.category,_that.categoryId,_that.type,_that.startDate,_that.applyHour,_that.applyMinute,_that.autoPost,_that.isSubmitting,_that.submissionSuccess,_that.isEditing,_that.initialRule,_that.titleError,_that.amountError,_that.accountError,_that.categoryError,_that.generalErrorMessage);case _:
   return orElse();
 
 }
@@ -226,10 +227,10 @@ return $default(_that.title,_that.amountInput,_that.account,_that.accountId,_tha
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String title,  String amountInput,  AccountEntity? account,  String? accountId,  Category? category,  String? categoryId,  TransactionType type,  DateTime startDate,  int applyHour,  int applyMinute,  bool autoPost,  bool isSubmitting,  bool submissionSuccess,  bool isEditing,  RecurringRule? initialRule,  RecurringRuleTitleError? titleError,  RecurringRuleAmountError? amountError,  RecurringRuleAccountError? accountError,  RecurringRuleCategoryError? categoryError,  String? generalErrorMessage)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String title,  String amountInput,  String notes,  AccountEntity? account,  String? accountId,  Category? category,  String? categoryId,  TransactionType type,  DateTime startDate,  int applyHour,  int applyMinute,  bool autoPost,  bool isSubmitting,  bool submissionSuccess,  bool isEditing,  RecurringRule? initialRule,  RecurringRuleTitleError? titleError,  RecurringRuleAmountError? amountError,  RecurringRuleAccountError? accountError,  RecurringRuleCategoryError? categoryError,  String? generalErrorMessage)  $default,) {final _that = this;
 switch (_that) {
 case _RecurringRuleFormState():
-return $default(_that.title,_that.amountInput,_that.account,_that.accountId,_that.category,_that.categoryId,_that.type,_that.startDate,_that.applyHour,_that.applyMinute,_that.autoPost,_that.isSubmitting,_that.submissionSuccess,_that.isEditing,_that.initialRule,_that.titleError,_that.amountError,_that.accountError,_that.categoryError,_that.generalErrorMessage);case _:
+return $default(_that.title,_that.amountInput,_that.notes,_that.account,_that.accountId,_that.category,_that.categoryId,_that.type,_that.startDate,_that.applyHour,_that.applyMinute,_that.autoPost,_that.isSubmitting,_that.submissionSuccess,_that.isEditing,_that.initialRule,_that.titleError,_that.amountError,_that.accountError,_that.categoryError,_that.generalErrorMessage);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -246,10 +247,10 @@ return $default(_that.title,_that.amountInput,_that.account,_that.accountId,_tha
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String title,  String amountInput,  AccountEntity? account,  String? accountId,  Category? category,  String? categoryId,  TransactionType type,  DateTime startDate,  int applyHour,  int applyMinute,  bool autoPost,  bool isSubmitting,  bool submissionSuccess,  bool isEditing,  RecurringRule? initialRule,  RecurringRuleTitleError? titleError,  RecurringRuleAmountError? amountError,  RecurringRuleAccountError? accountError,  RecurringRuleCategoryError? categoryError,  String? generalErrorMessage)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String title,  String amountInput,  String notes,  AccountEntity? account,  String? accountId,  Category? category,  String? categoryId,  TransactionType type,  DateTime startDate,  int applyHour,  int applyMinute,  bool autoPost,  bool isSubmitting,  bool submissionSuccess,  bool isEditing,  RecurringRule? initialRule,  RecurringRuleTitleError? titleError,  RecurringRuleAmountError? amountError,  RecurringRuleAccountError? accountError,  RecurringRuleCategoryError? categoryError,  String? generalErrorMessage)?  $default,) {final _that = this;
 switch (_that) {
 case _RecurringRuleFormState() when $default != null:
-return $default(_that.title,_that.amountInput,_that.account,_that.accountId,_that.category,_that.categoryId,_that.type,_that.startDate,_that.applyHour,_that.applyMinute,_that.autoPost,_that.isSubmitting,_that.submissionSuccess,_that.isEditing,_that.initialRule,_that.titleError,_that.amountError,_that.accountError,_that.categoryError,_that.generalErrorMessage);case _:
+return $default(_that.title,_that.amountInput,_that.notes,_that.account,_that.accountId,_that.category,_that.categoryId,_that.type,_that.startDate,_that.applyHour,_that.applyMinute,_that.autoPost,_that.isSubmitting,_that.submissionSuccess,_that.isEditing,_that.initialRule,_that.titleError,_that.amountError,_that.accountError,_that.categoryError,_that.generalErrorMessage);case _:
   return null;
 
 }
@@ -261,11 +262,12 @@ return $default(_that.title,_that.amountInput,_that.account,_that.accountId,_tha
 
 
 class _RecurringRuleFormState extends RecurringRuleFormState {
-  const _RecurringRuleFormState({this.title = '', this.amountInput = '', this.account, this.accountId, this.category, this.categoryId, this.type = TransactionType.expense, required this.startDate, this.applyHour = 0, this.applyMinute = 0, this.autoPost = false, this.isSubmitting = false, this.submissionSuccess = false, this.isEditing = false, this.initialRule, this.titleError, this.amountError, this.accountError, this.categoryError, this.generalErrorMessage}): super._();
+  const _RecurringRuleFormState({this.title = '', this.amountInput = '', this.notes = '', this.account, this.accountId, this.category, this.categoryId, this.type = TransactionType.expense, required this.startDate, this.applyHour = 0, this.applyMinute = 0, this.autoPost = false, this.isSubmitting = false, this.submissionSuccess = false, this.isEditing = false, this.initialRule, this.titleError, this.amountError, this.accountError, this.categoryError, this.generalErrorMessage}): super._();
   
 
 @override@JsonKey() final  String title;
 @override@JsonKey() final  String amountInput;
+@override@JsonKey() final  String notes;
 @override final  AccountEntity? account;
 @override final  String? accountId;
 @override final  Category? category;
@@ -295,16 +297,16 @@ _$RecurringRuleFormStateCopyWith<_RecurringRuleFormState> get copyWith => __$Rec
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _RecurringRuleFormState&&(identical(other.title, title) || other.title == title)&&(identical(other.amountInput, amountInput) || other.amountInput == amountInput)&&(identical(other.account, account) || other.account == account)&&(identical(other.accountId, accountId) || other.accountId == accountId)&&(identical(other.category, category) || other.category == category)&&(identical(other.categoryId, categoryId) || other.categoryId == categoryId)&&(identical(other.type, type) || other.type == type)&&(identical(other.startDate, startDate) || other.startDate == startDate)&&(identical(other.applyHour, applyHour) || other.applyHour == applyHour)&&(identical(other.applyMinute, applyMinute) || other.applyMinute == applyMinute)&&(identical(other.autoPost, autoPost) || other.autoPost == autoPost)&&(identical(other.isSubmitting, isSubmitting) || other.isSubmitting == isSubmitting)&&(identical(other.submissionSuccess, submissionSuccess) || other.submissionSuccess == submissionSuccess)&&(identical(other.isEditing, isEditing) || other.isEditing == isEditing)&&(identical(other.initialRule, initialRule) || other.initialRule == initialRule)&&(identical(other.titleError, titleError) || other.titleError == titleError)&&(identical(other.amountError, amountError) || other.amountError == amountError)&&(identical(other.accountError, accountError) || other.accountError == accountError)&&(identical(other.categoryError, categoryError) || other.categoryError == categoryError)&&(identical(other.generalErrorMessage, generalErrorMessage) || other.generalErrorMessage == generalErrorMessage));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _RecurringRuleFormState&&(identical(other.title, title) || other.title == title)&&(identical(other.amountInput, amountInput) || other.amountInput == amountInput)&&(identical(other.notes, notes) || other.notes == notes)&&(identical(other.account, account) || other.account == account)&&(identical(other.accountId, accountId) || other.accountId == accountId)&&(identical(other.category, category) || other.category == category)&&(identical(other.categoryId, categoryId) || other.categoryId == categoryId)&&(identical(other.type, type) || other.type == type)&&(identical(other.startDate, startDate) || other.startDate == startDate)&&(identical(other.applyHour, applyHour) || other.applyHour == applyHour)&&(identical(other.applyMinute, applyMinute) || other.applyMinute == applyMinute)&&(identical(other.autoPost, autoPost) || other.autoPost == autoPost)&&(identical(other.isSubmitting, isSubmitting) || other.isSubmitting == isSubmitting)&&(identical(other.submissionSuccess, submissionSuccess) || other.submissionSuccess == submissionSuccess)&&(identical(other.isEditing, isEditing) || other.isEditing == isEditing)&&(identical(other.initialRule, initialRule) || other.initialRule == initialRule)&&(identical(other.titleError, titleError) || other.titleError == titleError)&&(identical(other.amountError, amountError) || other.amountError == amountError)&&(identical(other.accountError, accountError) || other.accountError == accountError)&&(identical(other.categoryError, categoryError) || other.categoryError == categoryError)&&(identical(other.generalErrorMessage, generalErrorMessage) || other.generalErrorMessage == generalErrorMessage));
 }
 
 
 @override
-int get hashCode => Object.hashAll([runtimeType,title,amountInput,account,accountId,category,categoryId,type,startDate,applyHour,applyMinute,autoPost,isSubmitting,submissionSuccess,isEditing,initialRule,titleError,amountError,accountError,categoryError,generalErrorMessage]);
+int get hashCode => Object.hashAll([runtimeType,title,amountInput,notes,account,accountId,category,categoryId,type,startDate,applyHour,applyMinute,autoPost,isSubmitting,submissionSuccess,isEditing,initialRule,titleError,amountError,accountError,categoryError,generalErrorMessage]);
 
 @override
 String toString() {
-  return 'RecurringRuleFormState(title: $title, amountInput: $amountInput, account: $account, accountId: $accountId, category: $category, categoryId: $categoryId, type: $type, startDate: $startDate, applyHour: $applyHour, applyMinute: $applyMinute, autoPost: $autoPost, isSubmitting: $isSubmitting, submissionSuccess: $submissionSuccess, isEditing: $isEditing, initialRule: $initialRule, titleError: $titleError, amountError: $amountError, accountError: $accountError, categoryError: $categoryError, generalErrorMessage: $generalErrorMessage)';
+  return 'RecurringRuleFormState(title: $title, amountInput: $amountInput, notes: $notes, account: $account, accountId: $accountId, category: $category, categoryId: $categoryId, type: $type, startDate: $startDate, applyHour: $applyHour, applyMinute: $applyMinute, autoPost: $autoPost, isSubmitting: $isSubmitting, submissionSuccess: $submissionSuccess, isEditing: $isEditing, initialRule: $initialRule, titleError: $titleError, amountError: $amountError, accountError: $accountError, categoryError: $categoryError, generalErrorMessage: $generalErrorMessage)';
 }
 
 
@@ -315,7 +317,7 @@ abstract mixin class _$RecurringRuleFormStateCopyWith<$Res> implements $Recurrin
   factory _$RecurringRuleFormStateCopyWith(_RecurringRuleFormState value, $Res Function(_RecurringRuleFormState) _then) = __$RecurringRuleFormStateCopyWithImpl;
 @override @useResult
 $Res call({
- String title, String amountInput, AccountEntity? account, String? accountId, Category? category, String? categoryId, TransactionType type, DateTime startDate, int applyHour, int applyMinute, bool autoPost, bool isSubmitting, bool submissionSuccess, bool isEditing, RecurringRule? initialRule, RecurringRuleTitleError? titleError, RecurringRuleAmountError? amountError, RecurringRuleAccountError? accountError, RecurringRuleCategoryError? categoryError, String? generalErrorMessage
+ String title, String amountInput, String notes, AccountEntity? account, String? accountId, Category? category, String? categoryId, TransactionType type, DateTime startDate, int applyHour, int applyMinute, bool autoPost, bool isSubmitting, bool submissionSuccess, bool isEditing, RecurringRule? initialRule, RecurringRuleTitleError? titleError, RecurringRuleAmountError? amountError, RecurringRuleAccountError? accountError, RecurringRuleCategoryError? categoryError, String? generalErrorMessage
 });
 
 
@@ -332,10 +334,11 @@ class __$RecurringRuleFormStateCopyWithImpl<$Res>
 
 /// Create a copy of RecurringRuleFormState
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? title = null,Object? amountInput = null,Object? account = freezed,Object? accountId = freezed,Object? category = freezed,Object? categoryId = freezed,Object? type = null,Object? startDate = null,Object? applyHour = null,Object? applyMinute = null,Object? autoPost = null,Object? isSubmitting = null,Object? submissionSuccess = null,Object? isEditing = null,Object? initialRule = freezed,Object? titleError = freezed,Object? amountError = freezed,Object? accountError = freezed,Object? categoryError = freezed,Object? generalErrorMessage = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? title = null,Object? amountInput = null,Object? notes = null,Object? account = freezed,Object? accountId = freezed,Object? category = freezed,Object? categoryId = freezed,Object? type = null,Object? startDate = null,Object? applyHour = null,Object? applyMinute = null,Object? autoPost = null,Object? isSubmitting = null,Object? submissionSuccess = null,Object? isEditing = null,Object? initialRule = freezed,Object? titleError = freezed,Object? amountError = freezed,Object? accountError = freezed,Object? categoryError = freezed,Object? generalErrorMessage = freezed,}) {
   return _then(_RecurringRuleFormState(
 title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
 as String,amountInput: null == amountInput ? _self.amountInput : amountInput // ignore: cast_nullable_to_non_nullable
+as String,notes: null == notes ? _self.notes : notes // ignore: cast_nullable_to_non_nullable
 as String,account: freezed == account ? _self.account : account // ignore: cast_nullable_to_non_nullable
 as AccountEntity?,accountId: freezed == accountId ? _self.accountId : accountId // ignore: cast_nullable_to_non_nullable
 as String?,category: freezed == category ? _self.category : category // ignore: cast_nullable_to_non_nullable

--- a/lib/features/recurring_transactions/presentation/controllers/recurring_rule_form_controller.g.dart
+++ b/lib/features/recurring_transactions/presentation/controllers/recurring_rule_form_controller.g.dart
@@ -62,7 +62,7 @@ final class RecurringRuleFormControllerProvider
 }
 
 String _$recurringRuleFormControllerHash() =>
-    r'd20942a348907659efadb858f313874fd88cdfc8';
+    r'9d1dee81c5489b61f2ee4b4370a0491a843a9136';
 
 final class RecurringRuleFormControllerFamily extends $Family
     with

--- a/lib/features/recurring_transactions/presentation/widgets/recurring_rule_form_view.dart
+++ b/lib/features/recurring_transactions/presentation/widgets/recurring_rule_form_view.dart
@@ -196,6 +196,22 @@ class _RecurringRuleForm extends ConsumerWidget {
                 .updateAmount,
           ),
           const SizedBox(height: 16),
+          TextFormField(
+            initialValue: state.notes,
+            maxLines: 3,
+            decoration: InputDecoration(
+              labelText: strings.addRecurringRuleNoteLabel,
+              hintText: strings.addRecurringRuleNoteHint,
+            ),
+            onChanged: ref
+                .read(
+                  recurringRuleFormControllerProvider(
+                    initialRule: initialRule,
+                  ).notifier,
+                )
+                .updateNotes,
+          ),
+          const SizedBox(height: 16),
           InputDecorator(
             decoration: InputDecoration(
               labelText: strings.addRecurringRuleAccountLabel,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -582,6 +582,14 @@
   "@addRecurringRuleAmountInvalid": {
     "description": "Validation error when amount is invalid"
   },
+  "addRecurringRuleNoteLabel": "Note",
+  "@addRecurringRuleNoteLabel": {
+    "description": "Label for the optional note field"
+  },
+  "addRecurringRuleNoteHint": "Optional comment",
+  "@addRecurringRuleNoteHint": {
+    "description": "Hint text for the optional note field"
+  },
   "addRecurringRuleAccountLabel": "Account",
   "@addRecurringRuleAccountLabel": {
     "description": "Label for the account dropdown"
@@ -903,6 +911,10 @@
   "homeBudgetWidgetMissing": "The selected budget is no longer available.",
   "@homeBudgetWidgetMissing": {
     "description": "Error shown when the configured budget was deleted"
+  },
+  "homeBudgetWidgetCategoriesEmpty": "No category breakdown yet.",
+  "@homeBudgetWidgetCategoriesEmpty": {
+    "description": "Message shown when there are no categories to display in the budget widget"
   },
   "homeBudgetWidgetConfigureCta": "Open settings",
   "@homeBudgetWidgetConfigureCta": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -860,6 +860,18 @@ abstract class AppLocalizations {
   /// **'Enter a valid positive amount'**
   String get addRecurringRuleAmountInvalid;
 
+  /// Label for the optional note field
+  ///
+  /// In en, this message translates to:
+  /// **'Note'**
+  String get addRecurringRuleNoteLabel;
+
+  /// Hint for the optional note field
+  ///
+  /// In en, this message translates to:
+  /// **'Optional comment'**
+  String get addRecurringRuleNoteHint;
+
   /// Label for the account dropdown
   ///
   /// In en, this message translates to:
@@ -1267,6 +1279,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'The selected budget is no longer available.'**
   String get homeBudgetWidgetMissing;
+
+  /// Message shown when there are no categories to display in the budget widget
+  ///
+  /// In en, this message translates to:
+  /// **'No category breakdown yet.'**
+  String get homeBudgetWidgetCategoriesEmpty;
 
   /// Button label that opens settings to configure the budget widget
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -427,6 +427,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get addRecurringRuleAmountInvalid => 'Enter a valid positive amount';
 
   @override
+  String get addRecurringRuleNoteLabel => 'Note';
+
+  @override
+  String get addRecurringRuleNoteHint => 'Optional comment';
+
+  @override
   String get addRecurringRuleAccountLabel => 'Account';
 
   @override
@@ -665,6 +671,9 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get homeBudgetWidgetMissing =>
       'The selected budget is no longer available.';
+
+  @override
+  String get homeBudgetWidgetCategoriesEmpty => 'No category breakdown yet.';
 
   @override
   String get homeBudgetWidgetConfigureCta => 'Open settings';

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -429,6 +429,12 @@ class AppLocalizationsRu extends AppLocalizations {
   String get addRecurringRuleAmountInvalid => 'Введите положительную сумму';
 
   @override
+  String get addRecurringRuleNoteLabel => 'Заметка';
+
+  @override
+  String get addRecurringRuleNoteHint => 'Например: напомнить себе';
+
+  @override
   String get addRecurringRuleAccountLabel => 'Счёт';
 
   @override
@@ -668,6 +674,10 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get homeBudgetWidgetMissing => 'Выбранный бюджет недоступен.';
+
+  @override
+  String get homeBudgetWidgetCategoriesEmpty =>
+      'Категорий для анализа пока нет.';
 
   @override
   String get homeBudgetWidgetConfigureCta => 'Открыть настройки';

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -582,6 +582,14 @@
   "@addRecurringRuleAmountInvalid": {
     "description": "Сообщение об ошибке, если сумма некорректна"
   },
+  "addRecurringRuleNoteLabel": "Заметка",
+  "@addRecurringRuleNoteLabel": {
+    "description": "Подпись поля для заметки"
+  },
+  "addRecurringRuleNoteHint": "Например: напомнить себе",
+  "@addRecurringRuleNoteHint": {
+    "description": "Подсказка для необязательной заметки"
+  },
   "addRecurringRuleAccountLabel": "Счёт",
   "@addRecurringRuleAccountLabel": {
     "description": "Подпись выпадающего списка со счетами"
@@ -903,6 +911,10 @@
   "homeBudgetWidgetMissing": "Выбранный бюджет недоступен.",
   "@homeBudgetWidgetMissing": {
     "description": "Ошибка, если сохранённый бюджет удалён"
+  },
+  "homeBudgetWidgetCategoriesEmpty": "Категорий для анализа пока нет.",
+  "@homeBudgetWidgetCategoriesEmpty": {
+    "description": "Сообщение, когда в сводке бюджета нет категорий"
   },
   "homeBudgetWidgetConfigureCta": "Открыть настройки",
   "@homeBudgetWidgetConfigureCta": {

--- a/test/features/home/presentation/widgets/home_gamification_card_test.dart
+++ b/test/features/home/presentation/widgets/home_gamification_card_test.dart
@@ -24,7 +24,14 @@ void main() {
             locale: Locale('en'),
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
-            home: Scaffold(body: HomeGamificationCard(userId: userId)),
+            home: Scaffold(
+              body: Center(
+                child: SizedBox(
+                  height: 320,
+                  child: HomeGamificationCard(userId: userId),
+                ),
+              ),
+            ),
           ),
         ),
       );
@@ -52,14 +59,18 @@ void main() {
         ],
       );
 
-      expect(find.text('Level progress'), findsOneWidget);
-      expect(find.text('Level 2 — Apprentice'), findsOneWidget);
-      expect(find.text('350 XP to the next level'), findsOneWidget);
+      expect(find.textContaining('XP to the next level'), findsOneWidget);
 
       final LinearProgressIndicator indicator = tester.widget(
         find.byType(LinearProgressIndicator),
       );
       expect(indicator.value, closeTo(0.125, 0.001));
+
+      await tester.tap(find.byKey(const Key('homeGamificationCard.toggle')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Level 2 — Apprentice'), findsOneWidget);
+      expect(find.textContaining('Level 2'), findsWidgets);
     });
 
     testWidgets('shows loading indicator while data loads', (

--- a/test/features/recurring_transactions/presentation/controllers/recurring_rule_form_controller_test.dart
+++ b/test/features/recurring_transactions/presentation/controllers/recurring_rule_form_controller_test.dart
@@ -106,6 +106,7 @@ void main() {
     controller.updateStartDate(DateTime(2024, 1, 15));
     controller.updateTime(hour: 10, minute: 30);
     controller.updateAutoPost(true);
+    controller.updateNotes('  Для премии  ');
 
     await controller.submit();
 
@@ -128,6 +129,7 @@ void main() {
     expect(captured.nextDueLocalDate, DateTime(2024, 1, 15, 10, 30));
     expect(captured.createdAt.isUtc, isTrue);
     expect(captured.updatedAt.isUtc, isTrue);
+    expect(captured.notes, 'Для премии');
 
     final RecurringRuleFormState state = container.read(provider);
     expect(state.submissionSuccess, isTrue);
@@ -183,7 +185,9 @@ void main() {
   test('submit updates existing rule when editing', () async {
     when(() => mockUseCase.call(any())).thenAnswer((_) async {});
 
-    final RecurringRule existingRule = _fallbackRule();
+    final RecurringRule existingRule = _fallbackRule().copyWith(
+      notes: 'Предыдущая заметка',
+    );
     final RecurringRuleFormControllerProvider provider =
         recurringRuleFormControllerProvider(initialRule: existingRule);
     final RecurringRuleFormController controller = container.read(
@@ -199,6 +203,7 @@ void main() {
     controller.updateStartDate(DateTime(2024, 2, 5));
     controller.updateTime(hour: 8, minute: 45);
     controller.updateAutoPost(true);
+    controller.updateNotes('  Новая заметка  ');
 
     await controller.submit();
 
@@ -217,6 +222,7 @@ void main() {
     expect(captured.autoPost, isTrue);
     expect(captured.createdAt, existingRule.createdAt);
     expect(captured.updatedAt.isAfter(existingRule.updatedAt), isTrue);
+    expect(captured.notes, 'Новая заметка');
 
     final RecurringRuleFormState state = container.read(provider);
     expect(state.submissionSuccess, isTrue);

--- a/test/features/recurring_transactions/presentation/widgets/recurring_rule_form_view_test.dart
+++ b/test/features/recurring_transactions/presentation/widgets/recurring_rule_form_view_test.dart
@@ -85,7 +85,7 @@ void main() {
       startAt: DateTime(2024, 1, 10, 0, 1),
       timezone: 'Europe/Helsinki',
       rrule: 'FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=10',
-      notes: null,
+      notes: 'Оплатить до 5-го',
       dayOfMonth: 10,
       applyAtLocalHour: 0,
       applyAtLocalMinute: 1,
@@ -167,6 +167,7 @@ void main() {
       recurringRuleFormControllerProvider(initialRule: initialRule),
     );
     expect(initialState.autoPost, isTrue);
+    expect(initialState.notes, 'Оплатить до 5-го');
     expect(find.textContaining(account.name), findsOneWidget);
     expect(find.text(category.name), findsOneWidget);
 
@@ -186,6 +187,7 @@ void main() {
             as RecurringRule;
     expect(captured.autoPost, isFalse);
     expect(captured.categoryId, category.id);
+    expect(captured.notes, 'Оплатить до 5-го');
     expect(result, RecurringRuleFormResult.updated);
   });
 }


### PR DESCRIPTION
## Summary
- переработан виджет геймификации на домашнем экране с мотивационными фразами, расширяемым верхним листом и переходом к профилю
- обновлён виджет бюджета: добавлен переход к деталям и вывод категорий в цветных чипах
- добавлено поле заметки для повторяющихся операций и поддержка во всех формах, контроллерах и локализациях

## Testing
- `dart format --set-exit-if-changed .`
- `flutter analyze`
- `dart run build_runner build --delete-conflicting-outputs`
- `flutter test --reporter expanded`
- `flutter pub outdated`


------
https://chatgpt.com/codex/tasks/task_e_68e551134c04832ea23263ffa9d55036