### PR TITLE
Перенос прогресс-блока в SliverPersistentHeader

### DIFF
--- a/test/features/home/presentation/widgets/home_gamification_app_bar_test.dart
+++ b/test/features/home/presentation/widgets/home_gamification_app_bar_test.dart
@@ -96,10 +96,11 @@ void main() {
       await tester.drag(find.byType(CustomScrollView), const Offset(0, -400));
       await tester.pumpAndSettle();
 
-      final Opacity collapsedOpacity = tester.widget(
+      expect(
         find.byKey(const Key('homeGamification.progressOpacity')),
+        findsNothing,
       );
-      expect(collapsedOpacity.opacity, equals(0));
+      expect(find.byType(LinearProgressIndicator), findsNothing);
     });
 
     testWidgets('shows loading indicator while data loads', (


### PR DESCRIPTION
## Summary
- вынес блок прогресса HomeGamificationAppBar в отдельный SliverPersistentHeader с высотой 0-140 и отключённым pinning
- настроил SliverAppBar на высоты 56/130 с FlexibleSpaceBar для приветственной фразы
- обновил widget-тест, чтобы он проверял отсутствие прогресса после сворачивания

## Testing
- dart format --set-exit-if-changed .
- flutter analyze
- dart run build_runner build --delete-conflicting-outputs
- flutter test --reporter expanded
- flutter pub outdated

------
https://chatgpt.com/codex/tasks/task_e_68e579c7b768832e9aa83b51a005e90c