### PR TITLE
fix: вернуть верхний safe area на домашнем экране

### DIFF
--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -54,7 +54,6 @@ NavigationTabContent buildHomeTabContent(BuildContext context, WidgetRef ref) {
 
   return NavigationTabContent(
     bodyBuilder: (BuildContext context, WidgetRef ref) => SafeArea(
-      top: false,
       child: _HomeBody(
         authState: authState,
         accountsAsync: accountsAsync,


### PR DESCRIPTION
## Summary
- восстановил верхний отступ SafeArea для всего домашнего скролла, чтобы SliverAppBar и контент не перекрывались статус-баром

## Testing
- не запускались (не требовались)


------
https://chatgpt.com/codex/tasks/task_e_68e5816ad220832e88a11221a425faa1