### PR TITLE
Ограничение высоты прогресс-хедера

### DIFF
--- a/lib/features/home/presentation/widgets/home_gamification_app_bar.dart
+++ b/lib/features/home/presentation/widgets/home_gamification_app_bar.dart
@@ -199,19 +199,32 @@ class _HomeProgressHeaderDelegate extends SliverPersistentHeaderDelegate {
       );
     }
 
-    return SizedBox.expand(
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(20, 0, 20, 12),
-        child: Align(
-          alignment: Alignment.topLeft,
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 520),
-            child: Opacity(
-              key: const Key('homeGamification.progressOpacity'),
-              opacity: opacity,
-              child: Transform.translate(
-                offset: Offset(0, verticalOffset),
-                child: buildProgressSection(),
+    final double availableExtent = math.max(0.0, maxExtent - shrinkOffset);
+    final double heightFactor = availableExtent <= 0
+        ? 0.0
+        : (availableExtent / maxExtent).clamp(0.0, 1.0);
+
+    return ClipRect(
+      child: Align(
+        alignment: Alignment.topLeft,
+        heightFactor: heightFactor,
+        child: SizedBox(
+          height: maxExtent,
+          width: double.infinity,
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(20, 0, 20, 12),
+            child: Align(
+              alignment: Alignment.topLeft,
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 520),
+                child: Opacity(
+                  key: const Key('homeGamification.progressOpacity'),
+                  opacity: opacity,
+                  child: Transform.translate(
+                    offset: Offset(0, verticalOffset),
+                    child: buildProgressSection(),
+                  ),
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
## Summary
- вынес блок прогресса HomeGamificationAppBar в отдельный SliverPersistentHeader с высотой 0-140 и отключённым pinning
- настроил SliverAppBar на высоты 56/130 с FlexibleSpaceBar для приветственной фразы
- обновил widget-тест, чтобы он проверял отсутствие прогресса после сворачивания
- обрезал содержимое прогресс-хедера через ClipRect и Align, чтобы избежать переполнения при сворачивании

## Testing
- dart format lib/features/home/presentation/widgets/home_gamification_app_bar.dart

------
https://chatgpt.com/codex/tasks/task_e_68e58235cdec832ea95ecaeb89864a70