### PR TITLE
Перенос виджета геймификации под апп-бар

### DIFF
--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -351,15 +351,19 @@ class _HomePinnedTitleAppBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
+    final double topPadding = MediaQuery.of(context).padding.top;
 
     return SliverAppBar(
       automaticallyImplyLeading: false,
       floating: false,
-      pinned: true,
+      pinned: false,
       snap: false,
       elevation: 4,
       backgroundColor: theme.colorScheme.surface,
       surfaceTintColor: theme.colorScheme.surfaceTint,
+      toolbarHeight: HomeGamificationAppBar.appBarHeight,
+      collapsedHeight: topPadding + HomeGamificationAppBar.appBarHeight,
+      expandedHeight: topPadding + HomeGamificationAppBar.appBarHeight,
       titleSpacing: 20,
       title: Text(
         'Копим',

--- a/test/features/home/presentation/widgets/home_gamification_app_bar_test.dart
+++ b/test/features/home/presentation/widgets/home_gamification_app_bar_test.dart
@@ -66,14 +66,9 @@ void main() {
         find.byType(LinearProgressIndicator),
       );
       expect(indicator.value, closeTo(0.125, 0.001));
-
-      final Opacity expandedOpacity = tester.widget(
-        find.byKey(const Key('homeGamification.progressOpacity')),
-      );
-      expect(expandedOpacity.opacity, closeTo(1.0, 1e-3));
     });
 
-    testWidgets('collapses progress section when scrolled', (
+    testWidgets('uses fixed heights for app bar and gamification card', (
       WidgetTester tester,
     ) async {
       final UserProgress progress = UserProgress(
@@ -93,14 +88,18 @@ void main() {
         ],
       );
 
-      await tester.drag(find.byType(CustomScrollView), const Offset(0, -400));
-      await tester.pumpAndSettle();
-
-      expect(
-        find.byKey(const Key('homeGamification.progressOpacity')),
-        findsNothing,
+      final SliverAppBar appBar = tester.widget(
+        find.byType(SliverAppBar).first,
       );
-      expect(find.byType(LinearProgressIndicator), findsNothing);
+      expect(appBar.toolbarHeight, HomeGamificationAppBar.appBarHeight);
+
+      final Finder cardHeightFinder = find.byWidgetPredicate(
+        (Widget widget) =>
+            widget is SizedBox &&
+            widget.height == HomeGamificationAppBar.gamificationHeight,
+      );
+
+      expect(cardHeightFinder, findsOneWidget);
     });
 
     testWidgets('shows loading indicator while data loads', (


### PR DESCRIPTION
## Summary
- вынес виджет геймификации из flexible space апп-бара в отдельный блок под ним и задал фиксированную высоту 80 px
- уменьшил высоту апп-бара до 40 px и отключил его закрепление для главного экрана
- обновил виджет-тесты под новую структуру и проверки размеров

## Testing
- dart format --set-exit-if-changed .
- flutter analyze
- dart run build_runner build --delete-conflicting-outputs
- flutter test --reporter expanded
- flutter pub outdated

------
https://chatgpt.com/codex/tasks/task_e_68e5846795e4832ea28d326bad098108