### PR TITLE
Добавление виджета накоплений и обновление домашнего экрана

### DIFF
--- a/lib/features/home/domain/entities/home_dashboard_preferences.dart
+++ b/lib/features/home/domain/entities/home_dashboard_preferences.dart
@@ -9,6 +9,7 @@ abstract class HomeDashboardPreferences with _$HomeDashboardPreferences {
     @Default(false) bool showGamificationWidget,
     @Default(false) bool showBudgetWidget,
     @Default(false) bool showRecurringWidget,
+    @Default(false) bool showSavingsWidget,
     String? budgetId,
   }) = _HomeDashboardPreferences;
 

--- a/lib/features/home/domain/entities/home_dashboard_preferences.freezed.dart
+++ b/lib/features/home/domain/entities/home_dashboard_preferences.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$HomeDashboardPreferences {
 
- bool get showGamificationWidget; bool get showBudgetWidget; bool get showRecurringWidget; String? get budgetId;
+ bool get showGamificationWidget; bool get showBudgetWidget; bool get showRecurringWidget; bool get showSavingsWidget; String? get budgetId;
 /// Create a copy of HomeDashboardPreferences
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $HomeDashboardPreferencesCopyWith<HomeDashboardPreferences> get copyWith => _$Ho
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is HomeDashboardPreferences&&(identical(other.showGamificationWidget, showGamificationWidget) || other.showGamificationWidget == showGamificationWidget)&&(identical(other.showBudgetWidget, showBudgetWidget) || other.showBudgetWidget == showBudgetWidget)&&(identical(other.showRecurringWidget, showRecurringWidget) || other.showRecurringWidget == showRecurringWidget)&&(identical(other.budgetId, budgetId) || other.budgetId == budgetId));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is HomeDashboardPreferences&&(identical(other.showGamificationWidget, showGamificationWidget) || other.showGamificationWidget == showGamificationWidget)&&(identical(other.showBudgetWidget, showBudgetWidget) || other.showBudgetWidget == showBudgetWidget)&&(identical(other.showRecurringWidget, showRecurringWidget) || other.showRecurringWidget == showRecurringWidget)&&(identical(other.showSavingsWidget, showSavingsWidget) || other.showSavingsWidget == showSavingsWidget)&&(identical(other.budgetId, budgetId) || other.budgetId == budgetId));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,showGamificationWidget,showBudgetWidget,showRecurringWidget,budgetId);
+int get hashCode => Object.hash(runtimeType,showGamificationWidget,showBudgetWidget,showRecurringWidget,showSavingsWidget,budgetId);
 
 @override
 String toString() {
-  return 'HomeDashboardPreferences(showGamificationWidget: $showGamificationWidget, showBudgetWidget: $showBudgetWidget, showRecurringWidget: $showRecurringWidget, budgetId: $budgetId)';
+  return 'HomeDashboardPreferences(showGamificationWidget: $showGamificationWidget, showBudgetWidget: $showBudgetWidget, showRecurringWidget: $showRecurringWidget, showSavingsWidget: $showSavingsWidget, budgetId: $budgetId)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $HomeDashboardPreferencesCopyWith<$Res>  {
   factory $HomeDashboardPreferencesCopyWith(HomeDashboardPreferences value, $Res Function(HomeDashboardPreferences) _then) = _$HomeDashboardPreferencesCopyWithImpl;
 @useResult
 $Res call({
- bool showGamificationWidget, bool showBudgetWidget, bool showRecurringWidget, String? budgetId
+ bool showGamificationWidget, bool showBudgetWidget, bool showRecurringWidget, bool showSavingsWidget, String? budgetId
 });
 
 
@@ -65,11 +65,12 @@ class _$HomeDashboardPreferencesCopyWithImpl<$Res>
 
 /// Create a copy of HomeDashboardPreferences
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? showGamificationWidget = null,Object? showBudgetWidget = null,Object? showRecurringWidget = null,Object? budgetId = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? showGamificationWidget = null,Object? showBudgetWidget = null,Object? showRecurringWidget = null,Object? showSavingsWidget = null,Object? budgetId = freezed,}) {
   return _then(_self.copyWith(
 showGamificationWidget: null == showGamificationWidget ? _self.showGamificationWidget : showGamificationWidget // ignore: cast_nullable_to_non_nullable
 as bool,showBudgetWidget: null == showBudgetWidget ? _self.showBudgetWidget : showBudgetWidget // ignore: cast_nullable_to_non_nullable
 as bool,showRecurringWidget: null == showRecurringWidget ? _self.showRecurringWidget : showRecurringWidget // ignore: cast_nullable_to_non_nullable
+as bool,showSavingsWidget: null == showSavingsWidget ? _self.showSavingsWidget : showSavingsWidget // ignore: cast_nullable_to_non_nullable
 as bool,budgetId: freezed == budgetId ? _self.budgetId : budgetId // ignore: cast_nullable_to_non_nullable
 as String?,
   ));
@@ -156,10 +157,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool showGamificationWidget,  bool showBudgetWidget,  bool showRecurringWidget,  String? budgetId)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool showGamificationWidget,  bool showBudgetWidget,  bool showRecurringWidget,  bool showSavingsWidget,  String? budgetId)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _HomeDashboardPreferences() when $default != null:
-return $default(_that.showGamificationWidget,_that.showBudgetWidget,_that.showRecurringWidget,_that.budgetId);case _:
+return $default(_that.showGamificationWidget,_that.showBudgetWidget,_that.showRecurringWidget,_that.showSavingsWidget,_that.budgetId);case _:
   return orElse();
 
 }
@@ -177,10 +178,10 @@ return $default(_that.showGamificationWidget,_that.showBudgetWidget,_that.showRe
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool showGamificationWidget,  bool showBudgetWidget,  bool showRecurringWidget,  String? budgetId)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool showGamificationWidget,  bool showBudgetWidget,  bool showRecurringWidget,  bool showSavingsWidget,  String? budgetId)  $default,) {final _that = this;
 switch (_that) {
 case _HomeDashboardPreferences():
-return $default(_that.showGamificationWidget,_that.showBudgetWidget,_that.showRecurringWidget,_that.budgetId);case _:
+return $default(_that.showGamificationWidget,_that.showBudgetWidget,_that.showRecurringWidget,_that.showSavingsWidget,_that.budgetId);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -197,10 +198,10 @@ return $default(_that.showGamificationWidget,_that.showBudgetWidget,_that.showRe
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool showGamificationWidget,  bool showBudgetWidget,  bool showRecurringWidget,  String? budgetId)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool showGamificationWidget,  bool showBudgetWidget,  bool showRecurringWidget,  bool showSavingsWidget,  String? budgetId)?  $default,) {final _that = this;
 switch (_that) {
 case _HomeDashboardPreferences() when $default != null:
-return $default(_that.showGamificationWidget,_that.showBudgetWidget,_that.showRecurringWidget,_that.budgetId);case _:
+return $default(_that.showGamificationWidget,_that.showBudgetWidget,_that.showRecurringWidget,_that.showSavingsWidget,_that.budgetId);case _:
   return null;
 
 }
@@ -212,12 +213,13 @@ return $default(_that.showGamificationWidget,_that.showBudgetWidget,_that.showRe
 @JsonSerializable()
 
 class _HomeDashboardPreferences implements HomeDashboardPreferences {
-  const _HomeDashboardPreferences({this.showGamificationWidget = false, this.showBudgetWidget = false, this.showRecurringWidget = false, this.budgetId});
+  const _HomeDashboardPreferences({this.showGamificationWidget = false, this.showBudgetWidget = false, this.showRecurringWidget = false, this.showSavingsWidget = false, this.budgetId});
   factory _HomeDashboardPreferences.fromJson(Map<String, dynamic> json) => _$HomeDashboardPreferencesFromJson(json);
 
 @override@JsonKey() final  bool showGamificationWidget;
 @override@JsonKey() final  bool showBudgetWidget;
 @override@JsonKey() final  bool showRecurringWidget;
+@override@JsonKey() final  bool showSavingsWidget;
 @override final  String? budgetId;
 
 /// Create a copy of HomeDashboardPreferences
@@ -233,16 +235,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _HomeDashboardPreferences&&(identical(other.showGamificationWidget, showGamificationWidget) || other.showGamificationWidget == showGamificationWidget)&&(identical(other.showBudgetWidget, showBudgetWidget) || other.showBudgetWidget == showBudgetWidget)&&(identical(other.showRecurringWidget, showRecurringWidget) || other.showRecurringWidget == showRecurringWidget)&&(identical(other.budgetId, budgetId) || other.budgetId == budgetId));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _HomeDashboardPreferences&&(identical(other.showGamificationWidget, showGamificationWidget) || other.showGamificationWidget == showGamificationWidget)&&(identical(other.showBudgetWidget, showBudgetWidget) || other.showBudgetWidget == showBudgetWidget)&&(identical(other.showRecurringWidget, showRecurringWidget) || other.showRecurringWidget == showRecurringWidget)&&(identical(other.showSavingsWidget, showSavingsWidget) || other.showSavingsWidget == showSavingsWidget)&&(identical(other.budgetId, budgetId) || other.budgetId == budgetId));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,showGamificationWidget,showBudgetWidget,showRecurringWidget,budgetId);
+int get hashCode => Object.hash(runtimeType,showGamificationWidget,showBudgetWidget,showRecurringWidget,showSavingsWidget,budgetId);
 
 @override
 String toString() {
-  return 'HomeDashboardPreferences(showGamificationWidget: $showGamificationWidget, showBudgetWidget: $showBudgetWidget, showRecurringWidget: $showRecurringWidget, budgetId: $budgetId)';
+  return 'HomeDashboardPreferences(showGamificationWidget: $showGamificationWidget, showBudgetWidget: $showBudgetWidget, showRecurringWidget: $showRecurringWidget, showSavingsWidget: $showSavingsWidget, budgetId: $budgetId)';
 }
 
 
@@ -253,7 +255,7 @@ abstract mixin class _$HomeDashboardPreferencesCopyWith<$Res> implements $HomeDa
   factory _$HomeDashboardPreferencesCopyWith(_HomeDashboardPreferences value, $Res Function(_HomeDashboardPreferences) _then) = __$HomeDashboardPreferencesCopyWithImpl;
 @override @useResult
 $Res call({
- bool showGamificationWidget, bool showBudgetWidget, bool showRecurringWidget, String? budgetId
+ bool showGamificationWidget, bool showBudgetWidget, bool showRecurringWidget, bool showSavingsWidget, String? budgetId
 });
 
 
@@ -270,11 +272,12 @@ class __$HomeDashboardPreferencesCopyWithImpl<$Res>
 
 /// Create a copy of HomeDashboardPreferences
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? showGamificationWidget = null,Object? showBudgetWidget = null,Object? showRecurringWidget = null,Object? budgetId = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? showGamificationWidget = null,Object? showBudgetWidget = null,Object? showRecurringWidget = null,Object? showSavingsWidget = null,Object? budgetId = freezed,}) {
   return _then(_HomeDashboardPreferences(
 showGamificationWidget: null == showGamificationWidget ? _self.showGamificationWidget : showGamificationWidget // ignore: cast_nullable_to_non_nullable
 as bool,showBudgetWidget: null == showBudgetWidget ? _self.showBudgetWidget : showBudgetWidget // ignore: cast_nullable_to_non_nullable
 as bool,showRecurringWidget: null == showRecurringWidget ? _self.showRecurringWidget : showRecurringWidget // ignore: cast_nullable_to_non_nullable
+as bool,showSavingsWidget: null == showSavingsWidget ? _self.showSavingsWidget : showSavingsWidget // ignore: cast_nullable_to_non_nullable
 as bool,budgetId: freezed == budgetId ? _self.budgetId : budgetId // ignore: cast_nullable_to_non_nullable
 as String?,
   ));

--- a/lib/features/home/domain/entities/home_dashboard_preferences.g.dart
+++ b/lib/features/home/domain/entities/home_dashboard_preferences.g.dart
@@ -12,6 +12,7 @@ _HomeDashboardPreferences _$HomeDashboardPreferencesFromJson(
   showGamificationWidget: json['showGamificationWidget'] as bool? ?? false,
   showBudgetWidget: json['showBudgetWidget'] as bool? ?? false,
   showRecurringWidget: json['showRecurringWidget'] as bool? ?? false,
+  showSavingsWidget: json['showSavingsWidget'] as bool? ?? false,
   budgetId: json['budgetId'] as String?,
 );
 
@@ -21,5 +22,6 @@ Map<String, dynamic> _$HomeDashboardPreferencesToJson(
   'showGamificationWidget': instance.showGamificationWidget,
   'showBudgetWidget': instance.showBudgetWidget,
   'showRecurringWidget': instance.showRecurringWidget,
+  'showSavingsWidget': instance.showSavingsWidget,
   'budgetId': instance.budgetId,
 };

--- a/lib/features/home/presentation/controllers/home_dashboard_preferences_controller.dart
+++ b/lib/features/home/presentation/controllers/home_dashboard_preferences_controller.dart
@@ -43,6 +43,14 @@ class HomeDashboardPreferencesController
     await _persist(updated, previous: current);
   }
 
+  Future<void> setShowSavings(bool value) async {
+    final HomeDashboardPreferences current = await future;
+    final HomeDashboardPreferences updated = current.copyWith(
+      showSavingsWidget: value,
+    );
+    await _persist(updated, previous: current);
+  }
+
   Future<void> setBudgetId(String? budgetId) async {
     final HomeDashboardPreferences current = await future;
     final HomeDashboardPreferences updated = current.copyWith(

--- a/lib/features/home/presentation/controllers/home_dashboard_preferences_controller.g.dart
+++ b/lib/features/home/presentation/controllers/home_dashboard_preferences_controller.g.dart
@@ -41,7 +41,7 @@ final class HomeDashboardPreferencesControllerProvider
 }
 
 String _$homeDashboardPreferencesControllerHash() =>
-    r'de1525ec13d42d4b0459a7f0a7f56b005ff88e25';
+    r'f76223c85b53a96770755a943d73913f414686f4';
 
 abstract class _$HomeDashboardPreferencesController
     extends $AsyncNotifier<HomeDashboardPreferences> {

--- a/lib/features/home/presentation/controllers/home_providers.dart
+++ b/lib/features/home/presentation/controllers/home_providers.dart
@@ -10,6 +10,8 @@ import 'package:kopim/features/home/domain/use_cases/group_transactions_by_day_u
 import 'package:kopim/features/home/domain/use_cases/watch_upcoming_payments_use_case.dart';
 import 'package:kopim/features/home/presentation/controllers/home_transactions_filter_controller.dart';
 import 'package:kopim/features/recurring_transactions/domain/entities/recurring_rule.dart';
+import 'package:kopim/features/savings/domain/entities/saving_goal.dart';
+import 'package:kopim/features/savings/domain/value_objects/goal_progress.dart';
 import 'package:kopim/features/transactions/domain/entities/transaction.dart';
 import 'package:kopim/features/transactions/domain/entities/transaction_type.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -80,6 +82,25 @@ Stream<List<UpcomingPayment>> homeUpcomingPayments(Ref ref) {
   final DateTime now = DateTime.now();
   final DateTime end = now.add(const Duration(days: 30));
   return useCase(from: now, to: end);
+}
+
+@riverpod
+Stream<List<SavingGoal>> homeSavingGoals(Ref ref) {
+  return ref
+      .watch(watchSavingGoalsUseCaseProvider)
+      .call(includeArchived: false);
+}
+
+@riverpod
+AsyncValue<List<GoalProgress>> homeSavingGoalProgress(Ref ref) {
+  return ref
+      .watch(homeSavingGoalsProvider)
+      .whenData(
+        (List<SavingGoal> goals) => goals
+            .where((SavingGoal goal) => !goal.isArchived)
+            .map(GoalProgress.fromGoal)
+            .toList(growable: false),
+      );
 }
 
 @riverpod

--- a/lib/features/home/presentation/controllers/home_providers.g.dart
+++ b/lib/features/home/presentation/controllers/home_providers.g.dart
@@ -491,6 +491,95 @@ final class HomeUpcomingPaymentsProvider
 String _$homeUpcomingPaymentsHash() =>
     r'ade3465651c1d76a203ad59f06a4f7fdf8e8b833';
 
+@ProviderFor(homeSavingGoals)
+const homeSavingGoalsProvider = HomeSavingGoalsProvider._();
+
+final class HomeSavingGoalsProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<SavingGoal>>,
+          List<SavingGoal>,
+          Stream<List<SavingGoal>>
+        >
+    with $FutureModifier<List<SavingGoal>>, $StreamProvider<List<SavingGoal>> {
+  const HomeSavingGoalsProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'homeSavingGoalsProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$homeSavingGoalsHash();
+
+  @$internal
+  @override
+  $StreamProviderElement<List<SavingGoal>> $createElement(
+    $ProviderPointer pointer,
+  ) => $StreamProviderElement(pointer);
+
+  @override
+  Stream<List<SavingGoal>> create(Ref ref) {
+    return homeSavingGoals(ref);
+  }
+}
+
+String _$homeSavingGoalsHash() => r'4030a8cc0b315618bd1f7976e56dbb3820a1cbc7';
+
+@ProviderFor(homeSavingGoalProgress)
+const homeSavingGoalProgressProvider = HomeSavingGoalProgressProvider._();
+
+final class HomeSavingGoalProgressProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<GoalProgress>>,
+          AsyncValue<List<GoalProgress>>,
+          AsyncValue<List<GoalProgress>>
+        >
+    with $Provider<AsyncValue<List<GoalProgress>>> {
+  const HomeSavingGoalProgressProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'homeSavingGoalProgressProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$homeSavingGoalProgressHash();
+
+  @$internal
+  @override
+  $ProviderElement<AsyncValue<List<GoalProgress>>> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  AsyncValue<List<GoalProgress>> create(Ref ref) {
+    return homeSavingGoalProgress(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<List<GoalProgress>> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AsyncValue<List<GoalProgress>>>(
+        value,
+      ),
+    );
+  }
+}
+
+String _$homeSavingGoalProgressHash() =>
+    r'0ef1a4b8be63e03602f70f6fe70f7af1b5a76849';
+
 @ProviderFor(homeRecurringRuleById)
 const homeRecurringRuleByIdProvider = HomeRecurringRuleByIdFamily._();
 

--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -14,6 +14,7 @@ import 'package:kopim/features/home/presentation/controllers/home_dashboard_pref
 import 'package:kopim/features/home/presentation/controllers/home_transactions_filter_controller.dart';
 import 'package:kopim/features/home/presentation/widgets/home_budget_progress_card.dart';
 import 'package:kopim/features/home/presentation/widgets/home_gamification_app_bar.dart';
+import 'package:kopim/features/home/presentation/widgets/home_savings_overview_card.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import 'package:kopim/features/profile/domain/entities/auth_user.dart';
@@ -31,6 +32,7 @@ import 'package:kopim/core/utils/helpers.dart';
 import 'package:kopim/core/widgets/phosphor_icon_utils.dart';
 import 'package:kopim/features/profile/presentation/screens/profile_management_screen.dart';
 import 'package:kopim/features/transactions/presentation/screens/all_transactions_screen.dart';
+import 'package:kopim/features/savings/presentation/screens/savings_list_screen.dart';
 
 import '../controllers/home_providers.dart';
 
@@ -110,6 +112,7 @@ class _HomeBody extends StatelessWidget {
                 : 16;
             final HomeDashboardPreferences? dashboardPreferences =
                 dashboardPreferencesAsync.asData?.value;
+            final ThemeData theme = Theme.of(context);
             final List<Widget> slivers = <Widget>[];
             final bool showGamificationHeader =
                 user != null &&
@@ -121,7 +124,7 @@ class _HomeBody extends StatelessWidget {
               slivers.add(_HomePinnedTitleAppBar(strings: strings));
             }
 
-            double nextTopPadding = 24;
+            double nextTopPadding = 16;
 
             void addBoxSection(Widget child) {
               slivers.add(
@@ -135,7 +138,7 @@ class _HomeBody extends StatelessWidget {
                   sliver: SliverToBoxAdapter(child: child),
                 ),
               );
-              nextTopPadding = 24;
+              nextTopPadding = 16;
             }
 
             if (dashboardPreferencesAsync.hasError) {
@@ -162,23 +165,35 @@ class _HomeBody extends StatelessWidget {
               );
             }
 
+            if (dashboardPreferences?.showSavingsWidget ?? false) {
+              addBoxSection(
+                HomeSavingsOverviewCard(
+                  onOpenSavings: () {
+                    Navigator.of(
+                      context,
+                    ).pushNamed(SavingsListScreen.routeName);
+                  },
+                ),
+              );
+            }
+
             final EdgeInsets accountsPadding = EdgeInsets.fromLTRB(
               horizontalPadding,
-              slivers.isEmpty ? 16 : 24,
+              slivers.isEmpty ? 12 : 20,
               horizontalPadding,
               0,
             );
             final EdgeInsets transactionsHeaderPadding = EdgeInsets.fromLTRB(
               horizontalPadding,
-              32,
+              24,
               horizontalPadding,
-              12,
+              8,
             );
             final EdgeInsets transactionsContentPadding = EdgeInsets.fromLTRB(
               horizontalPadding,
               0,
               horizontalPadding,
-              16,
+              12,
             );
 
             final Widget accountsSection = accountsAsync.when(
@@ -297,7 +312,7 @@ class _HomeBody extends StatelessWidget {
                   horizontalPadding,
                   0,
                   horizontalPadding,
-                  12,
+                  8,
                 ),
                 sliver: SliverToBoxAdapter(
                   child: _TransactionsFilterBar(strings: strings),
@@ -316,7 +331,7 @@ class _HomeBody extends StatelessWidget {
                   horizontalPadding,
                   0,
                   horizontalPadding,
-                  24,
+                  20,
                 ),
                 sliver: SliverToBoxAdapter(
                   child: Align(
@@ -327,6 +342,11 @@ class _HomeBody extends StatelessWidget {
                           context,
                         ).pushNamed(AllTransactionsScreen.routeName);
                       },
+                      style: TextButton.styleFrom(
+                        foregroundColor: theme.colorScheme.primary.withValues(
+                          alpha: 0.9,
+                        ),
+                      ),
                       child: Text(strings.homeTransactionsSeeAll),
                     ),
                   ),
@@ -519,8 +539,13 @@ class _AccountsListState extends State<_AccountsList> {
                     child: Card(
                       elevation: 0,
                       clipBehavior: Clip.antiAlias,
+                      color: theme.colorScheme.surfaceContainerHigh,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(20),
+                      ),
                       surfaceTintColor: Colors.transparent,
                       child: InkWell(
+                        borderRadius: BorderRadius.circular(20),
                         onTap: () {
                           Navigator.of(context).pushNamed(
                             AccountDetailsScreen.routeName,
@@ -530,7 +555,10 @@ class _AccountsListState extends State<_AccountsList> {
                           );
                         },
                         child: Padding(
-                          padding: const EdgeInsets.all(16),
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 18,
+                            vertical: 16,
+                          ),
                           child: Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: <Widget>[
@@ -552,7 +580,13 @@ class _AccountsListState extends State<_AccountsList> {
                                             widget.strings,
                                             account.type,
                                           ),
-                                          style: theme.textTheme.bodySmall,
+                                          style: theme.textTheme.bodySmall
+                                              ?.copyWith(
+                                                color: theme
+                                                    .colorScheme
+                                                    .onSurface
+                                                    .withValues(alpha: 0.7),
+                                              ),
                                         ),
                                       ],
                                     ),
@@ -566,7 +600,7 @@ class _AccountsListState extends State<_AccountsList> {
                                   ),
                                 ],
                               ),
-                              const SizedBox(height: 12),
+                              const SizedBox(height: 10),
                               Row(
                                 children: <Widget>[
                                   Expanded(
@@ -580,7 +614,7 @@ class _AccountsListState extends State<_AccountsList> {
                                       valueColor: theme.colorScheme.primary,
                                     ),
                                   ),
-                                  const SizedBox(width: 16),
+                                  const SizedBox(width: 12),
                                   Expanded(
                                     child: _AccountMonthlyValue(
                                       label: widget
@@ -605,7 +639,7 @@ class _AccountsListState extends State<_AccountsList> {
             ),
             if (widget.accounts.length > 1)
               Padding(
-                padding: const EdgeInsets.only(top: 12),
+                padding: const EdgeInsets.only(top: 8),
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: List<Widget>.generate(widget.accounts.length, (
@@ -637,7 +671,11 @@ class _AccountsListState extends State<_AccountsList> {
 }
 
 String _resolveAccountTypeLabel(AppLocalizations strings, String type) {
-  switch (type.toLowerCase()) {
+  final String normalized = type.trim();
+  if (normalized.isEmpty) {
+    return strings.accountTypeOther;
+  }
+  switch (normalized.toLowerCase()) {
     case 'cash':
       return strings.accountTypeCash;
     case 'card':
@@ -645,7 +683,7 @@ String _resolveAccountTypeLabel(AppLocalizations strings, String type) {
     case 'bank':
       return strings.accountTypeBank;
     default:
-      return strings.accountTypeOther;
+      return normalized;
   }
 }
 
@@ -666,7 +704,12 @@ class _AccountMonthlyValue extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        Text(label, style: theme.textTheme.bodySmall),
+        Text(
+          label,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onSurface.withValues(alpha: 0.68),
+          ),
+        ),
         const SizedBox(height: 4),
         Text(
           value,
@@ -763,7 +806,7 @@ class _TransactionsFilterBar extends ConsumerWidget {
         fontWeight: isSelected ? FontWeight.w600 : baseStyle.fontWeight,
         color: isSelected
             ? theme.colorScheme.primary
-            : theme.colorScheme.onSurfaceVariant,
+            : theme.colorScheme.onSurface.withValues(alpha: 0.68),
       );
       return TextButton(
         onPressed: () => ref
@@ -784,12 +827,12 @@ class _TransactionsFilterBar extends ConsumerWidget {
           HomeTransactionsFilter.all,
           strings.homeTransactionsFilterAll,
         ),
-        const SizedBox(width: 16),
+        const SizedBox(width: 12),
         buildFilterButton(
           HomeTransactionsFilter.income,
           strings.homeTransactionsFilterIncome,
         ),
-        const SizedBox(width: 16),
+        const SizedBox(width: 12),
         buildFilterButton(
           HomeTransactionsFilter.expense,
           strings.homeTransactionsFilterExpense,
@@ -851,6 +894,8 @@ class _UpcomingPaymentsCard extends StatelessWidget {
 
     return Card(
       elevation: 0,
+      color: theme.colorScheme.surfaceContainerHigh,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
       surfaceTintColor: Colors.transparent,
       child: ExpansionTile(
         initiallyExpanded: false,
@@ -880,7 +925,7 @@ class _UpcomingPaymentsCard extends StatelessWidget {
           child: Text(
             subtitle,
             style: theme.textTheme.bodySmall?.copyWith(
-              color: theme.colorScheme.onSurfaceVariant,
+              color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
             ),
           ),
         ),
@@ -928,7 +973,7 @@ class _UpcomingPaymentTile extends ConsumerWidget {
 
     return ListTile(
       dense: true,
-      contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+      contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
       leading: CircleAvatar(
         backgroundColor:
             categoryColor ?? theme.colorScheme.surfaceContainerHighest,
@@ -940,7 +985,9 @@ class _UpcomingPaymentTile extends ConsumerWidget {
       title: Text(payment.title, style: theme.textTheme.bodyMedium),
       subtitle: Text(
         strings.homeUpcomingPaymentsDueDate(dateFormat.format(payment.dueDate)),
-        style: theme.textTheme.bodySmall,
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.onSurface.withValues(alpha: 0.68),
+        ),
       ),
       trailing: Column(
         mainAxisSize: MainAxisSize.min,
@@ -956,7 +1003,12 @@ class _UpcomingPaymentTile extends ConsumerWidget {
           if (account?.name != null)
             Padding(
               padding: const EdgeInsets.only(top: 4),
-              child: Text(account!.name, style: theme.textTheme.bodySmall),
+              child: Text(
+                account!.name,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurface.withValues(alpha: 0.68),
+                ),
+              ),
             ),
         ],
       ),
@@ -1050,7 +1102,7 @@ class _TransactionListItem extends ConsumerWidget {
     required this.strings,
   });
 
-  static const double extent = 120;
+  static const double extent = 112;
 
   final String transactionId;
   final String localeName;
@@ -1153,11 +1205,15 @@ class _TransactionListItem extends ConsumerWidget {
       },
       child: RepaintBoundary(
         child: Card(
-          margin: const EdgeInsets.symmetric(vertical: 6),
+          margin: const EdgeInsets.symmetric(vertical: 5),
           elevation: 0,
+          color: Theme.of(context).colorScheme.surfaceContainerHigh,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(18),
+          ),
           surfaceTintColor: Colors.transparent,
           child: InkWell(
-            borderRadius: const BorderRadius.all(Radius.circular(12)),
+            borderRadius: const BorderRadius.all(Radius.circular(18)),
             onTap: () {
               final TransactionEntity? transaction = ref.read(
                 homeTransactionByIdProvider(transactionId),
@@ -1173,20 +1229,21 @@ class _TransactionListItem extends ConsumerWidget {
               );
             },
             child: Padding(
-              padding: const EdgeInsets.all(12),
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
               child: Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
+                crossAxisAlignment: CrossAxisAlignment.center,
                 children: <Widget>[
                   CircleAvatar(
+                    radius: 24,
                     backgroundColor:
                         categoryColor ??
                         Theme.of(context).colorScheme.surfaceContainerHighest,
                     foregroundColor: avatarIconColor,
                     child: categoryIcon != null
-                        ? Icon(categoryIcon)
-                        : const Icon(Icons.category_outlined),
+                        ? Icon(categoryIcon, size: 22)
+                        : const Icon(Icons.category_outlined, size: 22),
                   ),
-                  const SizedBox(width: 12),
+                  const SizedBox(width: 14),
                   Expanded(
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
@@ -1194,7 +1251,8 @@ class _TransactionListItem extends ConsumerWidget {
                       children: <Widget>[
                         Text(
                           categoryName,
-                          style: Theme.of(context).textTheme.bodyMedium,
+                          style: Theme.of(context).textTheme.titleSmall
+                              ?.copyWith(fontWeight: FontWeight.w600),
                         ),
                         if (note != null && note.isNotEmpty)
                           Padding(
@@ -1203,7 +1261,13 @@ class _TransactionListItem extends ConsumerWidget {
                               note,
                               maxLines: 1,
                               overflow: TextOverflow.ellipsis,
-                              style: Theme.of(context).textTheme.bodySmall,
+                              style: Theme.of(context).textTheme.bodySmall
+                                  ?.copyWith(
+                                    color: Theme.of(context)
+                                        .colorScheme
+                                        .onSurface
+                                        .withValues(alpha: 0.68),
+                                  ),
                             ),
                           ),
                       ],
@@ -1215,14 +1279,21 @@ class _TransactionListItem extends ConsumerWidget {
                     children: <Widget>[
                       Text(
                         moneyFormat.format(amount.abs()),
-                        style: Theme.of(
-                          context,
-                        ).textTheme.titleMedium?.copyWith(color: amountColor),
+                        style: Theme.of(context).textTheme.titleMedium
+                            ?.copyWith(
+                              color: amountColor,
+                              fontWeight: FontWeight.w700,
+                            ),
                       ),
                       if (accountName != null)
                         Text(
                           accountName,
-                          style: Theme.of(context).textTheme.bodySmall,
+                          style: Theme.of(context).textTheme.bodySmall
+                              ?.copyWith(
+                                color: Theme.of(
+                                  context,
+                                ).colorScheme.onSurface.withValues(alpha: 0.68),
+                              ),
                         ),
                     ],
                   ),
@@ -1270,7 +1341,7 @@ class _TransactionsSkeletonList extends StatelessWidget {
 class _SkeletonContainer extends StatelessWidget {
   const _SkeletonContainer();
 
-  static const double _height = _TransactionListItem.extent - 12;
+  static const double _height = _TransactionListItem.extent - 10;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/home/presentation/widgets/home_budget_progress_card.dart
+++ b/lib/features/home/presentation/widgets/home_budget_progress_card.dart
@@ -32,6 +32,7 @@ class HomeBudgetProgressCard extends ConsumerWidget {
     final String? budgetId = preferences.budgetId;
     if (budgetId == null) {
       return Card(
+        color: theme.colorScheme.surfaceContainerHigh,
         child: Padding(
           padding: const EdgeInsets.all(16),
           child: Column(
@@ -45,7 +46,7 @@ class HomeBudgetProgressCard extends ConsumerWidget {
               Text(
                 strings.homeBudgetWidgetEmpty,
                 style: theme.textTheme.bodySmall?.copyWith(
-                  color: theme.colorScheme.onSurfaceVariant,
+                  color: theme.colorScheme.onSurface.withValues(alpha: 0.72),
                 ),
               ),
               const SizedBox(height: 16),
@@ -71,6 +72,7 @@ class HomeBudgetProgressCard extends ConsumerWidget {
     );
 
     return Card(
+      color: theme.colorScheme.surfaceContainerHigh,
       clipBehavior: Clip.antiAlias,
       child: InkWell(
         onTap: progressAsync.maybeWhen(
@@ -282,7 +284,7 @@ class _BudgetCategoriesBreakdown extends ConsumerWidget {
               return Text(
                 strings.homeBudgetWidgetCategoriesEmpty,
                 style: theme.textTheme.bodySmall?.copyWith(
-                  color: theme.colorScheme.onSurfaceVariant,
+                  color: theme.colorScheme.onSurface.withValues(alpha: 0.72),
                 ),
               );
             }
@@ -366,7 +368,8 @@ class _BudgetCategoryChip extends StatelessWidget {
     final NumberFormat percentFormat = NumberFormat.decimalPattern(
       strings.localeName,
     );
-    final String percentText = '${percentFormat.format(breakdown.percent)}%';
+    final int roundedPercent = breakdown.percent.round();
+    final String percentText = '${percentFormat.format(roundedPercent)}%';
 
     return Chip(
       avatar: Icon(
@@ -378,7 +381,7 @@ class _BudgetCategoryChip extends StatelessWidget {
       backgroundColor: backgroundColor,
       materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
       side: BorderSide.none,
-      labelPadding: const EdgeInsets.symmetric(horizontal: 8),
+      labelPadding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
       label: DefaultTextStyle.merge(
         style: theme.textTheme.labelLarge?.copyWith(
           color: foregroundColor,
@@ -390,7 +393,7 @@ class _BudgetCategoryChip extends StatelessWidget {
             Flexible(
               child: Text(category.name, overflow: TextOverflow.ellipsis),
             ),
-            const SizedBox(width: 4),
+            const SizedBox(width: 2),
             Text(percentText),
           ],
         ),

--- a/lib/features/profile/presentation/screens/general_settings_screen.dart
+++ b/lib/features/profile/presentation/screens/general_settings_screen.dart
@@ -66,6 +66,9 @@ class GeneralSettingsScreen extends ConsumerWidget {
                   onToggleRecurring: (bool value) => ref
                       .read(homeDashboardPreferencesControllerProvider.notifier)
                       .setShowRecurring(value),
+                  onToggleSavings: (bool value) => ref
+                      .read(homeDashboardPreferencesControllerProvider.notifier)
+                      .setShowSavings(value),
                   onSelectBudget: (List<BudgetProgress> budgets) async {
                     await _showBudgetSelector(
                       context: context,
@@ -120,6 +123,7 @@ class _HomeDashboardSettingsCard extends StatelessWidget {
     required this.onToggleGamification,
     required this.onToggleBudget,
     required this.onToggleRecurring,
+    required this.onToggleSavings,
     required this.onSelectBudget,
   });
 
@@ -129,6 +133,7 @@ class _HomeDashboardSettingsCard extends StatelessWidget {
   final ValueChanged<bool> onToggleGamification;
   final ValueChanged<bool> onToggleBudget;
   final ValueChanged<bool> onToggleRecurring;
+  final ValueChanged<bool> onToggleSavings;
   final ValueChanged<List<BudgetProgress>> onSelectBudget;
 
   @override
@@ -205,6 +210,14 @@ class _HomeDashboardSettingsCard extends StatelessWidget {
             onChanged: onToggleRecurring,
             title: Text(strings.settingsHomeRecurringTitle),
             subtitle: Text(strings.settingsHomeRecurringSubtitle),
+          ),
+          const Divider(height: 0),
+          SwitchListTile.adaptive(
+            contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+            value: preferences.showSavingsWidget,
+            onChanged: onToggleSavings,
+            title: Text(strings.settingsHomeSavingsTitle),
+            subtitle: Text(strings.settingsHomeSavingsSubtitle),
           ),
         ],
       ),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -61,6 +61,14 @@
   "@settingsHomeRecurringSubtitle": {
     "description": "Helper text for the recurring operations widget toggle"
   },
+  "settingsHomeSavingsTitle": "Savings widget",
+  "@settingsHomeSavingsTitle": {
+    "description": "Toggle title for enabling the savings widget on the home screen"
+  },
+  "settingsHomeSavingsSubtitle": "Keep track of your saving goals without leaving the home screen.",
+  "@settingsHomeSavingsSubtitle": {
+    "description": "Helper text for the savings widget toggle"
+  },
   "settingsHomeBudgetSelectedLabel": "Selected budget",
   "@settingsHomeBudgetSelectedLabel": {
     "description": "Title for the list tile showing the currently selected budget"
@@ -882,6 +890,18 @@
         "type": "int"
       }
     }
+  },
+  "homeSavingsWidgetTitle": "Saving goals",
+  "@homeSavingsWidgetTitle": {
+    "description": "Title for the savings overview widget on the home screen"
+  },
+  "homeSavingsWidgetEmpty": "Create your first goal to start tracking progress.",
+  "@homeSavingsWidgetEmpty": {
+    "description": "Empty state message for the savings widget"
+  },
+  "homeSavingsWidgetViewAll": "Open savings",
+  "@homeSavingsWidgetViewAll": {
+    "description": "CTA label that opens the savings screen from the home widget"
   },
   "homeGamificationTitle": "Level progress",
   "@homeGamificationTitle": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -194,6 +194,18 @@ abstract class AppLocalizations {
   /// **'Show upcoming recurring operations on the home screen.'**
   String get settingsHomeRecurringSubtitle;
 
+  /// Toggle title for enabling the savings widget on the home screen
+  ///
+  /// In en, this message translates to:
+  /// **'Savings widget'**
+  String get settingsHomeSavingsTitle;
+
+  /// Helper text for the savings widget toggle
+  ///
+  /// In en, this message translates to:
+  /// **'Keep track of your saving goals without leaving the home screen.'**
+  String get settingsHomeSavingsSubtitle;
+
   /// Title for the list tile showing the currently selected budget
   ///
   /// In en, this message translates to:
@@ -866,7 +878,7 @@ abstract class AppLocalizations {
   /// **'Note'**
   String get addRecurringRuleNoteLabel;
 
-  /// Hint for the optional note field
+  /// Hint text for the optional note field
   ///
   /// In en, this message translates to:
   /// **'Optional comment'**
@@ -1243,6 +1255,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'{count, plural, =0 {No scheduled payments} one {# upcoming payment} other {# upcoming payments}}'**
   String homeUpcomingPaymentsCountSemantics(int count);
+
+  /// Title for the savings overview widget on the home screen
+  ///
+  /// In en, this message translates to:
+  /// **'Saving goals'**
+  String get homeSavingsWidgetTitle;
+
+  /// Empty state message for the savings widget
+  ///
+  /// In en, this message translates to:
+  /// **'Create your first goal to start tracking progress.'**
+  String get homeSavingsWidgetEmpty;
+
+  /// CTA label that opens the savings screen from the home widget
+  ///
+  /// In en, this message translates to:
+  /// **'Open savings'**
+  String get homeSavingsWidgetViewAll;
 
   /// Title for the gamification widget on the home screen
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -60,6 +60,13 @@ class AppLocalizationsEn extends AppLocalizations {
       'Show upcoming recurring operations on the home screen.';
 
   @override
+  String get settingsHomeSavingsTitle => 'Savings widget';
+
+  @override
+  String get settingsHomeSavingsSubtitle =>
+      'Keep track of your saving goals without leaving the home screen.';
+
+  @override
   String get settingsHomeBudgetSelectedLabel => 'Selected budget';
 
   @override
@@ -648,6 +655,16 @@ class AppLocalizationsEn extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get homeSavingsWidgetTitle => 'Saving goals';
+
+  @override
+  String get homeSavingsWidgetEmpty =>
+      'Create your first goal to start tracking progress.';
+
+  @override
+  String get homeSavingsWidgetViewAll => 'Open savings';
 
   @override
   String get homeGamificationTitle => 'Level progress';

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -61,6 +61,13 @@ class AppLocalizationsRu extends AppLocalizations {
       'Показывать ближайшие повторяющиеся операции на главном экране.';
 
   @override
+  String get settingsHomeSavingsTitle => 'Виджет накоплений';
+
+  @override
+  String get settingsHomeSavingsSubtitle =>
+      'Следите за целями накоплений прямо с домашнего экрана.';
+
+  @override
   String get settingsHomeBudgetSelectedLabel => 'Выбранный бюджет';
 
   @override
@@ -652,6 +659,16 @@ class AppLocalizationsRu extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get homeSavingsWidgetTitle => 'Цели накоплений';
+
+  @override
+  String get homeSavingsWidgetEmpty =>
+      'Создайте первую цель, чтобы отслеживать прогресс.';
+
+  @override
+  String get homeSavingsWidgetViewAll => 'Открыть накопления';
 
   @override
   String get homeGamificationTitle => 'Прогресс уровня';

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -61,6 +61,14 @@
   "@settingsHomeRecurringSubtitle": {
     "description": "Подсказка к переключателю виджета повторяющихся операций"
   },
+  "settingsHomeSavingsTitle": "Виджет накоплений",
+  "@settingsHomeSavingsTitle": {
+    "description": "Подпись переключателя виджета накоплений"
+  },
+  "settingsHomeSavingsSubtitle": "Следите за целями накоплений прямо с домашнего экрана.",
+  "@settingsHomeSavingsSubtitle": {
+    "description": "Подсказка к переключателю виджета накоплений"
+  },
   "settingsHomeBudgetSelectedLabel": "Выбранный бюджет",
   "@settingsHomeBudgetSelectedLabel": {
     "description": "Заголовок элемента со статусом выбранного бюджета"
@@ -882,6 +890,18 @@
         "type": "int"
       }
     }
+  },
+  "homeSavingsWidgetTitle": "Цели накоплений",
+  "@homeSavingsWidgetTitle": {
+    "description": "Заголовок виджета накоплений на домашнем экране"
+  },
+  "homeSavingsWidgetEmpty": "Создайте первую цель, чтобы отслеживать прогресс.",
+  "@homeSavingsWidgetEmpty": {
+    "description": "Сообщение пустого состояния для виджета накоплений"
+  },
+  "homeSavingsWidgetViewAll": "Открыть накопления",
+  "@homeSavingsWidgetViewAll": {
+    "description": "Кнопка перехода на экран накоплений из виджета"
   },
   "homeGamificationTitle": "Прогресс уровня",
   "@homeGamificationTitle": {

--- a/test/features/home/presentation/controllers/home_dashboard_preferences_controller_test.dart
+++ b/test/features/home/presentation/controllers/home_dashboard_preferences_controller_test.dart
@@ -87,6 +87,21 @@ void main() {
       expect(repository.lastSaved?.showRecurringWidget, isTrue);
     });
 
+    test('setShowSavings toggles flag and persists value', () async {
+      await container.read(homeDashboardPreferencesControllerProvider.future);
+
+      await container
+          .read(homeDashboardPreferencesControllerProvider.notifier)
+          .setShowSavings(true);
+
+      final HomeDashboardPreferences? state = container
+          .read(homeDashboardPreferencesControllerProvider)
+          .value;
+
+      expect(state?.showSavingsWidget, isTrue);
+      expect(repository.lastSaved?.showSavingsWidget, isTrue);
+    });
+
     test(
       'setShowBudget toggles flag and clears budget when disabled',
       () async {


### PR DESCRIPTION
## Summary
- добавлен виджет обзора накоплений на домашнем экране и новые провайдеры данных
- расширены настройки домашнего экрана переключателем «Виджет накоплений» и новым полем предпочтений
- обновлён UI домашнего экрана: осветлены карточки, уменьшены отступы, улучшено отображение счетов и транзакций, скорректирован виджет бюджета

## Testing
- `dart format --set-exit-if-changed .` *(ошибка: отсутствует команда dart в окружении)*
- `flutter analyze` *(ошибка: отсутствует команда flutter в окружении)*
- `dart run build_runner build --delete-conflicting-outputs` *(ошибка: отсутствует команда dart в окружении)*
- `flutter test --reporter expanded` *(ошибка: отсутствует команда flutter в окружении)*
- `flutter pub outdated` *(ошибка: отсутствует команда flutter в окружении)*

------
https://chatgpt.com/codex/tasks/task_e_68e6191ef0a4832ea889b3356561431e